### PR TITLE
Update deployment triggers for apigateway stage

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -1030,7 +1030,7 @@ export class CloudCCLib {
                 triggers: {
                     routes: sha256.sync(
                         routes
-                            .map((r) => r.path)
+                            .map((r) => `${r.execUnitName}:${r.path}:${r.verb}`)
                             .sort()
                             .join()
                     ),


### PR DESCRIPTION
Resolves https://github.com/klothoplatform/klotho-history/issues/596

We were only checking the paths and not the exec units or verbs so when routes stayed the same path but moved exec units, we didn't recreate the deployment within the api gateway stage

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
