### PR TITLE
allow null to be value and set as empty array

### DIFF
--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -53,7 +53,7 @@ export interface EksExecUnit {
 export interface HelmChart {
     Name: string
     Directory: string
-    Values: Value[]
+    Values: Value[] | null
 }
 
 interface FargateProfileSelector {
@@ -385,7 +385,7 @@ export class Eks {
             this.setupExecUnit(lib, unit)
         }
         for (const chart of charts) {
-            this.setupKlothoHelmChart(lib, chart.Name, chart.Values)
+            this.setupKlothoHelmChart(lib, chart.Name, chart.Values || [])
         }
     }
 


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

We hit this bug during the komodor sync. Essentially for any helm pass through where they are deploying a fully owned chart, we dont have any values we need to substitute in after rendering the helm chart. We expected go embed to render the empty array as [] but its rendering it as null. So if we get a null we will just flip it to []

downloaded redis helm chart and tested passthrough using that. Deployed fine

### Standard checks

- **Unit tests**: Any special considerations? would need a full integration test, but not very easy to do since it wont be exposed or anything
- **Docs**: Do we need to update any docs, internal or public? no
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yes, bug fix
