### PR TITLE
Change annotations to be a map with pointer values

### DIFF
--- a/cmd/ast/main.go
+++ b/cmd/ast/main.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 
+	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang"
 	"github.com/klothoplatform/klotho/pkg/lang/javascript"
 	sitter "github.com/smacker/go-tree-sitter"
@@ -98,10 +100,25 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		caps, err := javascript.Language.CapabilityFinder.FindAllCapabilities(jsFile)
+		annots, err := javascript.Language.CapabilityFinder.FindAllCapabilities(jsFile)
 		if err != nil {
 			return err
 		}
+		var caps []core.Annotation
+		for _, v := range annots {
+			caps = append(caps, *v)
+		}
+		sort.Slice(caps, func(i, j int) bool {
+			startI := 0
+			if caps[i].Node != nil {
+				startI = int(caps[i].Node.StartByte())
+			}
+			startJ := 0
+			if caps[j].Node != nil {
+				startJ = int(caps[j].Node.StartByte())
+			}
+			return startI < startJ
+		})
 		return enc.Encode(caps)
 	}
 

--- a/cmd/ast/main.go
+++ b/cmd/ast/main.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 
-	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang"
 	"github.com/klothoplatform/klotho/pkg/lang/javascript"
 	sitter "github.com/smacker/go-tree-sitter"
@@ -104,21 +102,7 @@ func run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		var caps []core.Annotation
-		for _, v := range annots {
-			caps = append(caps, *v)
-		}
-		sort.Slice(caps, func(i, j int) bool {
-			startI := 0
-			if caps[i].Node != nil {
-				startI = int(caps[i].Node.StartByte())
-			}
-			startJ := 0
-			if caps[j].Node != nil {
-				startJ = int(caps[j].Node.StartByte())
-			}
-			return startI < startJ
-		})
+		caps := annots.InSourceOrder()
 		return enc.Encode(caps)
 	}
 

--- a/pkg/core/annotation.go
+++ b/pkg/core/annotation.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/CloudCompilers/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/pelletier/go-toml/v2"
 	sitter "github.com/smacker/go-tree-sitter"
@@ -79,4 +81,25 @@ func (m AnnotationMap) Update(other AnnotationMap) {
 
 func (m AnnotationMap) Add(a *Annotation) {
 	m[a.Key()] = a
+}
+
+// InSourceOrder returns a list of annotations in the order they are defined.
+func (m AnnotationMap) InSourceOrder() []*Annotation {
+	var list []*core.Annotation
+	for _, v := range m {
+		list = append(list, *v)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		startI := 0
+		if list[i].Node != nil {
+			startI = int(list[i].Node.StartByte())
+		}
+		startJ := 0
+		if list[j].Node != nil {
+			startJ = int(list[j].Node.StartByte())
+		}
+		return startI < startJ
+	})
+
+	return list
 }

--- a/pkg/core/annotation.go
+++ b/pkg/core/annotation.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/CloudCompilers/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/pelletier/go-toml/v2"
 	sitter "github.com/smacker/go-tree-sitter"
@@ -85,9 +84,9 @@ func (m AnnotationMap) Add(a *Annotation) {
 
 // InSourceOrder returns a list of annotations in the order they are defined.
 func (m AnnotationMap) InSourceOrder() []*Annotation {
-	var list []*core.Annotation
+	var list []*Annotation
 	for _, v := range m {
-		list = append(list, *v)
+		list = append(list, v)
 	}
 	sort.Slice(list, func(i, j int) bool {
 		startI := 0

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -17,7 +17,7 @@ type (
 
 	CompileError struct {
 		File       *SourceFile
-		Annotation Annotation
+		Annotation *Annotation
 		Cause      error
 	}
 
@@ -62,7 +62,7 @@ func (err *PluginError) Unwrap() error {
 	return err.Cause
 }
 
-func NewCompilerError(f *SourceFile, annotation Annotation, cause error) *CompileError {
+func NewCompilerError(f *SourceFile, annotation *Annotation, cause error) *CompileError {
 	return &CompileError{
 		File:       f,
 		Annotation: annotation,

--- a/pkg/core/project_file_test.go
+++ b/pkg/core/project_file_test.go
@@ -144,14 +144,16 @@ var testLang = SourceLanguage{
 	CapabilityFinder: &testCapabilityFinder{},
 }
 
-func (t *testCapabilityFinder) FindAllCapabilities(sf *SourceFile) ([]Annotation, error) {
+func (t *testCapabilityFinder) FindAllCapabilities(sf *SourceFile) (AnnotationMap, error) {
 	body := string(sf.Program())
-	annots := []Annotation{
-		{Capability: &annotation.Capability{
-			Name:       annotation.ExecutionUnitCapability,
-			ID:         body,
-			Directives: annotation.Directives{"id": body},
-		}},
+	annots := AnnotationMap{
+		AnnotationKey{Capability: annotation.ExecutionUnitCapability, ID: body}: &Annotation{
+			Capability: &annotation.Capability{
+				Name:       annotation.ExecutionUnitCapability,
+				ID:         body,
+				Directives: annotation.Directives{"id": body},
+			},
+		},
 	}
 	return annots, nil
 }

--- a/pkg/env_var/plugin_test.go
+++ b/pkg/env_var/plugin_test.go
@@ -302,7 +302,12 @@ const a = 1`,
 			if !assert.NoError(err) {
 				return
 			}
-			cap := f.Annotations()[0].Capability
+			var annot *core.Annotation
+			for _, v := range f.Annotations() {
+				annot = v
+				break
+			}
+			cap := annot.Capability
 			result, err := ParseDirectiveToEnvVars(cap)
 			if tt.wantErr {
 				assert.Error(err)

--- a/pkg/exec_unit/source_files_resolver_test.go
+++ b/pkg/exec_unit/source_files_resolver_test.go
@@ -131,22 +131,24 @@ var testAnnotationLang = core.SourceLanguage{
 	CapabilityFinder: &testMultipleCapabilityFinder{},
 }
 
-func (t *testMultipleCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) ([]core.Annotation, error) {
+func (t *testMultipleCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) (core.AnnotationMap, error) {
 	body := string(sf.Program())
 	rawAnnots := strings.SplitN(body, "|", 2)
-	var annots []core.Annotation
+	annots := make(core.AnnotationMap)
 	if body == "" {
-		return []core.Annotation{}, nil
+		return annots, nil
 	}
 	for _, rawAnnot := range rawAnnots {
 		annotParts := strings.SplitN(rawAnnot, ":", 2)
 		if len(annotParts) != 2 {
 			continue
 		}
-		annots = append(annots, core.Annotation{Capability: &annotation.Capability{
-			Name: strings.TrimSpace(annotParts[0]),
-			ID:   strings.TrimSpace(annotParts[1]),
-		}})
+		annots.Add(&core.Annotation{
+			Capability: &annotation.Capability{
+				Name: strings.TrimSpace(annotParts[0]),
+				ID:   strings.TrimSpace(annotParts[1]),
+			},
+		})
 
 	}
 	return annots, nil

--- a/pkg/infra/kubernetes/plugin_test.go
+++ b/pkg/infra/kubernetes/plugin_test.go
@@ -201,17 +201,17 @@ var testLang = core.SourceLanguage{
 	CapabilityFinder: &testCapabilityFinder{},
 }
 
-func (t *testCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) ([]core.Annotation, error) {
+func (t *testCapabilityFinder) FindAllCapabilities(sf *core.SourceFile) (core.AnnotationMap, error) {
 	body := string(sf.Program())
-	annots := []core.Annotation{}
+	annots := make(core.AnnotationMap)
 	if body != "" {
-		annots = []core.Annotation{
-			{Capability: &annotation.Capability{
+		annots.Add(&core.Annotation{
+			Capability: &annotation.Capability{
 				Name:       annotation.ExecutionUnitCapability,
 				ID:         body,
 				Directives: annotation.Directives{"id": body},
-			}},
-		}
+			},
+		})
 	}
 	return annots, nil
 }

--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -264,7 +264,7 @@ func (h *restAPIHandler) findChiRouterDefinition(f *core.SourceFile, appName str
 	return chiRouterDefResult{}, nil
 }
 
-func (h *restAPIHandler) findHttpListenAndServe(cap core.Annotation, f *core.SourceFile) (httpListener, error) {
+func (h *restAPIHandler) findHttpListenAndServe(cap *core.Annotation, f *core.SourceFile) (httpListener, error) {
 	nextMatch := doQuery(cap.Node, findHttpListen)
 	for {
 		match, found := nextMatch()

--- a/pkg/lang/golang/plugin_expose_test.go
+++ b/pkg/lang/golang/plugin_expose_test.go
@@ -53,7 +53,12 @@ func Test_findHttpListenServe(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			listener, err := testRestAPIHandler.findHttpListenAndServe(f.Annotations()[0], f)
+			var annot *core.Annotation
+			for _, v := range f.Annotations() {
+				annot = v
+				break
+			}
+			listener, err := testRestAPIHandler.findHttpListenAndServe(annot, f)
 
 			if tt.expectErr {
 				assert.Error(err)

--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -92,7 +92,7 @@ var dockerfileFargate []byte
 
 var sequelizeReplaceRE = regexp.MustCompile(`new (\w+\.|\b)Sequelize\(`)
 
-func (r *AwsRuntime) TransformPersist(file *core.SourceFile, annot core.Annotation, kind core.PersistKind, content string) (javascript.TransformResult, error) {
+func (r *AwsRuntime) TransformPersist(file *core.SourceFile, annot *core.Annotation, kind core.PersistKind, content string) (javascript.TransformResult, error) {
 	result := javascript.TransformResult{
 		NewFileContent:       content,
 		NewAnnotationContent: annot.Node.Content(file.Program()),

--- a/pkg/lang/javascript/expose.go
+++ b/pkg/lang/javascript/expose.go
@@ -30,7 +30,7 @@ type exposeListenResult struct {
 	Identifier *sitter.Node // Identifier of the listen result (app)
 }
 
-func findListener(cap core.Annotation, source []byte) exposeListenResult {
+func findListener(cap *core.Annotation, source []byte) exposeListenResult {
 
 	nextMatch := DoQuery(cap.Node, exposeListener)
 	for {

--- a/pkg/lang/javascript/expose_test.go
+++ b/pkg/lang/javascript/expose_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,7 +125,12 @@ async function setup() {
 			if !assert.NoError(err) {
 				return
 			}
-			listen := findListener(f.Annotations()[0], f.Program())
+			var annot *core.Annotation
+			for _, v := range f.Annotations() {
+				annot = v
+				break
+			}
+			listen := findListener(annot, f.Program())
 			if !assert.NotNil(listen.Expression, "error in test source listen function") {
 				return
 			}

--- a/pkg/lang/javascript/plugin_persist_test.go
+++ b/pkg/lang/javascript/plugin_persist_test.go
@@ -181,7 +181,7 @@ func Test_queryKV(t *testing.T) {
 				return
 			}
 
-			cap := core.Annotation{
+			cap := &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}
@@ -240,7 +240,11 @@ const m = new keyvalueRuntime.dMap({"versioned":true})`,
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 			// assuming aws runtime
 			p := persister{
 				runtime: NoopRuntime{},
@@ -342,7 +346,7 @@ func Test_queryFS(t *testing.T) {
 
 			p := persister{}
 
-			fsResult := p.queryFS(f, core.Annotation{
+			fsResult := p.queryFS(f, &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			})
@@ -420,7 +424,7 @@ func Test_queryORM(t *testing.T) {
 
 			p := persister{}
 
-			fsResult := p.queryORM(f, core.Annotation{
+			fsResult := p.queryORM(f, &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}, true)
@@ -526,7 +530,7 @@ func Test_queryRedis(t *testing.T) {
 
 			p := persister{}
 
-			fsResult := p.queryRedis(f, core.Annotation{
+			fsResult := p.queryRedis(f, &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}, true)
@@ -612,7 +616,11 @@ const client = createCluster(redis_clusterRuntime.getParams("REDIS_PERSIST_REDIS
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 			// assuming aws runtime
 			p := persister{
 				runtime: NoopRuntime{},
@@ -738,7 +746,7 @@ func Test_inferType(t *testing.T) {
 			}
 			p := persister{}
 
-			fsResult := p.queryFS(f, core.Annotation{
+			fsResult := p.queryFS(f, &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			})

--- a/pkg/lang/javascript/plugin_pubsub_test.go
+++ b/pkg/lang/javascript/plugin_pubsub_test.go
@@ -43,8 +43,13 @@ func TestPubSub_rewriteFileEmitters(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
+			var annot *core.Annotation
+			for _, v := range f.Annotations() {
+				annot = v
+				break
+			}
 
-			varDec := VarDeclarations{tt.varSpec: &VarParseStructs{Annotation: f.Annotations()[0]}}
+			varDec := VarDeclarations{tt.varSpec: &VarParseStructs{Annotation: annot}}
 			got := p.rewriteFileEmitters(f, varDec)
 			assert.Equal(tt.want, got)
 			assert.Contains(string(f.Program()), `exports.MyEmitter = new emitterRuntime.Emitter("test.js", "MyEmitter", "myEmitter");`)

--- a/pkg/lang/javascript/runtime.go
+++ b/pkg/lang/javascript/runtime.go
@@ -40,7 +40,7 @@ type TransformResult struct {
 
 type Runtime interface {
 	// TransformPersist applies any runtime-specific transformations to the given file for the annotation. Returns the modified source code, to be `Reparse`d by the caller.
-	TransformPersist(file *core.SourceFile, annot core.Annotation, kind core.PersistKind, content string) (TransformResult, error)
+	TransformPersist(file *core.SourceFile, annot *core.Annotation, kind core.PersistKind, content string) (TransformResult, error)
 	AddKvRuntimeFiles(unit *core.ExecutionUnit) error
 	AddFsRuntimeFiles(unit *core.ExecutionUnit) error
 	AddSecretRuntimeFiles(unit *core.ExecutionUnit) error

--- a/pkg/lang/javascript/runtime_test.go
+++ b/pkg/lang/javascript/runtime_test.go
@@ -69,6 +69,6 @@ func (NoopRuntime) AddProxyRuntimeFiles(unit *core.ExecutionUnit, proxyType stri
 func (NoopRuntime) AddExecRuntimeFiles(unit *core.ExecutionUnit, result *core.CompilationResult, deps *core.Dependencies) error {
 	return nil
 }
-func (NoopRuntime) TransformPersist(file *core.SourceFile, annot core.Annotation, kind core.PersistKind, content string) (TransformResult, error) {
+func (NoopRuntime) TransformPersist(file *core.SourceFile, annot *core.Annotation, kind core.PersistKind, content string) (TransformResult, error) {
 	return TransformResult{NewFileContent: content, NewAnnotationContent: annot.Node.Content(file.Program())}, nil
 }

--- a/pkg/lang/javascript/var_finder.go
+++ b/pkg/lang/javascript/var_finder.go
@@ -33,7 +33,7 @@ type (
 		requireExport bool
 	}
 
-	AnnotationFilter func(declaringFile *core.SourceFile, annot core.Annotation) bool
+	AnnotationFilter func(declaringFile *core.SourceFile, annot *core.Annotation) bool
 
 	VarDeclarations map[VarSpec]*VarParseStructs
 
@@ -54,7 +54,7 @@ type (
 	// VarSpecStructs often come paired with a `VarSpec`, which tells you the variable name within the file.
 	VarParseStructs struct {
 		File       *core.SourceFile
-		Annotation core.Annotation
+		Annotation *core.Annotation
 	}
 )
 
@@ -74,7 +74,7 @@ func (v VarDeclarations) SplitByFile() map[string]VarDeclarations {
 }
 
 func FilterByCapability(capability string) AnnotationFilter {
-	return func(_ *core.SourceFile, annot core.Annotation) bool {
+	return func(_ *core.SourceFile, annot *core.Annotation) bool {
 		return annot.Capability.Name == capability
 	}
 }
@@ -134,7 +134,7 @@ func (vf *varFinder) discoverFileDeclarations(f *core.SourceFile) VarDeclaration
 	return vars
 }
 
-func (vf *varFinder) parseNode(f *core.SourceFile, annot core.Annotation) (internalName string, exportName string, err error) {
+func (vf *varFinder) parseNode(f *core.SourceFile, annot *core.Annotation) (internalName string, exportName string, err error) {
 	next := DoQuery(annot.Node, declareAndInstantiate)
 
 	for {

--- a/pkg/lang/javascript/var_finder_test.go
+++ b/pkg/lang/javascript/var_finder_test.go
@@ -58,10 +58,10 @@ exports.a = e`,
 		{
 			name: "two emitters one file",
 			sources: map[string]string{
-				"test.js": `// @klotho::pubsub
+				"test.js": `// @klotho::pubsub { id = "e" }
 exports.e = new EventEmitter()
 
-// @klotho::pubsub
+// @klotho::pubsub { id = "e2" }
 exports.e2 = new EventEmitter()`,
 			},
 			want: []VarSpec{
@@ -174,7 +174,7 @@ exports.e1 = new something.EventEmitter()`,
 				return
 			}
 
-			var annots []core.Annotation
+			var annots []*core.Annotation
 			for _, a := range f.Annotations() {
 				if a.Capability.Name == core.PubSubKind {
 					annots = append(annots, a)

--- a/pkg/lang/python/plugin_expose.go
+++ b/pkg/lang/python/plugin_expose.go
@@ -70,7 +70,7 @@ func (p *Expose) transformSingle(result *core.CompilationResult, deps *core.Depe
 	return err
 }
 
-func (h *restAPIHandler) findFastAPIAppDefinition(cap core.Annotation, f *core.SourceFile) (fastapiDefResult, error) {
+func (h *restAPIHandler) findFastAPIAppDefinition(cap *core.Annotation, f *core.SourceFile) (fastapiDefResult, error) {
 
 	nextMatch := DoQuery(cap.Node, exposeFastAPIAssignment)
 	for {

--- a/pkg/lang/python/plugin_expose_test.go
+++ b/pkg/lang/python/plugin_expose_test.go
@@ -51,7 +51,12 @@ func Test_findFastApiApp(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			app, _ := testRestAPIHandler.findFastAPIAppDefinition(f.Annotations()[0], f)
+			var annot *core.Annotation
+			for _, v := range f.Annotations() {
+				annot = v
+				break
+			}
+			app, _ := testRestAPIHandler.findFastAPIAppDefinition(annot, f)
 			if !assert.NotNil(app.Expression, "error in test source app definition function") {
 				return
 			}

--- a/pkg/lang/python/plugin_persist.go
+++ b/pkg/lang/python/plugin_persist.go
@@ -114,7 +114,7 @@ func (p *persister) handleFile(f *core.SourceFile, unit *core.ExecutionUnit) ([]
 			errs.Append(core.NewCompilerError(f, annot, errors.New("'id' is required")))
 		}
 
-		var doTransform func(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, result *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error)
+		var doTransform func(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, result *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error)
 		var err error
 		switch keyType {
 		case core.PersistKVKind:
@@ -157,7 +157,7 @@ func (p *persister) handleFile(f *core.SourceFile, unit *core.ExecutionUnit) ([]
 	return resources, errs.ErrOrNil()
 }
 
-func (p *persister) transformKV(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, kvR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
+func (p *persister) transformKV(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, kvR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
 
 	// add the kv runtime import to the file containing a persisted aiocache instance
 	kvConfig := p.runtime.GetKvRuntimeConfig()
@@ -230,7 +230,7 @@ func (p *persister) transformKV(original *core.SourceFile, modified *core.Source
 	return result, nil
 }
 
-func (p *persister) transformFS(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, fsR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
+func (p *persister) transformFS(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, fsR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
 
 	nodeContent := cap.Node.Content(original.Program())
 
@@ -261,7 +261,7 @@ func (p *persister) transformFS(original *core.SourceFile, modified *core.Source
 	return result, nil
 }
 
-func (p *persister) transformSecret(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, secretR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
+func (p *persister) transformSecret(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, secretR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
 
 	nodeContent := cap.Node.Content(original.Program())
 
@@ -300,7 +300,7 @@ func (p *persister) transformSecret(original *core.SourceFile, modified *core.So
 	return result, nil
 }
 
-func (p *persister) transformORM(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, ormR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
+func (p *persister) transformORM(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, ormR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
 
 	nodeContent := cap.Node.Content(original.Program())
 
@@ -338,7 +338,7 @@ func (p *persister) transformORM(original *core.SourceFile, modified *core.Sourc
 	return result, nil
 }
 
-func (p *persister) transformRedis(original *core.SourceFile, modified *core.SourceFile, cap core.Annotation, redisR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
+func (p *persister) transformRedis(original *core.SourceFile, modified *core.SourceFile, cap *core.Annotation, redisR *persistResult, unit *core.ExecutionUnit) (core.CloudResource, error) {
 
 	nodeContent := cap.Node.Content(original.Program())
 
@@ -415,7 +415,7 @@ type persistResult struct {
 	kind       core.PersistKind
 }
 
-func (p *persister) queryKV(file *core.SourceFile, annotation core.Annotation, enableWarnings bool) *persistResult {
+func (p *persister) queryKV(file *core.SourceFile, annotation *core.Annotation, enableWarnings bool) *persistResult {
 	log := zap.L().With(logging.FileField(file), logging.AnnotationField(annotation))
 
 	imports := FindImports(file)
@@ -476,7 +476,7 @@ func (p *persister) queryKV(file *core.SourceFile, annotation core.Annotation, e
 	}
 }
 
-func (p *persister) queryFS(file *core.SourceFile, annotation core.Annotation, enableWarnings bool) *persistResult {
+func (p *persister) queryFS(file *core.SourceFile, annotation *core.Annotation, enableWarnings bool) *persistResult {
 	log := zap.L().With(logging.FileField(file), logging.AnnotationField(annotation))
 
 	imports := FindImports(file)
@@ -526,7 +526,7 @@ func (p *persister) queryFS(file *core.SourceFile, annotation core.Annotation, e
 	}
 }
 
-func (p *persister) queryORM(file *core.SourceFile, annotation core.Annotation, enableWarnings bool) *persistResult {
+func (p *persister) queryORM(file *core.SourceFile, annotation *core.Annotation, enableWarnings bool) *persistResult {
 	log := zap.L().With(logging.FileField(file), logging.AnnotationField(annotation))
 
 	imports := FindImports(file)
@@ -627,7 +627,7 @@ func (p *persister) querySecret(file *core.SourceFile, name string) ([]string, e
 
 }
 
-func (p *persister) queryRedis(file *core.SourceFile, annotation core.Annotation, enableWarnings bool) *persistResult {
+func (p *persister) queryRedis(file *core.SourceFile, annotation *core.Annotation, enableWarnings bool) *persistResult {
 	log := zap.L().With(logging.FileField(file), logging.AnnotationField(annotation))
 
 	imports := FindImports(file)
@@ -726,7 +726,7 @@ func (p *persister) queryRedis(file *core.SourceFile, annotation core.Annotation
 	}
 }
 
-func (p *persister) determinePersistType(f *core.SourceFile, annotation core.Annotation) (core.PersistKind, *persistResult) {
+func (p *persister) determinePersistType(f *core.SourceFile, annotation *core.Annotation) (core.PersistKind, *persistResult) {
 	log := zap.L().With(logging.FileField(f), logging.AnnotationField(annotation))
 
 	kvR := p.queryKV(f, annotation, false)

--- a/pkg/lang/python/plugin_persist_test.go
+++ b/pkg/lang/python/plugin_persist_test.go
@@ -44,7 +44,7 @@ func Test_persister_queryKV(t *testing.T) {
 				return
 			}
 
-			cap := core.Annotation{
+			cap := &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}
@@ -131,7 +131,11 @@ myCache = Cache(cache_class=keyvalue.KVStore, my_arg="value", serializer=keyvalu
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 
 			p := persister{
 				runtime: NoopRuntime{},
@@ -189,7 +193,7 @@ func Test_persister_queryFs(t *testing.T) {
 				return
 			}
 
-			cap := core.Annotation{
+			cap := &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}
@@ -254,7 +258,11 @@ import klotho_runtime.fs as fs`,
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 
 			p := persister{
 				runtime: NoopRuntime{},
@@ -423,7 +431,11 @@ import klotho_runtime.fs as fs`,
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 
 			p := persister{
 				runtime: NoopRuntime{},
@@ -552,7 +564,7 @@ func Test_persister_queryOrm(t *testing.T) {
 				return
 			}
 
-			cap := core.Annotation{
+			cap := &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability},
 				Node:       f.Tree().RootNode(),
 			}
@@ -677,7 +689,11 @@ engine = create_engine(os.environ.get("SQLALCHEMY_PERSIST_ORM_CONNECTION"))`,
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 
 			p := persister{
 				runtime: NoopRuntime{},
@@ -875,7 +891,7 @@ func Test_persister_queryRedis(t *testing.T) {
 				return
 			}
 
-			cap := core.Annotation{
+			cap := &core.Annotation{
 				Capability: &annotation.Capability{Name: annotation.PersistCapability, ID: "redis"},
 				Node:       f.Tree().RootNode(),
 			}
@@ -1007,7 +1023,11 @@ client = RedisCluster(host=os.environ.get("REDIS_PERSIST_REDIS_HOST"), port=os.e
 			}
 			newF := f.CloneSourceFile()
 
-			cap := f.Annotations()[0]
+			var cap *core.Annotation
+			for _, v := range f.Annotations() {
+				cap = v
+				break
+			}
 
 			p := persister{
 				runtime: NoopRuntime{},

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -39,7 +39,7 @@ func FileField(f core.File) zap.Field {
 }
 
 type annotationField struct {
-	a core.Annotation
+	a *core.Annotation
 }
 
 func (field annotationField) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -59,7 +59,7 @@ func (field annotationField) Sanitize(hasher func(any) string) SanitizedField {
 	}
 }
 
-func AnnotationField(a core.Annotation) zap.Field {
+func AnnotationField(a *core.Annotation) zap.Field {
 	return zap.Object("annotation", annotationField{a: a})
 }
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -85,7 +85,7 @@ func (p *Plugin) handleAnnotations(result *core.CompilationResult) error {
 
 		for _, annot := range ast.Annotations() {
 			log = log.With(logging.AnnotationField(annot))
-			p.checkAnnotationForResource(&annot, result, log)
+			p.checkAnnotationForResource(annot, result, log)
 		}
 	}
 	return errs.ErrOrNil()


### PR DESCRIPTION
This should enable us to do less "hacky" things when modifying source code - not having to worry about keeping a separate "newContent" then only calling reparse once at the end.

### Standard checks

- **Unit tests**: No changes expected - unit tests should pass to verify equivalent functionality.
- **Docs**: Entirely internal
- **Backwards compatibility**: ✅ 
