### PR TITLE
use appCfg.AppName, not cfg.appName

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -242,14 +242,14 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		return errors.New("'app' required")
 	} else if len(appCfg.AppName) > 35 {
 		analyticsClient.Error("Klotho parameter check failed. 'app' must be less than 35 characters in length")
-		return fmt.Errorf("'app' must be less than 35 characters in length. 'app' was %s", cfg.appName)
+		return fmt.Errorf("'app' must be less than 35 characters in length. 'app' was %s", appCfg.AppName)
 	}
-	match, err := regexp.MatchString(`^[\w-.:/]+$`, cfg.appName)
+	match, err := regexp.MatchString(`^[\w-.:/]+$`, appCfg.AppName)
 	if err != nil {
 		return err
 	} else if !match {
 		analyticsClient.Error("Klotho parameter check failed. 'app' can only contain alphanumeric, -, _, ., :, and /.")
-		return fmt.Errorf("'app' can only contain alphanumeric, -, _, ., :, and /. 'app' was %s", cfg.appName)
+		return fmt.Errorf("'app' can only contain alphanumeric, -, _, ., :, and /. 'app' was %s", appCfg.AppName)
 	}
 
 	if appCfg.Provider == "" {


### PR DESCRIPTION
Without this, `klotho -c klotho.yaml # no --app provided on CLI` fails.

### Standard checks

- **Unit tests**: not unit tested
- **Docs**: n/a
- **Backwards compatibility**: no issues
