### PR TITLE
make fileref use root path and stat unit have same logic as embed

### DIFF
--- a/pkg/core/file_ref.go
+++ b/pkg/core/file_ref.go
@@ -3,11 +3,13 @@ package core
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // FileRef is a lightweight representation of a file, deferring reading its contents until `WriteTo` is called.
 type FileRef struct {
-	FPath string
+	FPath          string
+	RootConfigPath string
 }
 
 func (r *FileRef) Clone() File {
@@ -19,7 +21,7 @@ func (r *FileRef) Path() string {
 }
 
 func (r *FileRef) WriteTo(w io.Writer) (int64, error) {
-	f, err := os.Open(r.FPath)
+	f, err := os.Open(filepath.Join(r.RootConfigPath, r.FPath))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/input/readdir.go
+++ b/pkg/input/readdir.go
@@ -127,7 +127,10 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 			// (so './dist/index.js' becomes 'index.js')
 			relPath = info.Name()
 		}
-		var f core.File = &core.FileRef{FPath: relPath}
+		var f core.File = &core.FileRef{
+			FPath:          relPath,
+			RootConfigPath: cfg.Path,
+		}
 
 		if info.IsDir() {
 			switch info.Name() {

--- a/pkg/static_unit/plugin_static_unit.go
+++ b/pkg/static_unit/plugin_static_unit.go
@@ -105,6 +105,8 @@ type staticAssetPathMatcher struct {
 	err         error
 }
 
+// ModifyPathsForAnnotatedFile transforms the staticAssetPathMatcher sharedFiles and staticFiles to be absolute paths from the klotho project root, without the prefix '/'.
+// This is done to conform to the file path structure of input files.
 func (m *staticAssetPathMatcher) ModifyPathsForAnnotatedFile(path string) error {
 	newInclude := []string{}
 	for _, pattern := range m.staticFiles {

--- a/pkg/static_unit/plugin_static_unit_test.go
+++ b/pkg/static_unit/plugin_static_unit_test.go
@@ -83,3 +83,77 @@ func Test_assetPathMatcher_Matches(t *testing.T) {
 		})
 	}
 }
+
+func Test_assetPathMatcher_ModifyPathsForAnnotatedFile(t *testing.T) {
+	type testResult struct {
+		include []string
+		exclude []string
+	}
+	tests := []struct {
+		name    string
+		matcher staticAssetPathMatcher
+		path    string
+		want    testResult
+	}{
+		{
+			name:    "simple relative match",
+			matcher: staticAssetPathMatcher{staticFiles: []string{"file.txt"}, sharedFiles: []string{"notfile.txt"}},
+			path:    "file.txt",
+			want:    testResult{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+		},
+		{
+			name:    "nested relative match",
+			matcher: staticAssetPathMatcher{staticFiles: []string{"file.txt"}, sharedFiles: []string{"notfile.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt"}, exclude: []string{"dir/notfile.txt"}},
+		},
+		{
+			name:    "simple absolute match",
+			matcher: staticAssetPathMatcher{staticFiles: []string{"/file.txt"}, sharedFiles: []string{"/notfile.txt"}},
+			path:    "file.txt",
+			want:    testResult{include: []string{"file.txt"}, exclude: []string{"notfile.txt"}},
+		},
+		{
+			name:    "nested absolute match",
+			matcher: staticAssetPathMatcher{staticFiles: []string{"/dir/file.txt"}, sharedFiles: []string{"/dir/notfile.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt"}, exclude: []string{"dir/notfile.txt"}},
+		},
+		{
+			name:    "mix relative and absolute match",
+			matcher: staticAssetPathMatcher{staticFiles: []string{"/dir/file.txt", "other.txt"}, sharedFiles: []string{"/dir/notfile.txt", "notother.txt"}},
+			path:    "dir/file.txt",
+			want:    testResult{include: []string{"dir/file.txt", "dir/other.txt"}, exclude: []string{"dir/notfile.txt", "dir/notother.txt"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := tt.matcher.ModifyPathsForAnnotatedFile(tt.path)
+			if !assert.NoError(err) {
+				return
+			}
+
+			for _, wantPath := range tt.want.include {
+				found := false
+				for _, path := range tt.matcher.staticFiles {
+					if wantPath == path {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+
+			for _, wantPath := range tt.want.exclude {
+				found := false
+				for _, path := range tt.matcher.sharedFiles {
+					if wantPath == path {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+		})
+	}
+}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

Since file ref needs to read the actual code from the file we need to supply it with the path from our config to join to the file path.

Also changing static unit to match files based on relative path and absolute path to close #33 

This is all work for the search the deck changes

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
