### PR TITLE
[Go] Update expose to allow mounting routes from imported packages

### DIFF
--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -245,14 +245,17 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 
 		routerMounts := h.findChiRouterMounts(f, routerName)
 		for _, m := range routerMounts {
-			h.findChiRouterMountPackage(f, &m)
+			err := h.findChiRouterMountPackage(f, &m)
+			if err != nil {
+				return nil, core.NewCompilerError(f, capNode, err)
+			}
 			filesForPackage := h.findFilesForPackageName(m.PkgName)
 			if len(filesForPackage) == 0 {
-				continue
+				return nil, core.NewCompilerError(f, capNode, errors.Errorf("No files found for package [%s]", m.PkgName))
 			}
 			file, funcNode := h.findFileForFunctionName(filesForPackage, m.FuncName)
 			if file == nil {
-				continue
+				return nil, core.NewCompilerError(f, capNode, errors.Errorf("No file found with function named [%s]", m.FuncName))
 			}
 			mountedRoutes := h.findChiRoutesInFunction(file, funcNode, m)
 			if len(mountedRoutes) > 0 {

--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -399,7 +399,7 @@ func (h *restAPIHandler) FindImports(f *core.SourceFile) (*sitter.Node, error) {
 func (h *restAPIHandler) findChiRouterMounts(f *core.SourceFile, routerName string) []routerMount {
 	source := f.Program()
 	nextMatch := doQuery(f.Tree().RootNode(), findRouterMounts)
-	var mounts []routerMount
+	var mounts = make([]routerMount, 0)
 
 	for {
 		match, found := nextMatch()
@@ -507,7 +507,7 @@ func (h *restAPIHandler) findChiRoutesInFunction(f *core.SourceFile, funcNode *s
 	log := h.log.With(logging.FileField(f))
 
 	// This is very similar in logic to how we find the local router and verbs. The difference is for external routers, we are starting from
-	// the node of the specified function and don't care about what the router name is so long as the router methods are declared in this function node
+	// the node of the specified function and don't care about what the router name is so long as the router methods are declared within this function node
 	nextMatch := doQuery(funcNode, findExposeVerb)
 	var routes []routeMethodPath
 	for {

--- a/pkg/lang/golang/plugin_expose_test.go
+++ b/pkg/lang/golang/plugin_expose_test.go
@@ -1,6 +1,7 @@
 package golang
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -138,6 +139,320 @@ func Test_findImports(t *testing.T) {
 			importsNode, _ := testRestAPIHandler.FindImports(f)
 
 			assert.NotNil(importsNode)
+		})
+	}
+}
+
+func Test_findChiRouterMounts(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		routerName string
+		want       []routerMount
+	}{
+		{
+			name:       "Basic single mount",
+			source:     `r.Mount("/test", routes.TestRoutes())`,
+			routerName: "r",
+			want: []routerMount{
+				{
+					Path:     "/test",
+					FuncName: "TestRoutes",
+					PkgAlias: "routes",
+				},
+			},
+		},
+		{
+			name:       "Incorrect router name",
+			source:     `wrong.Mount("/test", routes.TestRoutes())`,
+			routerName: "r",
+			want:       []routerMount{},
+		},
+		{
+			name: "Multiple router mount",
+			source: `
+			r.Mount("/test", routes.TestRoutes())
+			r.Mount("/test2", routes.TestRoutes2())
+			`,
+			routerName: "r",
+			want: []routerMount{
+				{
+					Path:     "/test",
+					FuncName: "TestRoutes",
+					PkgAlias: "routes",
+				},
+				{
+					Path:     "/test2",
+					FuncName: "TestRoutes2",
+					PkgAlias: "routes",
+				},
+			},
+		},
+		{
+			name: "Multiple router wrong router mount",
+			source: `
+			r.Mount("/test", routes.TestRoutes())
+			wrong.Mount("/test2", routes.TestRoutes2())
+			`,
+			routerName: "r",
+			want: []routerMount{
+				{
+					Path:     "/test",
+					FuncName: "TestRoutes",
+					PkgAlias: "routes",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			f, err := core.NewSourceFile("", strings.NewReader(tt.source), language)
+			if !assert.NoError(err) {
+				return
+			}
+			mounts := testRestAPIHandler.findChiRouterMounts(f, tt.routerName)
+
+			assert.Equal(tt.want, mounts)
+		})
+	}
+}
+
+func Test_findChiRouterMountPackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		mount   routerMount
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Block import no alias",
+			source: `
+			import (
+				"fmt"
+				"net/http"
+			
+				"github.com/go-chi/chi/v5"
+				"github.com/go-chi/chi/v5/middleware"
+				"github.com/klothoplatform/demo-app/pkg/routes"
+			)`,
+			mount: routerMount{PkgAlias: "routes"},
+			want:  "routes",
+		},
+		{
+			name: "Block import with matching alias",
+			source: `
+			import (
+				"fmt"
+				"net/http"
+			
+				"github.com/go-chi/chi/v5"
+				"github.com/go-chi/chi/v5/middleware"
+				routes "github.com/klothoplatform/demo-app/pkg/routes"
+			)`,
+			mount: routerMount{PkgAlias: "routes"},
+			want:  "routes",
+		},
+		{
+			name: "Block import with non matching alias",
+			source: `
+			import (
+				"fmt"
+				"net/http"
+			
+				"github.com/go-chi/chi/v5"
+				"github.com/go-chi/chi/v5/middleware"
+				test "github.com/klothoplatform/demo-app/pkg/routes"
+			)`,
+			mount: routerMount{PkgAlias: "test"},
+			want:  "routes",
+		},
+		{
+			name: "Block import missing import",
+			source: `
+			import (
+				"fmt"
+				"net/http"
+			)`,
+			mount:   routerMount{PkgAlias: "routes"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Block import with non multi alias",
+			source: `
+			import (
+				"fmt"
+				"net/http"
+			
+				chi "github.com/go-chi/chi/v5"
+				middleware "github.com/go-chi/chi/v5/middleware"
+				test "github.com/klothoplatform/demo-app/pkg/routes"
+			)`,
+			mount: routerMount{PkgAlias: "test"},
+			want:  "routes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			f, err := core.NewSourceFile("", strings.NewReader(tt.source), language)
+			if !assert.NoError(err) {
+				return
+			}
+			err = testRestAPIHandler.findChiRouterMountPackage(f, &tt.mount)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+
+			assert.Equal(tt.want, tt.mount.PkgName)
+		})
+	}
+}
+
+func Test_findFilesForPackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources map[string]string
+		pkgName string
+		want    []string
+	}{
+		{
+			name: "Single file correct package",
+			sources: map[string]string{
+				"file1.go": `package test`,
+			},
+			pkgName: "test",
+			want:    []string{"file1.go"},
+		},
+		{
+			name: "Multiple files correct package",
+			sources: map[string]string{
+				"file1.go": `package test`,
+				"file2.go": `package test`,
+				"file3.go": `package test`,
+			},
+			pkgName: "test",
+			want:    []string{"file1.go", "file2.go", "file3.go"},
+		},
+		{
+			name: "Mutliple files with different packages",
+			sources: map[string]string{
+				"file1.go": `package test`,
+				"file2.go": `package wrong`,
+				"file3.go": `package wrong2`,
+			},
+			pkgName: "test",
+			want:    []string{"file1.go"},
+		},
+		{
+			name: "No files with correct packages",
+			sources: map[string]string{
+				"file1.go": `package wrong`,
+				"file2.go": `package wrong`,
+				"file3.go": `package wrong`,
+			},
+			pkgName: "test",
+			want:    []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			restAPIHandler := &restAPIHandler{
+				log:  zap.L(),
+				Unit: &core.ExecutionUnit{Name: "testUnit", Executable: core.NewExecutable()},
+			}
+
+			for path, src := range tt.sources {
+				f, err := core.NewSourceFile(path, strings.NewReader(src), language)
+				if !assert.NoError(err) {
+					return
+				}
+				restAPIHandler.Unit.AddSourceFile(f)
+			}
+
+			foundFiles := restAPIHandler.findFilesForPackageName(tt.pkgName)
+			var filePaths = make([]string, 0)
+			for _, f := range foundFiles {
+				filePaths = append(filePaths, f.Path())
+			}
+			sort.Strings(filePaths)
+			assert.Equal(tt.want, filePaths)
+		})
+	}
+}
+
+func Test_findFilesForFunctionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		sources  map[string]string
+		funcName string
+		wantErr  bool
+	}{
+		{
+			name: "One file with function",
+			sources: map[string]string{
+				"file1.go": `func TestRoutes() chi.Router {}`,
+			},
+			funcName: "TestRoutes",
+		},
+		{
+			name: "One file with multiple functions",
+			sources: map[string]string{
+				"file1.go": `
+				func TestRoutes() chi.Router {}
+				func WrongRoutes() chi.Router {}
+				func MoreWrongRoutes() chi.Router {}`,
+			},
+			funcName: "TestRoutes",
+		},
+		{
+			name: "Multiple files",
+			sources: map[string]string{
+				"file1.go": `func WrongRoutes() chi.Router {}`,
+				"file2.go": `func MoreWrongRoutes() chi.Router {}`,
+				"file3.go": `func TestRoutes() chi.Router {}`,
+			},
+			funcName: "TestRoutes",
+		},
+		{
+			name: "Multiple files no matching function",
+			sources: map[string]string{
+				"file1.go": `func WrongRoutes() chi.Router {}`,
+				"file2.go": `func MoreWrongRoutes() chi.Router {}`,
+				"file3.go": `func EvenMoreWrongRoutes() chi.Router {}`,
+			},
+			funcName: "TestRoutes",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			var files = make([]*core.SourceFile, 0)
+			for path, src := range tt.sources {
+				f, err := core.NewSourceFile(path, strings.NewReader(src), language)
+				if !assert.NoError(err) {
+					return
+				}
+				files = append(files, f)
+			}
+
+			file, node := testRestAPIHandler.findFileForFunctionName(files, tt.funcName)
+			if tt.wantErr {
+				assert.Nil(file)
+				assert.Nil(node)
+				return
+			}
+			assert.NotNil(file)
+			assert.NotNil(node)
 		})
 	}
 }

--- a/pkg/lang/golang/queries.go
+++ b/pkg/lang/golang/queries.go
@@ -15,3 +15,15 @@ var findExposeVerb string
 
 //go:embed queries/expose/imports.scm
 var findImports string
+
+//go:embed queries/expose/router_mounts.scm
+var findRouterMounts string
+
+//go:embed queries/expose/router_mount_function.scm
+var findMountFunctionByNameAndPackage string
+
+//go:embed queries/expose/function.scm
+var findFunction string
+
+//go:embed queries/expose/package.scm
+var findPackage string

--- a/pkg/lang/golang/queries.go
+++ b/pkg/lang/golang/queries.go
@@ -19,9 +19,6 @@ var findImports string
 //go:embed queries/expose/router_mounts.scm
 var findRouterMounts string
 
-//go:embed queries/expose/router_mount_function.scm
-var findMountFunctionByNameAndPackage string
-
 //go:embed queries/expose/function.scm
 var findFunction string
 

--- a/pkg/lang/golang/queries/expose/function.scm
+++ b/pkg/lang/golang/queries/expose/function.scm
@@ -1,0 +1,3 @@
+(function_declaration
+	(identifier)@function_name
+)@function

--- a/pkg/lang/golang/queries/expose/imports.scm
+++ b/pkg/lang/golang/queries/expose/imports.scm
@@ -1,3 +1,12 @@
 (import_declaration
-	(import_spec_list)@importList
+	(import_spec_list
+   		[(import_spec
+        	(package_identifier)@package_id
+			(interpreted_string_literal)@package_path
+		)
+        (import_spec
+			(interpreted_string_literal)@package_path
+		)
+		]
+    )@importList
 )@expression

--- a/pkg/lang/golang/queries/expose/package.scm
+++ b/pkg/lang/golang/queries/expose/package.scm
@@ -1,0 +1,3 @@
+(package_clause
+	(package_identifier)@package_name
+)

--- a/pkg/lang/golang/queries/expose/router_mounts.scm
+++ b/pkg/lang/golang/queries/expose/router_mounts.scm
@@ -1,0 +1,15 @@
+(call_expression
+	(selector_expression
+		(identifier)@router_name
+        (field_identifier)@mount
+	)
+    (argument_list
+    	(interpreted_string_literal)@path
+        (call_expression
+        	(selector_expression
+            	(identifier)@package_name
+                (field_identifier)@package_func
+            )
+		)
+    )
+)@call_expression


### PR DESCRIPTION
Adds support for `router.Mount()` which allows you to import routers from other packages within your application. 
```
r.Get("/", func(w http.ResponseWriter, r *http.Request) {
	w.Write([]byte("Hello from Klotho!"))
})

r.Mount("/extra", routes.ExtraRoutes())
```

Updated Docs PR: https://github.com/klothoplatform/docs/pull/135
Updated Sample App PR: https://github.com/klothoplatform/GoSampleApps/pull/1/files

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
