### PR TITLE
using core env vars instead of hardcoded

### DIFF
--- a/pkg/core/environment_variable.go
+++ b/pkg/core/environment_variable.go
@@ -9,6 +9,17 @@ type (
 	}
 )
 
+type EnvironmentVariableValue string
+
 const (
-	EnvironmentVariableDirective = "environment_variables"
+	EnvironmentVariableDirective   = "environment_variables"
+	ORM_ENV_VAR_NAME_SUFFIX        = "_PERSIST_ORM_CONNECTION"
+	REDIS_PORT_ENV_VAR_NAME_SUFFIX = "_PERSIST_REDIS_PORT"
+	REDIS_HOST_ENV_VAR_NAME_SUFFIX = "_PERSIST_REDIS_HOST"
+)
+
+var (
+	HOST              EnvironmentVariableValue = "host"
+	PORT              EnvironmentVariableValue = "port"
+	CONNECTION_STRING EnvironmentVariableValue = "connection_string"
 )

--- a/pkg/core/persist.go
+++ b/pkg/core/persist.go
@@ -1,5 +1,10 @@
 package core
 
+import (
+	"fmt"
+	"strings"
+)
+
 type (
 	Persist struct {
 		Name        string
@@ -29,5 +34,32 @@ func (p *Persist) Key() ResourceKey {
 	return ResourceKey{
 		Name: p.Name,
 		Kind: string(p.Kind),
+	}
+}
+
+func GenerateRedisHostEnvVar(id string, kind string) EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:       fmt.Sprintf("%s%s", strings.ToUpper(id), REDIS_HOST_ENV_VAR_NAME_SUFFIX),
+		Kind:       kind,
+		ResourceID: id,
+		Value:      string(HOST),
+	}
+}
+
+func GenerateRedisPortEnvVar(id string, kind string) EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:       fmt.Sprintf("%s%s", strings.ToUpper(id), REDIS_PORT_ENV_VAR_NAME_SUFFIX),
+		Kind:       kind,
+		ResourceID: id,
+		Value:      string(PORT),
+	}
+}
+
+func GenerateOrmConnStringEnvVar(id string, kind string) EnvironmentVariable {
+	return EnvironmentVariable{
+		Name:       fmt.Sprintf("%s%s", strings.ToUpper(id), ORM_ENV_VAR_NAME_SUFFIX),
+		Kind:       kind,
+		ResourceID: id,
+		Value:      string(CONNECTION_STRING),
 	}
 }

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -193,6 +193,13 @@ func (chart *KlothoHelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.E
 		return nil, err
 	}
 	values = append(values, upstreamValues...)
+
+	persistValues, err := unit.handlePersistForExecUnit(deps)
+	if err != nil {
+		return nil, err
+	}
+	values = append(values, persistValues...)
+
 	return values, nil
 }
 

--- a/pkg/infra/kubernetes/persist.go
+++ b/pkg/infra/kubernetes/persist.go
@@ -1,25 +1,14 @@
 package kubernetes
 
 import (
-	"strings"
-
 	"github.com/klothoplatform/klotho/pkg/core"
 )
 
 type PersistEnvVars string
 
-// Constant portion of the env var name for each of the persist types which require connection info
-const (
-	ORMEnvVar              PersistEnvVars = "_PERSIST_ORM_CONNECTION"
-	RedisNodeHostEnvVar    PersistEnvVars = "_PERSIST_REDIS_NODE_HOST"
-	RedisNodePortEnvVar    PersistEnvVars = "_PERSIST_REDIS_NODE_PORT"
-	RedisClusterHostEnvVar PersistEnvVars = "_PERSIST_REDIS_CLUSTER_HOST"
-	RedisClusterPortEnvVar PersistEnvVars = "_PERSIST_REDIS_CLUSTER_PORT"
-)
-
-func (unit *HelmExecUnit) handlePersistForExecUnit(result *core.CompilationResult, deps *core.Dependencies) ([]Value, error) {
+func (unit *HelmExecUnit) handlePersistForExecUnit(deps *core.Dependencies) ([]Value, error) {
 	var values []Value
-	envVars := generateEnvVars(result, deps, unit.Name)
+	envVars := generateEnvVars(deps, unit.Name)
 
 	if len(envVars) == 0 {
 		return values, nil
@@ -44,27 +33,24 @@ func (unit *HelmExecUnit) handlePersistForExecUnit(result *core.CompilationResul
 	return values, nil
 }
 
-func generateEnvVars(result *core.CompilationResult, deps *core.Dependencies, name string) []string {
-	envVars := []string{}
+func generateEnvVars(deps *core.Dependencies, name string) []core.EnvironmentVariable {
+	envVars := []core.EnvironmentVariable{}
 	for _, target := range deps.Downstream(core.ResourceKey{Name: name, Kind: core.ExecutionUnitKind}) {
-		res := result.Get(target)
-		if p, ok := res.(*core.Persist); ok {
-			switch p.Kind {
-			case core.PersistORMKind:
-				envVars = append(envVars, strings.ToUpper(p.Name)+string(ORMEnvVar))
-			case core.PersistRedisNodeKind:
-				envVars = append(
-					envVars,
-					strings.ToUpper(p.Name)+string(RedisNodeHostEnvVar),
-					strings.ToUpper(p.Name)+string(RedisNodePortEnvVar),
-				)
-			case core.PersistRedisClusterKind:
-				envVars = append(
-					envVars,
-					strings.ToUpper(p.Name)+string(RedisClusterHostEnvVar),
-					strings.ToUpper(p.Name)+string(RedisClusterPortEnvVar),
-				)
-			}
+		switch target.Kind {
+		case string(core.PersistORMKind):
+			envVars = append(envVars, core.GenerateOrmConnStringEnvVar(target.Name, target.Kind))
+		case string(core.PersistRedisNodeKind):
+			envVars = append(
+				envVars,
+				core.GenerateRedisHostEnvVar(target.Name, target.Kind),
+				core.GenerateRedisPortEnvVar(target.Name, target.Kind),
+			)
+		case string(core.PersistRedisClusterKind):
+			envVars = append(
+				envVars,
+				core.GenerateRedisHostEnvVar(target.Name, target.Kind),
+				core.GenerateRedisPortEnvVar(target.Name, target.Kind),
+			)
 		}
 	}
 	return envVars

--- a/pkg/infra/kubernetes/persist_test.go
+++ b/pkg/infra/kubernetes/persist_test.go
@@ -1,0 +1,335 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/lang/yaml"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_handlePersistForExecUnit(t *testing.T) {
+	type testResult struct {
+		values []Value
+		file   string
+	}
+	tests := []struct {
+		name           string
+		unit           HelmExecUnit
+		deploymentYaml string
+		podYaml        string
+		deps           []core.Dependency
+		want           testResult
+		wantErr        bool
+	}{
+		{
+			name: "orm dependency and deployment",
+			unit: HelmExecUnit{
+				Name:      "unit",
+				Namespace: "default",
+			},
+			deploymentYaml: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    execUnit: testUnit
+  name: nginx-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      execUnit: testUnit
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+        execUnit: testUnit
+    spec:
+      containers:
+      - image: '{{ .Values.testUnitImage }}'
+        name: nginx
+        resources: {}
+      serviceAccountName: testUnit
+status: {}
+`,
+			deps: []core.Dependency{
+				{
+					Source: core.ResourceKey{Kind: core.ExecutionUnitKind, Name: "unit"},
+					Target: core.ResourceKey{Kind: string(core.PersistORMKind), Name: "unit"},
+				},
+			},
+			want: testResult{
+				file: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    execUnit: testUnit
+  name: nginx-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+      execUnit: testUnit
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+        execUnit: testUnit
+    spec:
+      containers:
+      - env:
+        - name: UNIT_PERSIST_ORM_CONNECTION
+          value: '{{ .Values.UNITPERSISTORMCONNECTION }}'
+        image: '{{ .Values.testUnitImage }}'
+        name: nginx
+        resources: {}
+      serviceAccountName: testUnit
+status: {}
+`,
+				values: []Value{
+					{
+						ExecUnitName:        "unit",
+						Kind:                "Deployment",
+						Type:                string(EnvironmentVariableTransformation),
+						Key:                 "UNITPERSISTORMCONNECTION",
+						EnvironmentVariable: core.EnvironmentVariable{Name: "UNIT_PERSIST_ORM_CONNECTION", Kind: "persist_orm", ResourceID: "unit", Value: "connection_string"},
+					},
+				},
+			},
+		},
+		{
+			name: "redis node dependency and pod",
+			unit: HelmExecUnit{
+				Name:      "unit",
+				Namespace: "default",
+			},
+			podYaml: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+  - name: web
+    image: nginx`,
+			deps: []core.Dependency{
+				{
+					Source: core.ResourceKey{Kind: core.ExecutionUnitKind, Name: "unit"},
+					Target: core.ResourceKey{Kind: string(core.PersistRedisNodeKind), Name: "unit"},
+				},
+			},
+			want: testResult{
+				file: `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: test
+spec:
+  containers:
+  - env:
+    - name: UNIT_PERSIST_REDIS_HOST
+      value: '{{ .Values.UNITPERSISTREDISHOST }}'
+    - name: UNIT_PERSIST_REDIS_PORT
+      value: '{{ .Values.UNITPERSISTREDISPORT }}'
+    image: nginx
+    name: web
+    resources: {}
+status: {}
+`,
+				values: []Value{
+					{
+						ExecUnitName:        "unit",
+						Kind:                "Pod",
+						Type:                string(EnvironmentVariableTransformation),
+						Key:                 "UNITPERSISTREDISHOST",
+						EnvironmentVariable: core.EnvironmentVariable{Name: "UNIT_PERSIST_REDIS_HOST", Kind: "persist_redis_node", ResourceID: "unit", Value: "host"},
+					},
+					{
+						ExecUnitName:        "unit",
+						Kind:                "Pod",
+						Type:                string(EnvironmentVariableTransformation),
+						Key:                 "UNITPERSISTREDISPORT",
+						EnvironmentVariable: core.EnvironmentVariable{Name: "UNIT_PERSIST_REDIS_PORT", Kind: "persist_redis_node", ResourceID: "unit", Value: "port"},
+					},
+				},
+			},
+		},
+		{
+			name: "redis cluster dependency and pod",
+			unit: HelmExecUnit{
+				Name:      "unit",
+				Namespace: "default",
+			},
+			podYaml: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+  - name: web
+    image: nginx`,
+			deps: []core.Dependency{
+				{
+					Source: core.ResourceKey{Kind: core.ExecutionUnitKind, Name: "unit"},
+					Target: core.ResourceKey{Kind: string(core.PersistRedisClusterKind), Name: "unit"},
+				},
+			},
+			want: testResult{
+				file: `apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: test
+spec:
+  containers:
+  - env:
+    - name: UNIT_PERSIST_REDIS_HOST
+      value: '{{ .Values.UNITPERSISTREDISHOST }}'
+    - name: UNIT_PERSIST_REDIS_PORT
+      value: '{{ .Values.UNITPERSISTREDISPORT }}'
+    image: nginx
+    name: web
+    resources: {}
+status: {}
+`,
+				values: []Value{
+					{
+						ExecUnitName:        "unit",
+						Kind:                "Pod",
+						Type:                string(EnvironmentVariableTransformation),
+						Key:                 "UNITPERSISTREDISHOST",
+						EnvironmentVariable: core.EnvironmentVariable{Name: "UNIT_PERSIST_REDIS_HOST", Kind: "persist_redis_cluster", ResourceID: "unit", Value: "host"},
+					},
+					{
+						ExecUnitName:        "unit",
+						Kind:                "Pod",
+						Type:                string(EnvironmentVariableTransformation),
+						Key:                 "UNITPERSISTREDISPORT",
+						EnvironmentVariable: core.EnvironmentVariable{Name: "UNIT_PERSIST_REDIS_PORT", Kind: "persist_redis_cluster", ResourceID: "unit", Value: "port"},
+					},
+				},
+			},
+		},
+		{
+			name: "has dependency but no pod or deployment file",
+			unit: HelmExecUnit{
+				Name:      "unit",
+				Namespace: "default",
+			},
+			deps: []core.Dependency{
+				{
+					Source: core.ResourceKey{Kind: core.ExecutionUnitKind, Name: "unit"},
+					Target: core.ResourceKey{Kind: string(core.PersistRedisClusterKind), Name: "unit"},
+				},
+			},
+		},
+		{
+			name: "no deps",
+			unit: HelmExecUnit{
+				Name:      "unit",
+				Namespace: "default",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			deps := &core.Dependencies{}
+			for _, dep := range tt.deps {
+				deps.Add(dep.Source, dep.Target)
+			}
+
+			if tt.deploymentYaml != "" {
+				f, err := yaml.NewFile("deployment.yaml", strings.NewReader(tt.deploymentYaml))
+				assert.NoError(err)
+				tt.unit.Deployment = f
+			}
+			if tt.podYaml != "" {
+				f, err := yaml.NewFile("pod.yaml", strings.NewReader(tt.podYaml))
+				assert.NoError(err)
+				tt.unit.Pod = f
+			}
+
+			values, err := tt.unit.handlePersistForExecUnit(deps)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			} else if !assert.NoError(err) {
+				return
+
+			}
+			assert.Equal(tt.want.values, values)
+
+			if tt.deploymentYaml != "" {
+				assert.Equal(tt.want.file, string(tt.unit.Deployment.Program()))
+			}
+			if tt.podYaml != "" {
+				assert.Equal(tt.want.file, string(tt.unit.Pod.Program()))
+			}
+		})
+	}
+}
+
+func Test_generateEnvVarsForPersist(t *testing.T) {
+	tests := []struct {
+		name     string
+		unit     *core.ExecutionUnit
+		resource core.CloudResource
+		values   []core.EnvironmentVariable
+	}{
+		{
+			name:     "Wrong dependencies",
+			unit:     &core.ExecutionUnit{Name: "main", ExecType: "exec_unit"},
+			resource: &core.Persist{Name: "file", Kind: core.PersistFileKind},
+			values:   []core.EnvironmentVariable{},
+		},
+		{
+			name:     "orm dependency",
+			unit:     &core.ExecutionUnit{Name: "main", ExecType: "exec_unit"},
+			resource: &core.Persist{Name: "orm", Kind: core.PersistORMKind},
+			values:   []core.EnvironmentVariable{{Name: "ORM_PERSIST_ORM_CONNECTION", Kind: "persist_orm", ResourceID: "orm", Value: string(core.CONNECTION_STRING)}},
+		},
+		{
+			name:     "redis node dependency",
+			unit:     &core.ExecutionUnit{Name: "main", ExecType: "exec_unit"},
+			resource: &core.Persist{Name: "redisNode", Kind: core.PersistRedisNodeKind},
+			values: []core.EnvironmentVariable{
+				{Name: "REDISNODE_PERSIST_REDIS_HOST", Kind: "persist_redis_node", ResourceID: "redisNode", Value: string(core.HOST)},
+				{Name: "REDISNODE_PERSIST_REDIS_PORT", Kind: "persist_redis_node", ResourceID: "redisNode", Value: string(core.PORT)},
+			},
+		},
+		{
+			name:     "redis cluster dependency",
+			unit:     &core.ExecutionUnit{Name: "main", ExecType: "exec_unit"},
+			resource: &core.Persist{Name: "redisCluster", Kind: core.PersistRedisClusterKind},
+			values: []core.EnvironmentVariable{
+				{Name: "REDISCLUSTER_PERSIST_REDIS_HOST", Kind: "persist_redis_cluster", ResourceID: "redisCluster", Value: string(core.HOST)},
+				{Name: "REDISCLUSTER_PERSIST_REDIS_PORT", Kind: "persist_redis_cluster", ResourceID: "redisCluster", Value: string(core.PORT)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			assert := assert.New(t)
+
+			results := &core.CompilationResult{}
+			results.Add(tt.resource)
+
+			deps := &core.Dependencies{}
+			deps.Add(tt.unit.Key(), tt.resource.Key())
+			envVars := generateEnvVars(deps, tt.unit.Name)
+
+			assert.Equal(tt.values, envVars)
+		})
+	}
+}

--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -85,12 +85,6 @@ func (p Kubernetes) Transform(result *core.CompilationResult, deps *core.Depende
 			}
 			khChart.Values = append(khChart.Values, execUnitValues...)
 
-			persistValues, err := unit.handlePersistForExecUnit(result, deps)
-			if err != nil {
-				errs.Append(err)
-			}
-			khChart.Values = append(khChart.Values, persistValues...)
-
 		}
 		output, err := yaml.Marshal(metadata)
 		if err != nil {

--- a/pkg/infra/kubernetes/values.go
+++ b/pkg/infra/kubernetes/values.go
@@ -1,11 +1,14 @@
 package kubernetes
 
+import "github.com/klothoplatform/klotho/pkg/core"
+
 // Values specifies the values that exist in the generated helm chart, which are necessary to provide during installation to run on the provider
 type Value struct {
-	ExecUnitName string // ExecUnitName signifies the exec unit that this value is for
-	Kind         string // Kind is the kind of the kubernetes object this value is applied to
-	Type         string // Type is the type of value expected
-	Key          string // Key is the key to be used in helms values.yaml file or cli
+	ExecUnitName        string                   // ExecUnitName signifies the exec unit that this value is for
+	Kind                string                   // Kind is the kind of the kubernetes object this value is applied to
+	Type                string                   // Type is the type of value expected
+	Key                 string                   // Key is the key to be used in helms values.yaml file or cli
+	EnvironmentVariable core.EnvironmentVariable //EnvironmentVariable provides information around what environment variable is needed for substitution
 }
 
 type ProviderValueTypes string

--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -46,6 +46,7 @@ export interface EksExecUnit {
     name: string
     params: EksExecUnitArgs
     helmOptions?: HelmOptions
+    envVars?: any
     image?: pulumi.Output<String>
 }
 
@@ -494,7 +495,9 @@ export class Eks {
         let role
 
         let additionalEnvVars: { name: string; value: pulumi.Input<string> }[] = []
-        for (const [name, value] of Object.entries(lib.generateExecUnitEnvVars(execUnit))) {
+        for (const [name, value] of Object.entries(
+            lib.generateExecUnitEnvVars(execUnit, unit.envVars)
+        )) {
             additionalEnvVars.push({ name, value })
         }
         let nodeSelector: { [key: string]: pulumi.Output<string> } | undefined = undefined

--- a/pkg/infra/pulumi_aws/iac/k8s/helm_chart.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/helm_chart.ts
@@ -8,6 +8,7 @@ export class Value {
     public Kind: string
     public Type: string
     public Key: string
+    public EnvironmentVariable: any
 }
 
 enum ValueTypes {
@@ -42,7 +43,7 @@ export const getChartValues = (
             case ValueTypes.EnvironmentVariableTransformation:
                 // Currently the only env vars we set are persist related
                 // This will need to be changed to be more extensible
-                values[t.Key] = lib.connectionString.get(t.Key)
+                values[t.Key] = lib.getEnvVarForDependency(t.EnvironmentVariable)[1]
                 break
             default:
                 throw new Error(`Unsupported Transformation Type ${t.Key}`)

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -105,11 +105,11 @@ export = async () => {
     {{range $unit := .ExecUnits -}}
 
     {{- if eq $unit.Type "fargate"}}
-    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>);
+    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}});
     {{else if eq $unit.Type "eks"}}
-    eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}})
+    eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, {{- if $unit.EnvironmentVariables}} envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
     {{else if eq $unit.Type "apprunner"}}
-    arUrls.push(cloudLib.createDockerAppRunner("{{$unit.Name}}"))
+    arUrls.push(cloudLib.createDockerAppRunner("{{$unit.Name}}", {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}))
     {{else}}
     cloudLib.createDockerLambda("{{$unit.Name}}", {{jsonPretty $unit.Params | indent 4}} as Partial<aws.lambda.FunctionArgs> {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}});
     {{end}}

--- a/pkg/lang/javascript/aws_runtime/_orm.ts
+++ b/pkg/lang/javascript/aws_runtime/_orm.ts
@@ -3,12 +3,12 @@
 
 const ormPrefix = '{{.AppName}}'
 
-export function getDBConn(dbName: string): string {
-    const conn = process.env[`${dbName.toUpperCase()}_PERSIST_ORM_CONNECTION`]
+export function getDBConn(dbNameEnvVar: string): string {
+    const conn = process.env[dbNameEnvVar]
     return conn
 }
 
-export function getDataSourceParams(dbName: string, params: { [key: string]: number }): dict {
+export function getDataSourceParams(dbNameEnvVar: string, params: { [key: string]: number }): dict {
     let newParams = { ...params }
     const fieldsToDelete = ['host', 'type', 'port', 'username', 'passowrd', 'database']
     for (const field of fieldsToDelete) {
@@ -18,6 +18,6 @@ export function getDataSourceParams(dbName: string, params: { [key: string]: num
     return {
         ...newParams,
         type: 'postgres',
-        url: getDBConn(dbName),
+        url: getDBConn(dbNameEnvVar),
     }
 }

--- a/pkg/lang/javascript/aws_runtime/_redis_cluster.ts
+++ b/pkg/lang/javascript/aws_runtime/_redis_cluster.ts
@@ -2,7 +2,11 @@
 'use strict'
 
 // The cluster client requires root nodes and defaults to be able to properly connect and get redirected to new slots in memorydb
-export function getParams(dbName: string, params: { [key: string]: any }): dict {
+export function getParams(
+    hostEnvVarName: string,
+    portEnvVarName: string,
+    params: { [key: string]: any }
+): dict {
     const socketDefaults = {}
     if (params['defaults']?.socket) {
         socketDefaults = params['defaults'].socket
@@ -12,8 +16,8 @@ export function getParams(dbName: string, params: { [key: string]: any }): dict 
         rootNodes: [
             {
                 socket: {
-                    host: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_HOST`]}`,
-                    port: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_PORT`]}`,
+                    host: `${process.env[hostEnvVarName]}`,
+                    port: `${process.env[portEnvVarName]}`,
                     tls: true,
                 },
             },
@@ -22,8 +26,8 @@ export function getParams(dbName: string, params: { [key: string]: any }): dict 
             ...params['defaults'],
             socket: {
                 ...socketDefaults,
-                host: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_HOST`]}`,
-                port: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_PORT`]}`,
+                host: `${process.env[hostEnvVarName]}`,
+                port: `${process.env[portEnvVarName]}`,
                 tls: true,
             },
         },

--- a/pkg/lang/javascript/aws_runtime/_redis_node.ts
+++ b/pkg/lang/javascript/aws_runtime/_redis_node.ts
@@ -1,13 +1,17 @@
 //@ts-nocheck
 'use strict'
 
-export function getParams(dbName: string, params: { [key: string]: any }): dict {
+export function getParams(
+    hostEnvVarName: string,
+    portEnvVarName: string,
+    params: { [key: string]: any }
+): dict {
     let newParams = {
         ...params,
         socket: {
             ...params['socket'],
-            host: process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_NODE_HOST`],
-            port: process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_NODE_PORT`],
+            host: process.env[hostEnvVarName],
+            port: process.env[portEnvVarName],
         },
     }
     return {

--- a/pkg/lang/javascript/aws_runtime/dispatcher_lambda.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/dispatcher_lambda.js.tmpl
@@ -14,7 +14,7 @@ const lumigo = require('@lumigo/tracer')({ token: process.env['LUMIGO_KEY'] });
 {{end}}
 const inflight = new Set();
 /**
- * Use this to attach background processes that need to be awaited before the lambda exists.
+ * Use this to attach background processes that need to be awaited before the lambda exits.
  * This is especially useful for cleanup tasks or to bridge between synchronous APIs.
  */
 function addInflight(p) {

--- a/pkg/lang/javascript/aws_runtime/orm.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/orm.js.tmpl
@@ -3,12 +3,12 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getDataSourceParams = exports.getDBConn = void 0;
 const ormPrefix = '{{.AppName}}';
-function getDBConn(dbName) {
-    const conn = process.env[`${dbName.toUpperCase()}_PERSIST_ORM_CONNECTION`];
+function getDBConn(dbNameEnvVar) {
+    const conn = process.env[dbNameEnvVar];
     return conn;
 }
 exports.getDBConn = getDBConn;
-function getDataSourceParams(dbName, params) {
+function getDataSourceParams(dbNameEnvVar, params) {
     let newParams = { ...params };
     const fieldsToDelete = ['host', 'type', 'port', 'username', 'passowrd', 'database'];
     for (const field of fieldsToDelete) {
@@ -17,7 +17,7 @@ function getDataSourceParams(dbName, params) {
     return {
         ...newParams,
         type: 'postgres',
-        url: getDBConn(dbName),
+        url: getDBConn(dbNameEnvVar),
     };
 }
 exports.getDataSourceParams = getDataSourceParams;

--- a/pkg/lang/javascript/aws_runtime/redis_cluster.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/redis_cluster.js.tmpl
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getParams = void 0;
 // The cluster client requires root nodes and defaults to be able to properly connect and get redirected to new slots in memorydb
-function getParams(dbName, params) {
+function getParams(hostEnvVarName, portEnvVarName, params) {
     const socketDefaults = {};
     if (params['defaults']?.socket) {
         socketDefaults = params['defaults'].socket;
@@ -13,8 +13,8 @@ function getParams(dbName, params) {
         rootNodes: [
             {
                 socket: {
-                    host: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_HOST`]}`,
-                    port: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_PORT`]}`,
+                    host: `${process.env[hostEnvVarName]}`,
+                    port: `${process.env[portEnvVarName]}`,
                     tls: true,
                 },
             },
@@ -23,8 +23,8 @@ function getParams(dbName, params) {
             ...params['defaults'],
             socket: {
                 ...socketDefaults,
-                host: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_HOST`]}`,
-                port: `${process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_CLUSTER_PORT`]}`,
+                host: `${process.env[hostEnvVarName]}`,
+                port: `${process.env[portEnvVarName]}`,
                 tls: true,
             },
         },

--- a/pkg/lang/javascript/aws_runtime/redis_node.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/redis_node.js.tmpl
@@ -2,13 +2,13 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getParams = void 0;
-function getParams(dbName, params) {
+function getParams(hostEnvVarName, portEnvVarName, params) {
     let newParams = {
         ...params,
         socket: {
             ...params['socket'],
-            host: process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_NODE_HOST`],
-            port: process.env[`${dbName.toUpperCase()}_PERSIST_REDIS_NODE_PORT`],
+            host: process.env[hostEnvVarName],
+            port: process.env[portEnvVarName],
         },
     };
     return {

--- a/pkg/lang/javascript/plugin_persist_test.go
+++ b/pkg/lang/javascript/plugin_persist_test.go
@@ -252,7 +252,8 @@ const m = new keyvalueRuntime.dMap({"versioned":true})`,
 				return
 			}
 
-			_, err = p.transformKV(f, newF, cap, pres)
+			unit := core.ExecutionUnit{}
+			_, err = p.transformKV(f, newF, cap, pres, &unit)
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -565,7 +566,7 @@ const client = createClient({ socket: {
 *   id = "redis"
 * }
 */
-const client = createClient(redis_nodeRuntime.getParams("redis", { socket: {
+const client = createClient(redis_nodeRuntime.getParams("REDIS_PERSIST_REDIS_HOST", "REDIS_PERSIST_REDIS_PORT", { socket: {
 	host: process.env.REDIS_HOST,
 	port: port,
 	keepAlive: 5000
@@ -592,7 +593,7 @@ const client = createCluster({
 *   id = "redis"
 * }
 */
-const client = createCluster(redis_clusterRuntime.getParams("redis", {
+const client = createCluster(redis_clusterRuntime.getParams("REDIS_PERSIST_REDIS_HOST", "REDIS_PERSIST_REDIS_PORT", {
 	rootNodes:[
 		{
 			url: 'redis://127.0.0.1:8001'
@@ -618,14 +619,15 @@ const client = createCluster(redis_clusterRuntime.getParams("redis", {
 			}
 
 			_, pres := p.determinePersistType(f, cap)
-
-			_, err = p.transformRedis(f, newF, cap, pres)
+			unit := &core.ExecutionUnit{}
+			_, err = p.transformRedis(f, newF, cap, pres, unit)
 			if tt.wantErr {
 				assert.Error(err)
 				return
 			}
 			assert.NoError(err)
 			assert.Equal(tt.want, string(newF.Program()))
+			assert.Len(unit.EnvironmentVariables, 2)
 		})
 	}
 }


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? makes progress towards [#601](https://github.com/klothoplatform/klotho-history/issues/601). It doesnt pull back all of the environment variables, but removes the need of hardcoding for redis, orm, helm env vars.

A lot of this is unit tests, but heres what isnt

python and js persist - we use the new method generateEnvVar (for orm and redis respectively) and then attach that to the exec unit.

Kubernetes - We attach the core.Environment Variable to the value so that our infra understands what it will need to inject. This prevents more hardcoding and creation if the same env vars as before without the _

DeployLib and index.tmpl - We always pass the unit.EnvironmentVariables to whichever function is creating the exec unit


### Standard checks

- **Unit tests**: Any special considerations? Added around code which was touched and running https://github.com/klothoplatform/klotho/actions/runs/3753900452 at the moment, so would like to see that pass. Also running helm testing manually
- **Docs**: Do we need to update any docs, internal or public? No, all internal
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? Yes, just changing the method in which we get env vars. We now validate if there are multiple resources for the same capabillity so using a single env var for redis cluster and node will be fine since they are both persist.
