### PR TITLE
make embed assets relative to where annotation lives or abs from proj…

### DIFF
--- a/pkg/exec_unit/plugin_assets.go
+++ b/pkg/exec_unit/plugin_assets.go
@@ -1,6 +1,7 @@
 package execunit
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -44,6 +45,11 @@ func (p Assets) Transform(result *core.CompilationResult, deps *core.Dependencie
 
 			includes, _ := annot.Capability.Directives.StringArray("include")
 			excludes, _ := annot.Capability.Directives.StringArray("exclude")
+
+			if len(includes) == 0 {
+				errs.Append(core.NewCompilerError(astF, annot, errors.New("include directive must contain at least 1 path")))
+				break
+			}
 
 			matcher, err := NewAssetPathMatcher(includes, excludes, f.Path())
 			if err != nil {

--- a/pkg/exec_unit/plugin_assets.go
+++ b/pkg/exec_unit/plugin_assets.go
@@ -93,33 +93,21 @@ func NewAssetPathMatcher(include []string, exclude []string, filePath string) (a
 	matcher := assetPathMatcher{}
 	filePath = filepath.ToSlash(filePath)
 	for _, pattern := range include {
-		newPath, err := modifyPathIfRelative(pattern, filePath)
-		if err != nil {
-			return matcher, err
-		}
-		matcher.include = append(matcher.include, newPath)
+		matcher.include = append(matcher.include, modifyPathIfRelative(pattern, filePath))
 	}
 
 	for _, pattern := range exclude {
-		newPath, err := modifyPathIfRelative(pattern, filePath)
-		if err != nil {
-			return matcher, err
-		}
-		matcher.exclude = append(matcher.exclude, newPath)
+		matcher.exclude = append(matcher.exclude, modifyPathIfRelative(pattern, filePath))
 	}
 	return matcher, nil
 
 }
 
-func modifyPathIfRelative(path string, currentPath string) (string, error) {
+func modifyPathIfRelative(path string, currentPath string) string {
 	if filepath.IsAbs(path) {
-		return strings.TrimPrefix(path, "/"), nil
+		return strings.TrimPrefix(path, "/")
 	}
-	relPath, err := filepath.Rel(filepath.Dir("."), filepath.Join(filepath.Dir(currentPath), path))
-	if err != nil {
-		return "", err
-	}
-	return relPath, nil
+	return filepath.Join(filepath.Dir(currentPath), path)
 }
 
 func (m *assetPathMatcher) Matches(p string) bool {

--- a/pkg/exec_unit/plugin_assets_test.go
+++ b/pkg/exec_unit/plugin_assets_test.go
@@ -1,7 +1,6 @@
 package execunit
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,19 +110,25 @@ func Test_assetPathMatcher_ModifyPathsForAnnotatedFile(t *testing.T) {
 			path:    "dir/file.txt",
 			want:    testResult{include: []string{"dir/file.txt", "dir/other.txt"}, exclude: []string{"dir/notfile.txt", "dir/notother.txt"}},
 		},
+		{
+			name:    "mix relative and absolute match",
+			matcher: assetPathMatcher{include: []string{"/dir/file.txt", "other.txt"}, exclude: []string{"/dir/notfile.txt", "notother.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt", "dir/other.txt"}, exclude: []string{"dir/notfile.txt", "dir/notother.txt"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := tt.matcher.ModifyPathsForAnnotatedFile(tt.path)
+			matcher, err := NewAssetPathMatcher(tt.matcher.include, tt.matcher.exclude, tt.path)
 			if !assert.NoError(err) {
 				return
 			}
 
 			for _, wantPath := range tt.want.include {
 				found := false
-				for _, path := range tt.matcher.include {
+				for _, path := range matcher.include {
 					if wantPath == path {
 						found = true
 					}
@@ -133,11 +138,10 @@ func Test_assetPathMatcher_ModifyPathsForAnnotatedFile(t *testing.T) {
 
 			for _, wantPath := range tt.want.exclude {
 				found := false
-				for _, path := range tt.matcher.exclude {
+				for _, path := range matcher.exclude {
 					if wantPath == path {
 						found = true
 					}
-					fmt.Println(path)
 				}
 				assert.True(found)
 			}

--- a/pkg/exec_unit/plugin_assets_test.go
+++ b/pkg/exec_unit/plugin_assets_test.go
@@ -116,6 +116,12 @@ func Test_assetPathMatcher_ModifyPathsForAnnotatedFile(t *testing.T) {
 			path:    "dir/file.txt",
 			want:    testResult{include: []string{"dir/file.txt", "dir/other.txt"}, exclude: []string{"dir/notfile.txt", "dir/notother.txt"}},
 		},
+		{
+			name:    "mix relative and absolute match",
+			matcher: assetPathMatcher{include: []string{"../otherdir/file.txt", "other.txt"}, exclude: []string{"../otherdir/notfile.txt", "notother.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"otherdir/file.txt", "dir/other.txt"}, exclude: []string{"otherdir/notfile.txt", "dir/notother.txt"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/exec_unit/plugin_assets_test.go
+++ b/pkg/exec_unit/plugin_assets_test.go
@@ -1,6 +1,7 @@
 package execunit
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,81 @@ func Test_assetPathMatcher_Matches(t *testing.T) {
 				return
 			}
 			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+func Test_assetPathMatcher_ModifyPathsForAnnotatedFile(t *testing.T) {
+	type testResult struct {
+		include []string
+		exclude []string
+	}
+	tests := []struct {
+		name    string
+		matcher assetPathMatcher
+		path    string
+		want    testResult
+	}{
+		{
+			name:    "simple relative match",
+			matcher: assetPathMatcher{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+			path:    "file.txt",
+			want:    testResult{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+		},
+		{
+			name:    "nested relative match",
+			matcher: assetPathMatcher{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt"}, exclude: []string{"dir/notfile.txt"}},
+		},
+		{
+			name:    "simple absolute match",
+			matcher: assetPathMatcher{include: []string{"/file.txt"}, exclude: []string{"/notfile.txt"}},
+			path:    "file.txt",
+			want:    testResult{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+		},
+		{
+			name:    "nested absolute match",
+			matcher: assetPathMatcher{include: []string{"/dir/file.txt"}, exclude: []string{"/dir/notfile.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt"}, exclude: []string{"dir/notfile.txt"}},
+		},
+		{
+			name:    "mix relative and absolute match",
+			matcher: assetPathMatcher{include: []string{"/dir/file.txt", "other.txt"}, exclude: []string{"/dir/notfile.txt", "notother.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt", "dir/other.txt"}, exclude: []string{"dir/notfile.txt", "dir/notother.txt"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := tt.matcher.ModifyPathsForAnnotatedFile(tt.path)
+			if !assert.NoError(err) {
+				return
+			}
+
+			for _, wantPath := range tt.want.include {
+				found := false
+				for _, path := range tt.matcher.include {
+					if wantPath == path {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+
+			for _, wantPath := range tt.want.exclude {
+				found := false
+				for _, path := range tt.matcher.exclude {
+					if wantPath == path {
+						found = true
+					}
+					fmt.Println(path)
+				}
+				assert.True(found)
+			}
 		})
 	}
 }


### PR DESCRIPTION
…ect root

• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #578

make embed assets relative to where annotation lives or abs from project root
Added docs in pr linked below

### Standard checks

- **Unit tests**: Any special considerations? added
- **Docs**: Do we need to update any docs, internal or public? https://github.com/klothoplatform/docs/pull/139
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? it should be because previously we would only match paths from the root of the project which we still should.
