### PR TITLE
Fixes #81 - wrong app var name for python expose

### DIFF
--- a/pkg/lang/python/plugin_expose.go
+++ b/pkg/lang/python/plugin_expose.go
@@ -200,7 +200,7 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 
 		}
 
-		var appName string
+		var appVarName string
 		app, err := h.findFastAPIAppDefinition(capNode, f)
 		if err != nil {
 			return nil, core.NewCompilerError(f, capNode, err)
@@ -210,23 +210,23 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 			continue
 		}
 
-		appName = app.Identifier.Content(f.Program())
+		appVarName = app.Identifier.Content(f.Program())
 		h.RootPath = app.RootPath
 
 		gwSpec := gatewaySpec{
 			FilePath:   f.Path(),
-			AppVarName: cap.ID,
+			AppVarName: appVarName,
 		}
 
-		log = log.With(zap.String("var", appName))
+		log = log.With(zap.String("var", appVarName))
 
-		localRoutes, err := h.findFastAPIRoutesForVar(f, appName, "")
+		localRoutes, err := h.findFastAPIRoutesForVar(f, appVarName, "")
 		if err != nil {
 			return nil, core.NewCompilerError(f, capNode, err)
 		}
 
 		if len(localRoutes) > 0 {
-			log.Sugar().Infof("Found %d route(s) on app '%s'", len(localRoutes), appName)
+			log.Sugar().Infof("Found %d route(s) on app '%s'", len(localRoutes), appVarName)
 			h.RoutesByGateway[gwSpec] = append(h.RoutesByGateway[gwSpec], localRoutes...)
 		}
 

--- a/pkg/lang/python/plugin_expose.go
+++ b/pkg/lang/python/plugin_expose.go
@@ -22,6 +22,7 @@ type (
 	gatewaySpec struct {
 		FilePath   string
 		AppVarName string
+		gatewayId  string
 	}
 
 	gatewayRouteDefinition struct {
@@ -127,7 +128,7 @@ func (h *restAPIHandler) handle(unit *core.ExecutionUnit) error {
 	}
 
 	for spec, routes := range h.RoutesByGateway {
-		gw := core.NewGateway(spec.AppVarName)
+		gw := core.NewGateway(spec.gatewayId)
 		if existing := h.Result.Get(gw.Key()); existing != nil {
 			gw = existing.(*core.Gateway)
 		} else {
@@ -216,6 +217,7 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 		gwSpec := gatewaySpec{
 			FilePath:   f.Path(),
 			AppVarName: appVarName,
+			gatewayId:  cap.ID,
 		}
 
 		log = log.With(zap.String("var", appVarName))


### PR DESCRIPTION
Fixes #81 by changing the `AppVarName` value set in the gateway spec back from `Capability.ID` to the name of the exported variable associated with the annotated FastAPI app.

compiled output for `py-microservices` Output after change:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/110404901/212351762-42eefca1-b503-44aa-88ea-f26fce1dc975.png">
<img width="494" alt="image" src="https://user-images.githubusercontent.com/110404901/212351877-54f6c20e-eb9e-46bb-95ce-990ffcea1bdc.png">
<img width="544" alt="image" src="https://user-images.githubusercontent.com/110404901/212352082-58b4c2e8-f314-4639-a775-5e02c0449089.png">


### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
