### PR TITLE
Adds accountId + appName prefix to static unit buckets

### DIFF
--- a/pkg/infra/pulumi_aws/iac/static_s3_website.ts
+++ b/pkg/infra/pulumi_aws/iac/static_s3_website.ts
@@ -9,21 +9,24 @@ export const createStaticS3Website = (
     staticUnit: string,
     indexDocument: string,
     contentDeliveryNetworkId: string,
-    lib: CloudCCLib
+    lib: CloudCCLib,
+    appName: string
 ) => {
     // Create an S3 bucket
 
-    const bucketArgs: aws.s3.BucketArgs = {}
-
-    if (indexDocument != '' && contentDeliveryNetworkId == '') {
-        bucketArgs['website'] = {
-            indexDocument: indexDocument,
+    lib.account.accountId.apply((accountId) => {
+        const bucket = `${accountId}-${appName}-${staticUnit}`
+        const bucketArgs: aws.s3.BucketArgs = { bucket }
+        if (indexDocument != '' && contentDeliveryNetworkId == '') {
+            bucketArgs['website'] = {
+                indexDocument: indexDocument,
+            }
         }
-    }
 
-    let siteBucket = new aws.s3.Bucket(`static-website-${staticUnit}`, bucketArgs)
-    lib.siteBuckets.set(staticUnit, siteBucket)
-    createAllObjects(staticUnit, siteBucket)
+        let siteBucket = new aws.s3.Bucket(bucket, bucketArgs)
+        lib.siteBuckets.set(staticUnit, siteBucket)
+        createAllObjects(staticUnit, siteBucket)
+    })
 }
 
 const createAllObjects = (staticUnit, siteBucket, prefixPath = '') => {

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -143,7 +143,7 @@ export = async () => {
 
     {{range $unit := .StaticUnits}}
     staticUnitUrls.push(createStaticS3Website(
-    "{{$unit.Name}}", "{{$unit.IndexDocument}}", "{{$unit.ContentDeliveryNetwork.Id}}", cloudLib
+    "{{$unit.Name}}", "{{$unit.IndexDocument}}", "{{$unit.ContentDeliveryNetwork.Id}}", cloudLib, appName
     ))
     {{end}}
 


### PR DESCRIPTION
This PR resolves #54 by replacing the `static-website` prefix with an `<accountId>-<appName>-` prefix to the buckets create for static units. Logic for shortening bucket names that are too long will be part of #18.
  
### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? will cause buckets created previously by static unit to be replaced
