### PR TITLE
Adds multi-language support to integration test workflow

### DIFF
--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -69,7 +69,13 @@ jobs:
           set -x
           dirs_with_tests="$(
             for d in $(find * -type d -maxdepth 0 || printf ''); do
-              jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d"
+              TESTABLE_APP=$(jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d")
+              if [[ ! -z $(grep "^integ-test:" "${d}/Makefile" 2> /dev/null) ]]; then
+                TESTABLE_APP=$d
+              fi
+              if [[ ! -z "${TESTABLE_APP}" ]]; then
+                echo $TESTABLE_APP
+              fi
             done
             exit 0 # otherwise, will fail if the last dir failed the jq match
           )"
@@ -141,7 +147,7 @@ jobs:
           echo $RUNNER_TEMP/bin >> $GITHUB_PATH
       - name: get sample app language
         id: get_language
-        run: echo language=$(echo "${{ matrix.app_to_test }}" | cut -d "-" -f 1) >> $GITHUB_ENV
+        run: echo language=$(echo "${{ matrix.app_to_test }}" | cut -d "-" -f 1) >> $GITHUB_OUTPUT
       - name: Install Public Klotho (old version)
         if: matrix.mode == 'upgrade'
         run: |
@@ -169,7 +175,7 @@ jobs:
         env:
           KLOTHO_LOGIN: ${{ inputs.klotho-login }}
       - name: typescript compilation
-        if: steps.find_dirs.outputs.language == 'ts'
+        if: steps.get_language.outputs.language == 'ts'
         working-directory: ${{ matrix.app_to_test }}
         run: |
           npm install
@@ -312,19 +318,19 @@ jobs:
             ts-eks-helm
         working-directory: ${{ matrix.app_to_test }}
       - name: TypeScript - run integ tests
-        if: steps.find_dirs.outputs.language == 'ts'
+        if: steps.get_language.outputs.language == 'ts'
         uses: klothoplatform/gh-action-retry@v1
         with:
           description: npm run integ-test
           working-directory: ${{ matrix.app_to_test }}
           script: npm run integ-test
       - name: Python - run integ tests
-        if: steps.find_dirs.outputs.language == 'py'
+        if: steps.get_language.outputs.language == 'py'
         uses: klothoplatform/gh-action-retry@v1
         with:
           description: make integ-test
           working-directory: ${{ matrix.app_to_test }}
-          script: make integ-test
+          script: make install integ-test
       - name: wait a bit for logs to propagate
         if: always()
         run: sleep 15

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -139,6 +139,9 @@ jobs:
           mkdir $RUNNER_TEMP/bin
           echo $RUNNER_TEMP/bin
           echo $RUNNER_TEMP/bin >> $GITHUB_PATH
+      - name: get sample app language
+        id: get_language
+        run: echo language=$(echo "${{ matrix.app_to_test }}" | cut -d "-" -f 1) >> $GITHUB_ENV
       - name: Install Public Klotho (old version)
         if: matrix.mode == 'upgrade'
         run: |
@@ -166,6 +169,7 @@ jobs:
         env:
           KLOTHO_LOGIN: ${{ inputs.klotho-login }}
       - name: typescript compilation
+        if: steps.find_dirs.outputs.language == 'ts'
         working-directory: ${{ matrix.app_to_test }}
         run: |
           npm install
@@ -238,7 +242,7 @@ jobs:
             pulumi_out="$(pulumi -C compiled -s "$STACK_NAME" stack output --json)"
             echo "$pulumi_out" | jq .
             API_ENDPOINT="$(echo "$pulumi_out" | jq -er '.apiUrls[0]')"
-            echo "API_ENDPOINT=$API_ENDPOINT" >> $GITHUB_ENV # used by npm run integ-test below
+            echo "API_ENDPOINT=$API_ENDPOINT" >> $GITHUB_ENV # used by integ-test runners below
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -283,7 +287,7 @@ jobs:
             pulumi_out="$(pulumi -C compiled -s "$STACK_NAME" stack output --json)"
             echo "$pulumi_out" | jq .
             API_ENDPOINT="$(echo "$pulumi_out" | jq -er '.apiUrls[0]')"
-            echo "API_ENDPOINT=$API_ENDPOINT" >> $GITHUB_ENV # used by npm run integ-test below
+            echo "API_ENDPOINT=$API_ENDPOINT" >> $GITHUB_ENV # used by integ-test runners below
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -307,12 +311,20 @@ jobs:
             ts-eks
             ts-eks-helm
         working-directory: ${{ matrix.app_to_test }}
-      - name: run integ tests
+      - name: TypeScript - run integ tests
+        if: steps.find_dirs.outputs.language == 'ts'
         uses: klothoplatform/gh-action-retry@v1
         with:
           description: npm run integ-test
           working-directory: ${{ matrix.app_to_test }}
           script: npm run integ-test
+      - name: Python - run integ tests
+        if: steps.find_dirs.outputs.language == 'py'
+        uses: klothoplatform/gh-action-retry@v1
+        with:
+          description: make integ-test
+          working-directory: ${{ matrix.app_to_test }}
+          script: make integ-test
       - name: wait a bit for logs to propagate
         if: always()
         run: sleep 15

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -70,10 +70,10 @@ jobs:
           dirs_with_tests="$(
             for d in $(find * -type d -maxdepth 0 || printf ''); do
               TESTABLE_APP=$(jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d")
-              if [[ ! -z $(grep "^integ-test:" "${d}/Makefile" 2> /dev/null) ]]; then
+              if grep -s "^integ-test:" "${d}/Makefile"; then
                 TESTABLE_APP=$d
               fi
-              if [[ ! -z "${TESTABLE_APP}" ]]; then
+              if [[ -n "${TESTABLE_APP}" ]]; then
                 echo $TESTABLE_APP
               fi
             done


### PR DESCRIPTION
This PR adds support for multiple languages (specifically including Python) through the following means:
- Adding a step to detect language based on the sample app directory prefix
- Modifying the sample app directory detection logic to include apps containing a `Makefile` containing an `integ-test` rule
- Making language-specific steps conditionally executed
- Adding a step to run python integraiton tests

### Standard checks

- **Unit tests**: Any special considerations? No
- **Docs**: Do we need to update any docs, internal or public? No
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? Np
