### PR TITLE
Fixes integration tests detecting "integ-test:" sample app

### DIFF
--- a/.github/workflows/nightly-integ-tests.yaml
+++ b/.github/workflows/nightly-integ-tests.yaml
@@ -7,7 +7,7 @@ on:
 name: nightly integration tests
 concurrency: integ-tests
 jobs:
-  javascript:
+  all-tests:
     uses: ./.github/workflows/run-integ-tests.yaml
     with:
       test-app-repo: klothoplatform/sample-apps

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -70,7 +70,7 @@ jobs:
           dirs_with_tests="$(
             for d in $(find * -type d -maxdepth 0 || printf ''); do
               TESTABLE_APP=$(jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d")
-              if grep -s "^integ-test:" "${d}/Makefile"; then
+              if grep -s -q "^integ-test:" "${d}/Makefile"; then
                 TESTABLE_APP=$d
               fi
               if [[ -n "${TESTABLE_APP}" ]]; then


### PR DESCRIPTION
- Added -q flag to to silence grep stdout (-s seems to be for errors only)
- Renamed "javascript" nightly job to "all-tests"