### PR TITLE
move most of integtest into a callable workflow

### DIFF
--- a/.github/workflows/nightly-integ-tests.yaml
+++ b/.github/workflows/nightly-integ-tests.yaml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    # 7am Mon - Fri, UTC: https://crontab.guru/#0_7_*_*_1-5
+    # This corresponds to 2-3am us/eastern (depending on daylight savings), or 11pm - midnight pacific
+    - cron: '0 7 * * 1-5'
+name: integration tests
+concurrency: integ-tests
+jobs:
+  javascript:
+    uses: ./.github/workflows/run-integ-tests.yaml
+    with:
+      test-app-repo: klothoplatform/sample-apps
+      klotho-login: klotho-engineering@klo.dev
+    secrets: inherit

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -1,26 +1,64 @@
 on:
-  schedule:
-    # 7am Mon - Fri, UTC: https://crontab.guru/#0_7_*_*_1-5
-    # This corresponds to 2-3am us/eastern (depending on daylight savings), or 11pm - midnight pacific
-    - cron: '0 7 * * 1-5'
   workflow_dispatch:
     inputs:
-      sample-apps-git-ref:
-        description: Git SHA or branch name of the sample-apps repo
+      test-app-repo:
+        description: The repo of the app to test, in Organization/Repo format
+        required: true
+        type: string
+      test-app-ref:
+        description: Git SHA or branch name of test-app-repo
         required: false
         type: string
-      sample-app-names:
-        description: Comma-delimited list of apps within the sample-apps repo
+        default: main
+      test-app-overrides:
+        description: comma-delimited list of dirs within test-app-repo
         required: false
         type: string
-concurrency:
-  group: integ-tests
+      klotho-login:
+        description: email address to log into Klotho
+        required: true
+        type: string
+      region:
+        description: the AWS region to deploy to
+        required: false
+        type: string
+        default: us-east-1
+      klotho-repo:
+        description: org/repo of the Klotho source
+        required: false
+        type: string
+  workflow_call:
+    # same inputs as workflow_dispatch
+    inputs:
+      test-app-repo:
+        description: The repo of the app to test, in Organization/Repo format
+        required: true
+        type: string
+      test-app-ref:
+        description: Git SHA or branch name of test-app-repo
+        required: false
+        type: string
+        default: main
+      test-app-overrides:
+        description: comma-delimited list of dirs within test-app-repo
+        required: false
+        type: string
+      klotho-login:
+        description: email address to log into Klotho
+        required: true
+        type: string
+      region:
+        description: the AWS region to deploy to
+        required: false
+        type: string
+        default: us-east-1
+      klotho-repo:
+        description: org/repo of the Klotho source
+        required: false
+        type: string
 env:
-  SAMPLE_APPS_GIT_REF: main
-  KLOTHO_LOGIN: klotho-engineering@klo.dev
-  AWS_REGION: us-east-1
   INTEG_TEST_ATTEMPTS: 3 # how many times we'll try to run "npm run integ-test" before we mark it as failed. See klothoplatform/sample-apps#44
-name: integration tests
+name: run integration tests
 jobs:
   list-apps:
     runs-on: ubuntu-latest
@@ -29,11 +67,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: KlothoPlatform/sample-apps
-          ref: ${{ inputs.sample-apps-git-ref || env.SAMPLE_APPS_GIT_REF }}
+          repository: ${{ inputs.test-app-repo }}
+          ref: ${{ inputs.test-app-ref }}
       - name: find test dirs
         id: find_dirs
         run: |
+          set -x
           dirs_with_tests="$(
             for d in $(find * -type d -maxdepth 0 || printf ''); do
               jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d"
@@ -54,12 +93,14 @@ jobs:
           echo "$test_cases" | jq .
           echo "to_test=$test_cases" > $GITHUB_OUTPUT
         env:
-          APP_NAME_OVERRIDES: ${{ inputs.sample-app-names }}
+          APP_NAME_OVERRIDES: ${{ inputs.test-app-overrides }}
   build-klotho:
     runs-on: ubuntu-latest
     steps:
       - name: checkout klotho
         uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.klotho-repo }}
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
@@ -90,8 +131,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: KlothoPlatform/sample-apps
-          ref: ${{ inputs.sample-apps-git-ref || env.SAMPLE_APPS_GIT_REF }}
+          repository: ${{ inputs.test-app-repo }}
+          ref: ${{ inputs.test-app-ref }}
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -109,6 +150,8 @@ jobs:
           curl -fsSL http://srv.klo.dev/update/latest/linux/amd64 -o "$RUNNER_TEMP/klotho-old"
           chmod +x "$RUNNER_TEMP/klotho-old"
           "$RUNNER_TEMP/klotho-old" --login "$KLOTHO_LOGIN"
+        env:
+          KLOTHO_LOGIN: ${{ inputs.klotho-login }}
       - name: download klotho
         uses: actions/download-artifact@v3
         with:
@@ -125,6 +168,8 @@ jobs:
         run: |
           chmod +x $RUNNER_TEMP/klotho
           klotho --login $KLOTHO_LOGIN
+        env:
+          KLOTHO_LOGIN: ${{ inputs.klotho-login }}
       - name: typescript compilation
         working-directory: ${{ matrix.app_to_test }}
         run: |
@@ -171,6 +216,7 @@ jobs:
           fi
           echo '::endgroup'
         env:
+          AWS_REGION: ${{ inputs.region }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -188,7 +234,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
       - name: pulumi up (upgrade path)
         if: matrix.mode == 'upgrade'
-        uses: klothoplatform/gh-action-retry@v1
+        uses: CloudCompilers/gh-action-retry@v1
         with:
           description: pulumi up (upgrade path)
           working-directory: ${{ matrix.app_to_test }}
@@ -233,7 +279,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_CONFIG_PASSPHRASE: ""
       - name: pulumi up
-        uses: klothoplatform/gh-action-retry@v1
+        uses: CloudCompilers/gh-action-retry@v1
         with:
           description: pulumi up
           working-directory: ${{ matrix.app_to_test }}
@@ -266,7 +312,7 @@ jobs:
             ts-eks
         working-directory: ${{ matrix.app_to_test }}
       - name: run integ tests
-        uses: klothoplatform/gh-action-retry@v1
+        uses: CloudCompilers/gh-action-retry@v1
         with:
           description: npm run integ-test
           working-directory: ${{ matrix.app_to_test }}
@@ -305,7 +351,7 @@ jobs:
           path: ${{ runner.temp }}/cw-logs/
       - name: pulumi destroy
         if: always()
-        uses: klothoplatform/gh-action-retry@v1
+        uses: CloudCompilers/gh-action-retry@v1
         with:
           description: pulumi destroy
           working-directory: ${{ matrix.app_to_test }}

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -125,13 +125,13 @@ jobs:
         app_to_test: ${{ fromJson(needs.list-apps.outputs.to_test) }}
         mode: [fresh, upgrade]
         exclude:
-          - # issue #618
+          - # issue #48
             app_to_test: ts-eks
             mode: upgrade
-          - # issue 259
+          - # issue #49
             app_to_test: ts-eks-helm
             mode: upgrade
-          - # issue 259
+          - # issue #49
             app_to_test: ts-eks-helm
             mode: fresh
     steps:
@@ -240,7 +240,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
       - name: pulumi up (upgrade path)
         if: matrix.mode == 'upgrade'
-        uses: CloudCompilers/gh-action-retry@v1
+        uses: klothoplatform/gh-action-retry@v1
         with:
           description: pulumi up (upgrade path)
           working-directory: ${{ matrix.app_to_test }}
@@ -285,7 +285,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           PULUMI_CONFIG_PASSPHRASE: ""
       - name: pulumi up
-        uses: CloudCompilers/gh-action-retry@v1
+        uses: klothoplatform/gh-action-retry@v1
         with:
           description: pulumi up
           working-directory: ${{ matrix.app_to_test }}
@@ -318,7 +318,7 @@ jobs:
             ts-eks
         working-directory: ${{ matrix.app_to_test }}
       - name: run integ tests
-        uses: CloudCompilers/gh-action-retry@v1
+        uses: klothoplatform/gh-action-retry@v1
         with:
           description: npm run integ-test
           working-directory: ${{ matrix.app_to_test }}
@@ -357,7 +357,7 @@ jobs:
           path: ${{ runner.temp }}/cw-logs/
       - name: pulumi destroy
         if: always()
-        uses: CloudCompilers/gh-action-retry@v1
+        uses: klothoplatform/gh-action-retry@v1
         with:
           description: pulumi destroy
           working-directory: ${{ matrix.app_to_test }}

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -125,9 +125,15 @@ jobs:
         app_to_test: ${{ fromJson(needs.list-apps.outputs.to_test) }}
         mode: [fresh, upgrade]
         exclude:
-          - # issue $618
+          - # issue #618
             app_to_test: ts-eks
             mode: upgrade
+          - # issue 259
+            app_to_test: ts-eks-helm
+            mode: upgrade
+          - # issue 259
+            app_to_test: ts-eks-helm
+            mode: fresh
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![formatting badge](https://github.com/klothoplatform/klotho/actions/workflows/prettier.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/prettier.yaml)
 [![linter badge](https://github.com/klothoplatform/klotho/actions/workflows/lint.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/lint.yaml)
 [![staticcheck badge](https://github.com/klothoplatform/klotho/actions/workflows/staticcheck.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/staticcheck.yaml)
-[![integ tests badge](https://github.com/klothoplatform/klotho/actions/workflows/integtest.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/integtest.yaml)
+[![integ tests badge](https://github.com/klothoplatform/klotho/actions/workflows/nightly-integ-tests.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/nightly-integ-tests.yaml)
 [![release badge](https://github.com/klothoplatform/klotho/actions/workflows/release.yaml/badge.svg)](https://github.com/klothoplatform/klotho/actions/workflows/release.yaml)
 
 Klotho is an open source tool that transforms plain code into cloud native code.


### PR DESCRIPTION
Rather than integtest.yaml containing all of the integ test logic, it now just invokes a new workflow, which contains all of its old logic. This makes it possible to invoke the tests from other repos.

It seems silly to create a workflow that does nothing but call another workflow, but I _think_ that's necessary because during a cron-triggered run, the `inputs.*` object is empty (not populated with the default values).

It's also silly and a bit brittle to have the workflow_dispatch and workflow_call sections duplicate the same inputs, but unfortunately that seems to be what GH Actions require.

As part of this, rename integtest.yaml to nightly-integ-tests.yaml. This will kill the existing workflow history, but there's not much of it right now anyway.

<!-- Describe the PR. 
• Does any part of it require special attention?
• Does it relate to or fix any issue?
-->

### Standard checks

- **Unit tests**: n/a
- **Docs**: none needed
- **Backwards compatibility**: will reset the GH action history ([link](https://github.com/klothoplatform/klotho/actions/workflows/integtest.yaml)), but otherwise no issues
