### PR TITLE
Return annotation parsing errors

### DIFF
--- a/cmd/ast/main.go
+++ b/cmd/ast/main.go
@@ -98,7 +98,10 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		caps := javascript.FindAllCapabilities(jsFile)
+		caps, err := javascript.Language.CapabilityFinder.FindAllCapabilities(jsFile)
+		if err != nil {
+			return err
+		}
 		return enc.Encode(caps)
 	}
 

--- a/pkg/annotation/capability.go
+++ b/pkg/annotation/capability.go
@@ -2,6 +2,8 @@ package annotation
 
 import (
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 type Capability struct {
@@ -26,7 +28,7 @@ func ParseCapability(s string) (*Capability, error) {
 		var err error
 		cap.Directives, err = ParseDirectives(matches[2])
 		if err != nil {
-			return cap, err
+			return cap, errors.Wrap(err, "could not parse directives")
 		}
 		cap.ID, _ = cap.Directives.String("id")
 	}

--- a/pkg/core/project_file_test.go
+++ b/pkg/core/project_file_test.go
@@ -144,7 +144,7 @@ var testLang = SourceLanguage{
 	CapabilityFinder: &testCapabilityFinder{},
 }
 
-func (t *testCapabilityFinder) FindAllCapabilities(sf *SourceFile) []Annotation {
+func (t *testCapabilityFinder) FindAllCapabilities(sf *SourceFile) ([]Annotation, error) {
 	body := string(sf.Program())
 	annots := []Annotation{
 		{Capability: &annotation.Capability{
@@ -153,5 +153,5 @@ func (t *testCapabilityFinder) FindAllCapabilities(sf *SourceFile) []Annotation 
 			Directives: annotation.Directives{"id": body},
 		}},
 	}
-	return annots
+	return annots, nil
 }

--- a/pkg/core/source_file.go
+++ b/pkg/core/source_file.go
@@ -28,7 +28,7 @@ type SourceLanguage struct {
 type LanguageId string
 
 type CapabilityFinder interface {
-	FindAllCapabilities(*SourceFile) []Annotation
+	FindAllCapabilities(*SourceFile) ([]Annotation, error)
 }
 
 type Commenter func(string) string
@@ -45,7 +45,7 @@ func (f *SourceFile) Reparse(newProgram []byte) (err error) {
 	f.program = newProgram
 	f.tree, err = f.parser.ParseCtx(context.TODO(), nil, f.program)
 	if err == nil {
-		f.caps = f.Language.CapabilityFinder.FindAllCapabilities(f)
+		f.caps, err = f.Language.CapabilityFinder.FindAllCapabilities(f)
 	} else {
 		err = WrapErrf(err, "could not reparse %s", f.Path())
 	}

--- a/pkg/exec_unit/source_files_resolver_test.go
+++ b/pkg/exec_unit/source_files_resolver_test.go
@@ -131,12 +131,12 @@ var testAnnotationLang = core.SourceLanguage{
 	CapabilityFinder: &testMultipleCapabilityFinder{},
 }
 
-func (t *testMultipleCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) []core.Annotation {
+func (t *testMultipleCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) ([]core.Annotation, error) {
 	body := string(sf.Program())
 	rawAnnots := strings.SplitN(body, "|", 2)
 	var annots []core.Annotation
 	if body == "" {
-		return []core.Annotation{}
+		return []core.Annotation{}, nil
 	}
 	for _, rawAnnot := range rawAnnots {
 		annotParts := strings.SplitN(rawAnnot, ":", 2)
@@ -149,5 +149,5 @@ func (t *testMultipleCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) 
 		}})
 
 	}
-	return annots
+	return annots, nil
 }

--- a/pkg/infra/kubernetes/plugin_test.go
+++ b/pkg/infra/kubernetes/plugin_test.go
@@ -201,7 +201,7 @@ var testLang = core.SourceLanguage{
 	CapabilityFinder: &testCapabilityFinder{},
 }
 
-func (t *testCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) []core.Annotation {
+func (t *testCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) ([]core.Annotation, error) {
 	body := string(sf.Program())
 	annots := []core.Annotation{}
 	if body != "" {
@@ -213,7 +213,7 @@ func (t *testCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) []core.A
 			}},
 		}
 	}
-	return annots
+	return annots, nil
 }
 
 func Test_getKlothoCharts(t *testing.T) {

--- a/pkg/lang/javascript/parser.go
+++ b/pkg/lang/javascript/parser.go
@@ -48,7 +48,3 @@ var Language = core.SourceLanguage{
 func NewFile(path string, content io.Reader) (f *core.SourceFile, err error) {
 	return core.NewSourceFile(path, content, Language)
 }
-
-func FindAllCapabilities(f *core.SourceFile) []core.Annotation {
-	return Language.CapabilityFinder.FindAllCapabilities(f)
-}


### PR DESCRIPTION
## Testing
```ts
/**
 * @klotho::persist {
 *   id = users
 * }
 */
const users = new Map<string, string>();
```
Results in error:
```
 error could not read root path .: error reading 'dist/users.js' (rel: 'users.js'): error in users.js:8:0 (in persist): error parsing annotation: could not parse directives: toml: incomplete number
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
