### PR TITLE
add CODEOWNERS to GH Actions

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+*.yaml @klothoplatform/engineers
+*.yml  @klothoplatform/engineers


### PR DESCRIPTION
This means that if anybody other than the @klothoplatform/engineers team puts up a PR, a member of that team needs to authorize that PR's actions to run.

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

### Standard checks

- **Unit tests**: none
- **Docs**: we don't have a contribution guide; when we do, we may want to note this there
- **Backwards compatibility**: no issues
