### PR TITLE
support cloudfront for gateway and static unit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type (
 	}
 	Expose struct {
 		Type        string      `json:"type" yaml:"type" toml:"type"`
+		CdnId       string      `json:"cdn_id,omitempty" yaml:"cdn_id,omitempty" toml:"cdn_id,omitempty"`
 		InfraParams InfraParams `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
 	}
 
@@ -60,6 +61,7 @@ type (
 	StaticUnit struct {
 		Type        string      `json:"type" yaml:"type" toml:"type"`
 		InfraParams InfraParams `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
+		CdnId       string      `json:"cdn_id,omitempty" yaml:"cdn_id,omitempty" toml:"cdn_id,omitempty"`
 	}
 
 	Defaults struct {
@@ -150,6 +152,7 @@ func (cfg *Expose) Merge(other Expose) {
 	if other.Type != "" {
 		cfg.Type = other.Type
 	}
+	cfg.CdnId = other.CdnId
 	cfg.InfraParams.Merge(other.InfraParams)
 }
 
@@ -171,6 +174,7 @@ func (cfg *StaticUnit) Merge(other StaticUnit) {
 	if other.Type != "" {
 		cfg.Type = other.Type
 	}
+	cfg.CdnId = other.CdnId
 	cfg.InfraParams.Merge(other.InfraParams)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,9 +30,9 @@ type (
 		PubSub         map[string]*PubSub        `json:"pubsub,omitempty" yaml:"pubsub,omitempty" toml:"pubsub,omitempty"`
 	}
 	Expose struct {
-		Type        string      `json:"type" yaml:"type" toml:"type"`
-		CdnId       string      `json:"cdn_id,omitempty" yaml:"cdn_id,omitempty" toml:"cdn_id,omitempty"`
-		InfraParams InfraParams `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
+		Type                   string                 `json:"type" yaml:"type" toml:"type"`
+		ContentDeliveryNetwork ContentDeliveryNetwork `json:"content_delivery_network,omitempty" yaml:"content_delivery_network,omitempty" toml:"content_delivery_network,omitempty"`
+		InfraParams            InfraParams            `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
 	}
 
 	Persist struct {
@@ -59,9 +59,9 @@ type (
 	}
 
 	StaticUnit struct {
-		Type        string      `json:"type" yaml:"type" toml:"type"`
-		InfraParams InfraParams `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
-		CdnId       string      `json:"cdn_id,omitempty" yaml:"cdn_id,omitempty" toml:"cdn_id,omitempty"`
+		Type                   string                 `json:"type" yaml:"type" toml:"type"`
+		InfraParams            InfraParams            `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
+		ContentDeliveryNetwork ContentDeliveryNetwork `json:"content_delivery_network,omitempty" yaml:"content_delivery_network,omitempty" toml:"content_delivery_network,omitempty"`
 	}
 
 	Defaults struct {
@@ -84,6 +84,10 @@ type (
 		ORM          KindDefaults `json:"orm" yaml:"orm" toml:"orm"`
 		RedisNode    KindDefaults `json:"redis_node" yaml:"redis_node" toml:"redis_node"`
 		RedisCluster KindDefaults `json:"redis_cluster" yaml:"redis_cluster" toml:"redis_cluster"`
+	}
+
+	ContentDeliveryNetwork struct {
+		Id string `json:"id,omitempty" yaml:"id,omitempty" toml:"id,omitempty"`
 	}
 
 	// InfraParams are passed as-is to the generated IaC
@@ -152,7 +156,7 @@ func (cfg *Expose) Merge(other Expose) {
 	if other.Type != "" {
 		cfg.Type = other.Type
 	}
-	cfg.CdnId = other.CdnId
+	cfg.ContentDeliveryNetwork = other.ContentDeliveryNetwork
 	cfg.InfraParams.Merge(other.InfraParams)
 }
 
@@ -174,7 +178,7 @@ func (cfg *StaticUnit) Merge(other StaticUnit) {
 	if other.Type != "" {
 		cfg.Type = other.Type
 	}
-	cfg.CdnId = other.CdnId
+	cfg.ContentDeliveryNetwork = other.ContentDeliveryNetwork
 	cfg.InfraParams.Merge(other.InfraParams)
 }
 

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -9,22 +9,15 @@ import * as fs from 'fs'
 import * as requestRetry from 'requestretry'
 import * as crypto from 'crypto'
 import { setupElasticacheCluster } from './iac/elasticache'
-
 import * as analytics from './iac/analytics'
 
 import { LoadBalancerPlugin } from './iac/load_balancing'
-import {
-    DefaultEksClusterOptions,
-    Eks,
-    EksExecUnit,
-    EksExecUnitArgs,
-    HelmChart,
-    plugins as EksPlugins,
-} from './iac/eks'
+import { DefaultEksClusterOptions, Eks, EksExecUnit, HelmChart } from './iac/eks'
 import { setupMemoryDbCluster } from './iac/memorydb'
 
 export enum Resource {
     exec_unit = 'exec_unit',
+    static_unit = 'static_unit',
     gateway = 'gateway',
     kv = 'persist_kv',
     fs = 'persist_fs',
@@ -33,6 +26,11 @@ export enum Resource {
     redis_node = 'persist_redis_node',
     redis_cluster = 'persist_redis_cluster',
     pubsub = 'pubsub',
+}
+
+export interface ResourceKey {
+    Kind: string
+    Name: string
 }
 
 interface ResourceInfo {
@@ -72,6 +70,9 @@ export class CloudCCLib {
     execUnitToRole = new Map<string, aws.iam.Role>()
     execUnitToPolicyStatements = new Map<string, aws.iam.PolicyStatement[]>()
     execUnitToImage = new Map<string, pulumi.Output<String>>()
+
+    gatewayToUrl = new Map<string, pulumi.Output<string>>()
+    siteBuckets = new Map<string, aws.s3.Bucket>()
 
     topologySpecOutputs: pulumi.Output<ResourceInfo>[] = []
     connectionString = new Map<string, pulumi.Output<string>>()
@@ -1068,6 +1069,8 @@ export class CloudCCLib {
                 url: `https://console.aws.amazon.com/apigateway/home?region=${this.region}#/apis/${id}/resources/`,
             }))
         )
+
+        this.gatewayToUrl.set(providedName, stage.invokeUrl)
 
         return stage.invokeUrl
     }

--- a/pkg/infra/pulumi_aws/iac/cloudfront.ts
+++ b/pkg/infra/pulumi_aws/iac/cloudfront.ts
@@ -23,7 +23,6 @@ export class Cloudfront {
             let targetOrigin: TargetOrigin = {}
             const indexDocument = dist.DefaultRootObject == '' ? undefined : dist.DefaultRootObject
             for (const origin of dist.Origins) {
-                console.log(origin.Name)
                 if (origin.Kind == Resource.gateway) {
                     origins.push(
                         this.createCustomOrigin(origin.Name, lib.gatewayToUrl.get(origin.Name)!)
@@ -51,7 +50,6 @@ export class Cloudfront {
         name: string,
         domainName: pulumi.Output<string>
     ): aws.types.input.cloudfront.DistributionOrigin {
-        console.log(domainName.apply((d) => d.split('//')[1]))
         const origin: aws.types.input.cloudfront.DistributionOrigin = {
             originId: name,
             customOriginConfig: {
@@ -61,6 +59,7 @@ export class Cloudfront {
                 originSslProtocols: ['SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'],
             },
             domainName: domainName.apply((d) => d.split('//')[1].split('/')[0]),
+            originPath: domainName.apply((d) => '/' + d.split('//')[1].split('/')[1]),
         }
         return origin
     }

--- a/pkg/infra/pulumi_aws/iac/cloudfront.ts
+++ b/pkg/infra/pulumi_aws/iac/cloudfront.ts
@@ -1,0 +1,152 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import * as mime from 'mime'
+import * as fs from 'fs'
+import * as path from 'path'
+import { CloudCCLib, ResourceKey, Resource } from '../deploylib'
+
+export interface CloudfrontDistribution {
+    Id: string
+    Origins: ResourceKey[]
+    DefaultRootObject: string
+}
+
+interface TargetOrigin {
+    type?: Resource.static_unit | Resource.gateway
+    id?: string
+}
+
+export class Cloudfront {
+    constructor(lib: CloudCCLib, cloudfrontDistributions: CloudfrontDistribution[]) {
+        for (const dist of cloudfrontDistributions) {
+            const origins: aws.types.input.cloudfront.DistributionOrigin[] = []
+            let targetOrigin: TargetOrigin = {}
+            const indexDocument = dist.DefaultRootObject == '' ? undefined : dist.DefaultRootObject
+            for (const origin of dist.Origins) {
+                console.log(origin.Name)
+                if (origin.Kind == Resource.gateway) {
+                    origins.push(
+                        this.createCustomOrigin(origin.Name, lib.gatewayToUrl.get(origin.Name)!)
+                    )
+                    if (!targetOrigin.id) {
+                        targetOrigin = {
+                            type: Resource.gateway,
+                            id: origin.Name,
+                        }
+                    }
+                } else if (origin.Kind == Resource.static_unit) {
+                    const bucket = lib.siteBuckets.get(origin.Name)!
+                    origins.push(this.createS3Origin(origin.Name, bucket))
+                    targetOrigin = {
+                        type: Resource.static_unit,
+                        id: origin.Name,
+                    }
+                }
+            }
+            this.createDistribution(dist.Id, origins, targetOrigin, indexDocument)
+        }
+    }
+
+    createCustomOrigin(
+        name: string,
+        domainName: pulumi.Output<string>
+    ): aws.types.input.cloudfront.DistributionOrigin {
+        console.log(domainName.apply((d) => d.split('//')[1]))
+        const origin: aws.types.input.cloudfront.DistributionOrigin = {
+            originId: name,
+            customOriginConfig: {
+                httpPort: 80,
+                httpsPort: 443,
+                originProtocolPolicy: 'https-only',
+                originSslProtocols: ['SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'],
+            },
+            domainName: domainName.apply((d) => d.split('//')[1].split('/')[0]),
+        }
+        return origin
+    }
+
+    createS3Origin(
+        name: string,
+        siteBucket: aws.s3.Bucket
+    ): aws.types.input.cloudfront.DistributionOrigin {
+        const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity(
+            `${siteBucket}-originAccessIdentity`,
+            {
+                comment: 'this is needed to setup s3 polices and make s3 not public.',
+            }
+        )
+
+        new aws.s3.BucketPolicy('bucketPolicy', {
+            bucket: siteBucket.id, // refer to the bucket created earlier
+            policy: pulumi
+                .all([originAccessIdentity.iamArn, siteBucket.arn])
+                .apply(([oaiArn, bucketArn]) =>
+                    JSON.stringify({
+                        Version: '2012-10-17',
+                        Statement: [
+                            {
+                                Effect: 'Allow',
+                                Principal: {
+                                    AWS: oaiArn,
+                                }, // Only allow Cloudfront read access.
+                                Action: ['s3:GetObject'],
+                                Resource: [`${bucketArn}/*`], // Give Cloudfront access to the entire bucket.
+                            },
+                        ],
+                    })
+                ),
+        })
+
+        const origin = {
+            domainName: siteBucket.bucketRegionalDomainName,
+            originId: name,
+            s3OriginConfig: {
+                originAccessIdentity: originAccessIdentity.cloudfrontAccessIdentityPath,
+            },
+        }
+
+        return origin
+    }
+
+    createDistribution(
+        name,
+        origins,
+        targetOrigin: TargetOrigin,
+        indexDocument?
+    ): aws.cloudfront.Distribution {
+        let defaultTtl = 3600
+        if (targetOrigin.type == Resource.gateway) {
+            defaultTtl = 0
+        }
+
+        const distribution = new aws.cloudfront.Distribution(name, {
+            origins,
+            enabled: true,
+            viewerCertificate: {
+                cloudfrontDefaultCertificate: true,
+            },
+            defaultCacheBehavior: {
+                allowedMethods: ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
+                cachedMethods: ['HEAD', 'GET'],
+                targetOriginId: targetOrigin.id!,
+                forwardedValues: {
+                    queryString: true,
+                    cookies: {
+                        forward: 'none',
+                    },
+                },
+                viewerProtocolPolicy: 'allow-all',
+                minTtl: 0,
+                defaultTtl,
+                maxTtl: 86400,
+            },
+            restrictions: {
+                geoRestriction: {
+                    restrictionType: 'none',
+                },
+            },
+            defaultRootObject: indexDocument,
+        })
+        return distribution
+    }
+}

--- a/pkg/infra/pulumi_aws/iac/static_s3_website.ts
+++ b/pkg/infra/pulumi_aws/iac/static_s3_website.ts
@@ -3,121 +3,26 @@ import * as pulumi from '@pulumi/pulumi'
 import * as mime from 'mime'
 import * as fs from 'fs'
 import * as path from 'path'
+import { CloudCCLib } from '../deploylib'
 
 export const createStaticS3Website = (
     staticUnit: string,
     indexDocument: string,
-    params
-): pulumi.Output<string> => {
+    lib: CloudCCLib
+) => {
     // Create an S3 bucket
 
     const bucketArgs: aws.s3.BucketArgs = {}
 
-    if (indexDocument != '' && !params.cloudFrontEnabled) {
+    if (indexDocument != '') {
         bucketArgs['website'] = {
             indexDocument: indexDocument,
         }
     }
 
     let siteBucket = new aws.s3.Bucket(`static-website-${staticUnit}`, bucketArgs)
+    lib.siteBuckets.set(staticUnit, siteBucket)
     createAllObjects(staticUnit, siteBucket)
-
-    if (params.cloudFrontEnabled) {
-        // Generate Origin Access Identity to access the private s3 bucket.
-        const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity(
-            'originAccessIdentity',
-            {
-                comment: 'this is needed to setup s3 polices and make s3 not public.',
-            }
-        )
-
-        const bucketPolicy = new aws.s3.BucketPolicy('bucketPolicy', {
-            bucket: siteBucket.id, // refer to the bucket created earlier
-            policy: pulumi
-                .all([originAccessIdentity.iamArn, siteBucket.arn])
-                .apply(([oaiArn, bucketArn]) =>
-                    JSON.stringify({
-                        Version: '2012-10-17',
-                        Statement: [
-                            {
-                                Effect: 'Allow',
-                                Principal: {
-                                    AWS: oaiArn,
-                                }, // Only allow Cloudfront read access.
-                                Action: ['s3:GetObject'],
-                                Resource: [`${bucketArn}/*`], // Give Cloudfront access to the entire bucket.
-                            },
-                        ],
-                    })
-                ),
-        })
-
-        const distribution = new aws.cloudfront.Distribution(`cdn-static-${staticUnit}`, {
-            origins: [
-                {
-                    domainName: siteBucket.bucketRegionalDomainName,
-                    originId: siteBucket.arn,
-                    s3OriginConfig: {
-                        originAccessIdentity: originAccessIdentity.cloudfrontAccessIdentityPath,
-                    },
-                },
-            ],
-            enabled: true,
-            viewerCertificate: {
-                cloudfrontDefaultCertificate: true,
-            },
-            defaultCacheBehavior: {
-                allowedMethods: ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
-                cachedMethods: ['GET', 'HEAD'],
-                targetOriginId: siteBucket.arn,
-                forwardedValues: {
-                    queryString: false,
-                    cookies: {
-                        forward: 'none',
-                    },
-                },
-                viewerProtocolPolicy: 'allow-all',
-                minTtl: 0,
-                defaultTtl: 3600,
-                maxTtl: 86400,
-            },
-            restrictions: {
-                geoRestriction: {
-                    restrictionType: 'none',
-                },
-            },
-            defaultRootObject: indexDocument,
-        })
-
-        return distribution.domainName
-    } else {
-        // Create an S3 Bucket Policy to allow public read of all objects in bucket
-        // This reusable function can be pulled out into its own module
-        function publicReadPolicyForBucket(bucketName) {
-            return JSON.stringify({
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Effect: 'Allow',
-                        Principal: '*',
-                        Action: ['s3:GetObject'],
-                        Resource: [
-                            `arn:aws:s3:::${bucketName}/*`, // policy refers to bucket name explicitly
-                        ],
-                    },
-                ],
-            })
-        }
-
-        // Set the access policy for the bucket so all objects are readable
-        let bucketPolicy = new aws.s3.BucketPolicy('bucketPolicy', {
-            bucket: siteBucket.bucket, // depends on siteBucket -- see explanation below
-            policy: siteBucket.bucket.apply(publicReadPolicyForBucket),
-            // transform the siteBucket.bucket output property -- see explanation below
-        })
-
-        return siteBucket.websiteEndpoint
-    }
 }
 
 const createAllObjects = (staticUnit, siteBucket, prefixPath = '') => {

--- a/pkg/infra/pulumi_aws/iac/static_s3_website.ts
+++ b/pkg/infra/pulumi_aws/iac/static_s3_website.ts
@@ -8,13 +8,14 @@ import { CloudCCLib } from '../deploylib'
 export const createStaticS3Website = (
     staticUnit: string,
     indexDocument: string,
+    contentDeliveryNetworkId: string,
     lib: CloudCCLib
 ) => {
     // Create an S3 bucket
 
     const bucketArgs: aws.s3.BucketArgs = {}
 
-    if (indexDocument != '') {
+    if (indexDocument != '' && contentDeliveryNetworkId == '') {
         bucketArgs['website'] = {
             indexDocument: indexDocument,
         }

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -143,7 +143,7 @@ export = async () => {
 
     {{range $unit := .StaticUnits}}
     staticUnitUrls.push(createStaticS3Website(
-    "{{$unit.Name}}", "{{$unit.IndexDocument}}", cloudLib
+    "{{$unit.Name}}", "{{$unit.IndexDocument}}", "{{$unit.ContentDeliveryNetwork.Id}}", cloudLib
     ))
     {{end}}
 

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -13,9 +13,16 @@ import * as awsx from '@pulumi/awsx'
 import * as k8s from '@pulumi/kubernetes'
 import { v4 as uuidv4 } from "uuid";
 import {CloudCCLib, kloConfig} from './deploylib'
-import {createStaticS3Website} from './iac/static_s3_website'
 import {EksExecUnitArgs, EksExecUnit} from './iac/eks'
 import {CockroachDB} from './iac/cockroachdb'
+
+{{- if .StaticUnits}}
+import {createStaticS3Website} from './iac/static_s3_website'
+{{end}}
+
+{{- if .CloudfrontDistributions}}
+import { Cloudfront } from './iac/cloudfront'
+{{end}}
 
 export = async () => {
     const minimumNodeVersion = 16
@@ -136,12 +143,13 @@ export = async () => {
 
     {{range $unit := .StaticUnits}}
     staticUnitUrls.push(createStaticS3Website(
-    "{{$unit.Name}}", "{{$unit.IndexDocument}}", {{jsonPretty $unit.Params | indent 4}})
-    )
+    "{{$unit.Name}}", "{{$unit.IndexDocument}}", cloudLib
+    ))
     {{end}}
 
-    const apprunnerUrls = arUrls.filter(url => { return url != null});;
     const frontendUrls = staticUnitUrls;
+
+    const apprunnerUrls = arUrls.filter(url => { return url != null});;
 
 
     const gatewayUrls: any[] = [];
@@ -158,6 +166,9 @@ export = async () => {
 
     const apiUrls = gatewayUrls;
 
+    {{- if .CloudfrontDistributions}}
+        new Cloudfront(cloudLib, {{jsonPretty .CloudfrontDistributions | indent 4}})
+    {{end}}
 
     {{range $event := .PubSubs}}
     cloudLib.createTopic(

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -119,6 +119,14 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 		}
 	}
 
+	if len(data.CloudfrontDistributions) > 0 {
+		addFile("iac/cloudfront.ts")
+	}
+
+	if len(data.StaticUnits) > 0 {
+		addFile("iac/static_s3_website.ts")
+	}
+
 	addFile("deploylib.ts")
 	addFile("package.json")
 	addFile("tsconfig.json")
@@ -126,7 +134,6 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 	addFile("iac/memorydb.ts")
 	addFile("iac/eks.ts")
 	addFile("iac/kubernetes.ts")
-	addFile("iac/static_s3_website.ts")
 	addFile("iac/cockroachdb.ts")
 	addFile("iac/analytics.ts")
 	addFile("iac/load_balancing.ts")

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/provider"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 )
 
 type (
@@ -15,7 +16,8 @@ type (
 	TemplateData struct {
 		provider.TemplateData
 		TemplateConfig
-		UseVPC bool
+		UseVPC                  bool
+		CloudfrontDistributions []*resources.CloudfrontDistribution
 	}
 )
 
@@ -27,6 +29,17 @@ func (t *TemplateData) Key() core.ResourceKey {
 	return core.ResourceKey{
 		Name: t.AppName,
 		Kind: AwsTemplateDataKind,
+	}
+}
+
+func NewTemplateData(config *config.Application) *TemplateData {
+	return &TemplateData{
+		TemplateConfig: TemplateConfig{
+			TemplateConfig: provider.TemplateConfig{
+				AppName: config.AppName,
+			},
+			PayloadsBucketName: SanitizeS3BucketName(config.AppName),
+		},
 	}
 }
 

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -89,10 +89,10 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 		case *core.StaticUnit:
 			cfg := a.Config.GetStaticUnit(key.Name)
 			unit := provider.StaticUnit{
-				Name:          res.Name,
-				Type:          res.Type(),
-				IndexDocument: res.IndexDocument,
-				Params:        cfg.InfraParams,
+				Name:                   res.Name,
+				Type:                   res.Type(),
+				IndexDocument:          res.IndexDocument,
+				ContentDeliveryNetwork: cfg.ContentDeliveryNetwork,
 			}
 			data.StaticUnits = append(data.StaticUnits, unit)
 

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -176,7 +176,7 @@ func (a *AWS) GenerateCloudfrontDistributions(data *TemplateData, result *core.C
 		switch res.(type) {
 		case *core.Gateway:
 			cfg := a.Config.GetExposed(key.Name)
-			cfId := cfg.CdnId
+			cfId := cfg.ContentDeliveryNetwork.Id
 			if cfId != "" {
 				cf, ok := cloudfrontMap[cfId]
 				if ok {
@@ -187,7 +187,7 @@ func (a *AWS) GenerateCloudfrontDistributions(data *TemplateData, result *core.C
 			}
 		case *core.StaticUnit:
 			cfg := a.Config.GetStaticUnit(key.Name)
-			cfId := cfg.CdnId
+			cfId := cfg.ContentDeliveryNetwork.Id
 			if cfId != "" {
 				cf, ok := cloudfrontMap[cfId]
 				if ok {

--- a/pkg/provider/aws/infra_template_test.go
+++ b/pkg/provider/aws/infra_template_test.go
@@ -150,8 +150,8 @@ func Test_GenerateCloudfrontDistributions(t *testing.T) {
 				AppName:  "app",
 				Exposed: map[string]*config.Expose{
 					"gw": {
-						Type:  "apigateway",
-						CdnId: "distro",
+						Type:                   "apigateway",
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: "distro"},
 					},
 				},
 			},
@@ -183,8 +183,8 @@ func Test_GenerateCloudfrontDistributions(t *testing.T) {
 				AppName:  "app",
 				StaticUnit: map[string]*config.StaticUnit{
 					"su": {
-						Type:  "apigateway",
-						CdnId: "distro",
+						Type:                   "apigateway",
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: "distro"},
 					},
 				},
 			},
@@ -217,8 +217,8 @@ func Test_GenerateCloudfrontDistributions(t *testing.T) {
 				AppName:  "app",
 				StaticUnit: map[string]*config.StaticUnit{
 					"su": {
-						Type:  "apigateway",
-						CdnId: "distro",
+						Type:                   "apigateway",
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: "distro"},
 					},
 				},
 			},
@@ -256,14 +256,14 @@ func Test_GenerateCloudfrontDistributions(t *testing.T) {
 				AppName:  "app",
 				StaticUnit: map[string]*config.StaticUnit{
 					"su": {
-						Type:  "apigateway",
-						CdnId: "distro",
+						Type:                   "apigateway",
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: "distro"},
 					},
 				},
 				Exposed: map[string]*config.Expose{
 					"gw": {
-						Type:  "apigateway",
-						CdnId: "distro",
+						Type:                   "apigateway",
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: "distro"},
 					},
 				},
 			},

--- a/pkg/provider/aws/resources/cloudfront.go
+++ b/pkg/provider/aws/resources/cloudfront.go
@@ -1,0 +1,31 @@
+package resources
+
+import (
+	"github.com/klothoplatform/klotho/pkg/core"
+	"go.uber.org/zap"
+)
+
+type CloudfrontDistribution struct {
+	Id                string
+	Origins           []core.ResourceKey
+	DefaultRootObject string
+}
+
+func CreateCloudfrontDistribution(resources []core.CloudResource) *CloudfrontDistribution {
+	distribution := &CloudfrontDistribution{}
+
+	for _, res := range resources {
+		switch res.Key().Kind {
+		case core.GatewayKind:
+			distribution.Origins = append(distribution.Origins, res.Key())
+		case core.StaticUnitKind:
+			sunit := res.(*core.StaticUnit)
+			distribution.Origins = append(distribution.Origins, res.Key())
+			if distribution.DefaultRootObject != "" {
+				zap.S().Warn("Cannot have a cdn with multiple root objects")
+			}
+			distribution.DefaultRootObject = sunit.IndexDocument
+		}
+	}
+	return distribution
+}

--- a/pkg/provider/infra_template.go
+++ b/pkg/provider/infra_template.go
@@ -68,10 +68,10 @@ type (
 	}
 
 	StaticUnit struct {
-		Name          string
-		Type          string
-		IndexDocument string
-		Params        config.InfraParams
+		Name                   string
+		Type                   string
+		IndexDocument          string
+		ContentDeliveryNetwork config.ContentDeliveryNetwork
 	}
 
 	Gateway struct {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #349

adds cdnId to both gateway and static unit config. This allows us to have logic in the compiler to understand when and how many cloudfront distributions we need with respective origins.

Then the remainder of the logic is handled in deploylib for now until we have a better dependency tree for our aws resources.

We conditionally add the files for static website and cloudfront since we know if we are creating any and just pass in cloudlibs object to avoid more stuff being stuck in compiled

### Standard checks

- **Unit tests**: Any special considerations? added some for cloudfront generation
- **Docs**: Do we need to update any docs, internal or public? will update before pushing
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? static units will no longer use pulumi params and must explicitly set the cdnId to be backed by cloudfront. We also no longer create a publicly accessible bucket ever.
