### PR TITLE
fail if an error log has occured

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -47,10 +47,11 @@ var cfg struct {
 }
 
 var hadWarnings = atomic.NewBool(false)
+var hadErrors = atomic.NewBool(false)
 
 func init() {
 	err := zap.RegisterEncoder("klotho-cli", func(zcfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
-		return logging.NewConsoleEncoder(cfg.verbose, hadWarnings), nil
+		return logging.NewConsoleEncoder(cfg.verbose, hadWarnings, hadErrors), nil
 	})
 
 	if err != nil {
@@ -264,7 +265,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	analyticsClient.Info("klotho compiling")
 
 	result, err := compiler.Compile(input)
-	if err != nil {
+	if err != nil || hadErrors.Load() {
 		errHandler.PrintErr(err)
 		analyticsClient.Error("klotho compiling failed")
 

--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -84,11 +84,7 @@ func main() {
 
 	err := root.Execute()
 	if err != nil {
-		if cfg.internalDebug {
-			zap.S().Errorf("%+v", err)
-		} else if !root.SilenceErrors {
-			zap.S().Errorf("%v", err)
-		}
+		zap.S().Error("Klotho compilation failed")
 		os.Exit(1)
 	}
 	if hadWarnings.Load() && cfg.strict {
@@ -266,12 +262,14 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	result, err := compiler.Compile(input)
 	if err != nil || hadErrors.Load() {
-		errHandler.PrintErr(err)
+		if err != nil {
+			errHandler.PrintErr(err)
+		}
 		analyticsClient.Error("klotho compiling failed")
 
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
-		return err
+		return errors.New("Failed run of klotho invocation")
 	}
 
 	if cfg.uploadSource {

--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -87,6 +87,8 @@ func main() {
 	if err != nil {
 		if cfg.internalDebug {
 			zap.S().Errorf("%+v", err)
+		} else if !root.SilenceErrors {
+			zap.S().Errorf("%v", err)
 		}
 		zap.S().Error("Klotho compilation failed")
 		os.Exit(1)

--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -51,14 +51,16 @@ type ConsoleEncoder struct {
 	Annotation  annotationField
 	Node        astNodeField
 	HadWarnings *atomic.Bool
+	HadErrors   *atomic.Bool
 
 	*bufferEncoder
 }
 
-func NewConsoleEncoder(verbose bool, hadWarnings *atomic.Bool) *ConsoleEncoder {
+func NewConsoleEncoder(verbose bool, hadWarnings *atomic.Bool, hadErrors *atomic.Bool) *ConsoleEncoder {
 	return &ConsoleEncoder{
 		Verbose:       verbose,
 		HadWarnings:   hadWarnings,
+		HadErrors:     hadErrors,
 		bufferEncoder: &bufferEncoder{b: pool.Get()},
 	}
 }
@@ -68,9 +70,9 @@ func (enc *ConsoleEncoder) Clone() zapcore.Encoder {
 		bufferEncoder: &bufferEncoder{b: pool.Get()},
 		Verbose:       enc.Verbose,
 		HadWarnings:   enc.HadWarnings,
-
-		File:       enc.File,
-		Annotation: enc.Annotation,
+		HadErrors:     enc.HadErrors,
+		File:          enc.File,
+		Annotation:    enc.Annotation,
 	}
 	_, _ = ne.bufferEncoder.b.Write(enc.b.Bytes())
 
@@ -109,6 +111,9 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 
 	if ent.Level >= zapcore.WarnLevel {
 		enc.HadWarnings.Store(true)
+	}
+	if ent.Level >= zapcore.ErrorLevel {
+		enc.HadErrors.Store(true)
 	}
 
 	var (


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #297

making compilation fail if an error is logged. Making consistent message at the end of the failure as well

case for logging an error

```
jordansinger@Jordans-MacBook-Pro ts-ms-lambda % klotho . --app ondemandddb -p aws -c test/klotho.yaml
██╗  ██╗██╗      ██████╗ ████████╗██╗  ██╗ ██████╗
██║ ██╔╝██║     ██╔═══██╗╚══██╔══╝██║  ██║██╔═══██╗
█████╔╝ ██║     ██║   ██║   ██║   ███████║██║   ██║
██╔═██╗ ██║     ██║   ██║   ██║   ██╔══██║██║   ██║
██║  ██╗███████╗╚██████╔╝   ██║   ██║  ██║╚██████╔╝
╚═╝  ╚═╝╚══════╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝

new update is available, please run klotho --update to get the latest version
Adding resource exec_unit:main
This is a test
| @klotho::persist {
|      id = 'users'
| }
| in users.js
| 8| const users = new Map();

This is a test
| @klotho::expose {
|      id = 'app'
|      target = 'public'
| }
| in index.js
| 36| app.listen(3000, async () => {
| 37|     console.log(`App listening at :3000`);
| 38| });

Found 2 route(s) for middleware 'router'                                                                                                                                                                                      unit: main
Adding resource gateway:app
Adding resource persist_kv:users
Adding resource topology:ondemandddb
Adding resource aws_template_data:ondemandddb
Adding resource infra_as_code:Pulumi (AWS)
Klotho compilation failed
```

case for an error being returned
```
jordansinger@Jordans-MacBook-Pro ts-ms-lambda % klotho . --app ondemandddb -p aws -c test/klotho.yaml
██╗  ██╗██╗      ██████╗ ████████╗██╗  ██╗ ██████╗
██║ ██╔╝██║     ██╔═══██╗╚══██╔══╝██║  ██║██╔═══██╗
█████╔╝ ██║     ██║   ██║   ██║   ███████║██║   ██║
██╔═██╗ ██║     ██║   ██║   ██║   ██╔══██║██║   ██║
██║  ██╗███████╗╚██████╔╝   ██║   ██║  ██║╚██████╔╝
╚═╝  ╚═╝╚══════╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝

new update is available, please run klotho --update to get the latest version
Adding resource exec_unit:main
Found 2 route(s) for middleware 'router'                                                                                                                                                                                      unit: main
Adding resource gateway:app
[err 0] error in plugin javascript/Express: error in plugin javascript/Express: 2 errors occurred:
	* This is also a test
	* This is also a test
Klotho compilation failed
```

### Standard checks

- **Unit tests**: Any special considerations? nope
- **Docs**: Do we need to update any docs, internal or public? nope
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? im not sure if we even log errors anywhere but if we do and people are deploying anyways, they wouldnt be able to now
