### PR TITLE
Telemetry

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -283,6 +283,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	cli.CloseTreeSitter(result)
+	analyticsClient.AppendProperties(map[string]interface{}{"resource_types": cli.GetResourceTypeCount(result)})
 	analyticsClient.AppendProperties(map[string]interface{}{"languages": cli.GetLanguagesUsed(result)})
 	analyticsClient.AppendProperties(map[string]interface{}{"resources": resourceCounts})
 	analyticsClient.Info("klotho compile complete")

--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -283,7 +283,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	cli.CloseTreeSitter(result)
-
+	analyticsClient.AppendProperties(map[string]interface{}{"languages": cli.GetLanguagesUsed(result)})
 	analyticsClient.AppendProperties(map[string]interface{}{"resources": resourceCounts})
 	analyticsClient.Info("klotho compile complete")
 

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -178,6 +178,17 @@ func GetLanguagesUsed(result *core.CompilationResult) map[core.ExecutableType]bo
 	return executableLangs
 }
 
+func GetResourceTypeCount(result *core.CompilationResult) (resourceCounts map[string]map[string]int) {
+	resourceCounts = make(map[string]map[string]int)
+	for _, res := range result.Resources() {
+		if _, ok := resourceCounts[res.Key().Kind]; !ok {
+			resourceCounts[res.Key().Kind] = make(map[string]int)
+		}
+		resourceCounts[res.Key().Kind][res.Type()] = resourceCounts[res.Key().Kind][res.Type()] + 1
+	}
+	return
+}
+
 func CloseTreeSitter(result *core.CompilationResult) {
 	for _, res := range result.Resources() {
 		if eu, ok := res.(*core.ExecutionUnit); ok {

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -167,6 +167,17 @@ func OutputResources(result *core.CompilationResult, outDir string) (resourceCou
 	return
 }
 
+func GetLanguagesUsed(result *core.CompilationResult) map[core.ExecutableType]bool {
+	executableLangs := make(map[core.ExecutableType]bool)
+	for _, res := range result.Resources() {
+		switch r := res.(type) {
+		case *core.ExecutionUnit:
+			executableLangs[r.Executable.Type] = true
+		}
+	}
+	return executableLangs
+}
+
 func CloseTreeSitter(result *core.CompilationResult) {
 	for _, res := range result.Resources() {
 		if eu, ok := res.(*core.ExecutionUnit); ok {

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -184,7 +184,7 @@ func GetResourceTypeCount(result *core.CompilationResult) (resourceCounts map[st
 		if _, ok := resourceCounts[res.Key().Kind]; !ok {
 			resourceCounts[res.Key().Kind] = make(map[string]int)
 		}
-		resourceCounts[res.Key().Kind][res.Type()] = resourceCounts[res.Key().Kind][res.Type()] + 1
+		resourceCounts[res.Key().Kind][res.Type()]++
 	}
 	return
 }


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #46 and closes #47 


can see sample here https://app.datadoghq.com/logs?query=-service%3A%28cc_compiler%20OR%20cloudviz-233a56a%20OR%20cc_api%29&cols=host%2Cservice&event=AQAAAYWrmRqTOXkp7wAAAABBWVdybVJxVEFBQ3RzeGFtMWNiX1BnQUE&index=%2A&messageDisplay=inline&stream_sort=service%2Cdesc&viz=stream&from_ts=1673619895397&to_ts=1673620795397&live=true

right now a lot of kinds dont have types. This looks really messed up in here but i promise its normal in datadog

```


{
--
_logLevel | info
app | test-upgrade-path
languages { |  
NodeJStrue | NodeJS | true
NodeJS | true
}
provider | aws
resource_types { |  
aws_template_data {1}exec_unit {eks1}gateway {1}infra_as_code {1}input_files {1}persist_kv {1}persist_orm {1}topology {1} | aws_template_data { |   | 1 |   | 1 | } | exec_unit { |   | eks1 | eks | 1 | } | gateway { |   | 1 |   | 1 | } | infra_as_code { |   | 1 |   | 1 | } | input_files { |   | 1 |   | 1 | } | persist_kv { |   | 1 |   | 1 | } | persist_orm { |   | 1 |   | 1 | } | topology { |   | 1 |   | 1 | }
aws_template_data { |  
1 |   | 1
  | 1
}
exec_unit { |  
eks1 | eks | 1
eks | 1
}
gateway { |  
1 |   | 1
  | 1
}
infra_as_code { |  
1 |   | 1
  | 1
}
input_files { |  
1 |   | 1
  | 1
}
persist_kv { |  
1 |   | 1
  | 1
}
persist_orm { |  
1 |   | 1
  | 1
}
topology { |  
1 |   | 1
  | 1
}
}
resources { |  
aws_template_data1exec_unit1gateway1infra_as_code1input_files1persist_kv1persist_orm1topology1 | aws_template_data | 1 | exec_unit | 1 | gateway | 1 | infra_as_code | 1 | input_files | 1 | persist_kv | 1 | persist_orm | 1 | topology | 1
aws_template_data | 1
exec_unit | 1
gateway | 1
infra_as_code | 1
input_files | 1
persist_kv | 1
persist_orm | 1
topology | 1
}
runId | 259ba75e-db0a-4d66-a382-6a798d6dcc32
service | klo_cli_v1
strict | false
validated | false
version | v0.0.0
}


```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
