### PR TITLE
add workflow_dispatch to nightly integ tests

### DIFF
--- a/.github/workflows/nightly-integ-tests.yaml
+++ b/.github/workflows/nightly-integ-tests.yaml
@@ -3,6 +3,7 @@ on:
     # 7am Mon - Fri, UTC: https://crontab.guru/#0_7_*_*_1-5
     # This corresponds to 2-3am us/eastern (depending on daylight savings), or 11pm - midnight pacific
     - cron: '0 7 * * 1-5'
+  workflow_dispatch: null
 name: integration tests
 concurrency: integ-tests
 jobs:


### PR DESCRIPTION
This lets us manually trigger them, if we want a run earlier than nightly. Sorry for the double-PR (with #45), I forgot this use case. :-)

### Standard checks

- **Unit tests**: n/a
- **Docs**: no issues
- **Backwards compatibility**: no issues
