### PR TITLE
Set annotation to empty struct prevent nil pointer deref

### DIFF
--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -154,6 +154,10 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 		f.AddTo(&bufferEncoder{b: fields})
 	}
 
+	if annotation == nil {
+		annotation = &core.Annotation{}
+	}
+
 	writeFields := func() {
 		if fields.Len() == 0 {
 			return
@@ -181,7 +185,7 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 	}
 
 	node := nodeField.n
-	if node == nil && annotation != nil {
+	if node == nil {
 		node = annotation.Node
 	}
 


### PR DESCRIPTION
this matches previous behaviour and regressed when annotation became a pointer field

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
