### PR TITLE
fix scenario where env vars are empty

### DIFF
--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -112,7 +112,7 @@ export = async () => {
     {{range $unit := .ExecUnits -}}
 
     {{- if eq $unit.Type "fargate"}}
-    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{- if $unit.EnvironmentVariables}} {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{else}} [] {{end}});
+    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{jsonPretty $unit.EnvironmentVariables | indent 4}});
     {{else if eq $unit.Type "eks"}}
     eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, {{- if $unit.EnvironmentVariables}} envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
     {{else if eq $unit.Type "apprunner"}}

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -112,7 +112,7 @@ export = async () => {
     {{range $unit := .ExecUnits -}}
 
     {{- if eq $unit.Type "fargate"}}
-    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}});
+    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{- if $unit.EnvironmentVariables}} {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{else}} [] {{end}});
     {{else if eq $unit.Type "eks"}}
     eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, {{- if $unit.EnvironmentVariables}} envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
     {{else if eq $unit.Type "apprunner"}}


### PR DESCRIPTION
When the env var was empty, the end of the method call was `, )` instead of `,[])`.

### Standard checks

- **Unit tests**: not unit tested
- **Docs**: n/a
- **Backwards compatibility**: no issues
