### PR TITLE
make sure no resource has the same id for capability type

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -116,32 +116,32 @@ func (p *Plugin) validateConfigOverrideResourcesExist(result *core.CompilationRe
 		}
 	}
 
-	for unit := range p.UserConfigOverrides.Persisted {
+	for persistResource := range p.UserConfigOverrides.Persisted {
 		resources := result.GetResourcesOfType(string(core.PersistFileKind))
 		resources = append(result.GetResourcesOfType(string(core.PersistKVKind)), resources...)
 		resources = append(result.GetResourcesOfType(string(core.PersistORMKind)), resources...)
 		resources = append(result.GetResourcesOfType(string(core.PersistRedisClusterKind)), resources...)
 		resources = append(result.GetResourcesOfType(string(core.PersistRedisNodeKind)), resources...)
 		resources = append(result.GetResourcesOfType(string(core.PersistSecretKind)), resources...)
-		resource := getResourceById(unit, resources)
+		resource := getResourceById(persistResource, resources)
 		if resource == (core.ResourceKey{}) {
-			log.Warnf("Unknown persist in config override, \"%s\".", unit)
+			log.Warnf("Unknown persist in config override, \"%s\".", persistResource)
 		}
 
 	}
-	for unit := range p.UserConfigOverrides.Exposed {
+	for exposeResource := range p.UserConfigOverrides.Exposed {
 		resources := result.GetResourcesOfType(core.GatewayKind)
-		resource := getResourceById(unit, resources)
+		resource := getResourceById(exposeResource, resources)
 		if resource == (core.ResourceKey{}) {
-			log.Warnf("Unknown expose in config override, \"%s\".", unit)
+			log.Warnf("Unknown expose in config override, \"%s\".", exposeResource)
 		}
 	}
 
-	for unit := range p.UserConfigOverrides.PubSub {
+	for pubsubResource := range p.UserConfigOverrides.PubSub {
 		resources := result.GetResourcesOfType(core.PubSubKind)
-		resource := getResourceById(unit, resources)
+		resource := getResourceById(pubsubResource, resources)
 		if resource == (core.ResourceKey{}) {
-			log.Warnf("Unknown pubsub in config override, \"%s\".", unit)
+			log.Warnf("Unknown pubsub in config override, \"%s\".", pubsubResource)
 		}
 	}
 
@@ -202,9 +202,8 @@ func validateNoDuplicateIds[T core.CloudResource](result *core.CompilationResult
 	unitIds := make(map[string]struct{})
 	units := core.GetResourcesOfType[T](result)
 	for _, unit := range units {
-		fmt.Println(unit)
-		if id, ok := unitIds[unit.Key().Name]; ok {
-			return fmt.Errorf("Multiple Persist objects with the same name, '%s'", id)
+		if _, ok := unitIds[unit.Key().Name]; ok {
+			return fmt.Errorf(`multiple Persist objects with the same name, "%s"`, unit.Key().Name)
 		}
 		unitIds[unit.Key().Name] = struct{}{}
 	}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/annotation"
@@ -277,6 +278,74 @@ func Test_validation_handleProviderValidation(t *testing.T) {
 			err := p.handleProviderValidation(&result)
 			if tt.wantErr {
 				assert.Error(err)
+				return
+			} else {
+				assert.NoError(err)
+				return
+			}
+		})
+	}
+}
+
+func Test_validation_handleResources(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  []core.CloudResource
+		wantErr bool
+	}{
+		{
+			name: "diff resources duplicate ids",
+			result: []core.CloudResource{
+				&core.ExecutionUnit{
+					Name: "test",
+				},
+				&core.Gateway{
+					Name: "test",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "persist different ids",
+			result: []core.CloudResource{
+				&core.Persist{
+					Name: "test",
+					Kind: core.PersistFileKind,
+				},
+				&core.Persist{
+					Name: "another",
+					Kind: core.PersistORMKind,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "persist duplicate ids",
+			result: []core.CloudResource{
+				&core.Persist{
+					Name: "test",
+					Kind: core.PersistFileKind,
+				},
+				&core.Persist{
+					Name: "test",
+					Kind: core.PersistORMKind,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			p := Plugin{}
+			result := core.CompilationResult{}
+			result.AddAll(tt.result)
+
+			err := p.handleResources(&result)
+			if tt.wantErr {
+				assert.Error(err)
+				fmt.Println(err.Error())
 				return
 			} else {
 				assert.NoError(err)


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #635

For now this only really will ever catch persist since no other resource type has multiple kinds, but checking them anyways in case they ever do.

### Standard checks

- **Unit tests**: Any special considerations? added
- **Docs**: Do we need to update any docs, internal or public? no
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? it shouldnt
