### PR TITLE
longer app name required for our integ tests

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -240,9 +240,9 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 
 	if appCfg.AppName == "" {
 		return errors.New("'app' required")
-	} else if len(appCfg.AppName) > 25 {
-		analyticsClient.Error("Klotho parameter check failed. 'app' must be less than 20 characters in length")
-		return fmt.Errorf("'app' must be less than 25 characters in length. 'app' was %s", cfg.appName)
+	} else if len(appCfg.AppName) > 35 {
+		analyticsClient.Error("Klotho parameter check failed. 'app' must be less than 35 characters in length")
+		return fmt.Errorf("'app' must be less than 35 characters in length. 'app' was %s", cfg.appName)
 	}
 	match, err := regexp.MatchString(`^[\w-.:/]+$`, cfg.appName)
 	if err != nil {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

our integ tests failed some because of the length of their app names so increasing

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
