### PR TITLE
rm CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,2 +1,0 @@
-*.yaml @klothoplatform/engineers
-*.yml  @klothoplatform/engineers


### PR DESCRIPTION
Turns out we don't need it, after all.

### Standard checks

- **Unit tests**: n/a
- **Docs**: no issues
- **Backwards compatibility**: no issues
