### PR TITLE
Adds workflow to trigger the klotho docker image build workflow

### DIFF
--- a/.github/workflows/update_docker_image.yaml
+++ b/.github/workflows/update_docker_image.yaml
@@ -1,0 +1,33 @@
+name: Trigger Docker Image Build Workflow
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      klotho-release-ref:
+        description: 'the klotho release tag ref to use in the Docker image (e.g refs/tags/v1.0.0)'
+        required: true
+
+jobs:
+  update-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.KLOTHOPLATFORM_GH_ACTIONS_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'klothoplatform',
+              repo: 'docker-klotho',
+              workflow_id: 'build-image.yaml',
+              ref: 'refs/heads/main',
+              inputs: {
+                "klotho-version": "${{ github.ref_name || github.event.inputs.klotho-release-ref }}".split("/")[2] // (e.g. v1.0.0)
+              }
+            });
+            console.log(result);
+    
+


### PR DESCRIPTION
This PR adds a workflow that triggers the build job for the Klotho docker image whenever a release is published.