### PR TITLE
add the ability to place exec unit in private or public subnet

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type (
 
 	ExecutionUnit struct {
 		Type             string            `json:"type" yaml:"type" toml:"type"`
+		NetworkPlacement string            `json:"network_placement,omitempty" yaml:"network_placement,omitempty" toml:"network_placement,omitempty"`
 		HelmChartOptions *HelmChartOptions `json:"helm_chart_options,omitempty" yaml:"helm_chart_options,omitempty" toml:"helm_chart_options,omitempty"`
 		InfraParams      InfraParams       `json:"pulumi_params,omitempty" yaml:"pulumi_params,omitempty" toml:"pulumi_params,omitempty"`
 	}
@@ -147,6 +148,10 @@ func (cfg *KindDefaults) Merge(other KindDefaults) {
 func (cfg *ExecutionUnit) Merge(other ExecutionUnit) {
 	if other.Type != "" {
 		cfg.Type = other.Type
+	}
+	cfg.NetworkPlacement = other.NetworkPlacement
+	if other.NetworkPlacement == "" {
+		cfg.NetworkPlacement = "private"
 	}
 	cfg.HelmChartOptions = other.HelmChartOptions
 	cfg.InfraParams.Merge(other.InfraParams)

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -112,13 +112,13 @@ export = async () => {
     {{range $unit := .ExecUnits -}}
 
     {{- if eq $unit.Type "fargate"}}
-    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, {{jsonPretty $unit.EnvironmentVariables | indent 4}});
+    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, "{{ $unit.NetworkPlacement }}", {{jsonPretty $unit.EnvironmentVariables | indent 4}});
     {{else if eq $unit.Type "eks"}}
-    eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, {{- if $unit.EnvironmentVariables}} envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
+    eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, network_placement: "{{ $unit.NetworkPlacement }}" {{- if $unit.EnvironmentVariables}}, envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
     {{else if eq $unit.Type "apprunner"}}
     arUrls.push(cloudLib.createDockerAppRunner("{{$unit.Name}}", {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}))
     {{else}}
-    cloudLib.createDockerLambda("{{$unit.Name}}", {{jsonPretty $unit.Params | indent 4}} as Partial<aws.lambda.FunctionArgs> {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}});
+    cloudLib.createDockerLambda("{{$unit.Name}}", {{jsonPretty $unit.Params | indent 4}} as Partial<aws.lambda.FunctionArgs>, "{{ $unit.NetworkPlacement }}" {{- if $unit.EnvironmentVariables}} , {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}});
     {{end}}
 
     {{- if .KeepWarm}}

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -31,6 +31,7 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 				Name:                 res.Name,
 				Type:                 res.Type(),
 				EnvironmentVariables: res.EnvironmentVariables,
+				NetworkPlacement:     cfg.NetworkPlacement,
 			}
 
 			buildImage := true

--- a/pkg/provider/aws/infra_template_test.go
+++ b/pkg/provider/aws/infra_template_test.go
@@ -44,7 +44,7 @@ func TestInfraTemplateModification(t *testing.T) {
 						{Name: "gw", Routes: []provider.Route{{ExecUnitName: "", Path: "/", Verb: ""}}, Targets: map[string]core.GatewayTarget(nil)},
 					},
 					ExecUnits: []provider.ExecUnit{
-						{Name: "unit", Type: "eks", MemReqMB: 0, KeepWarm: false, Schedules: []provider.Schedule(nil), Params: config.InfraParams{}},
+						{Name: "unit", Type: "eks", NetworkPlacement: "private", MemReqMB: 0, KeepWarm: false, Schedules: []provider.Schedule(nil), Params: config.InfraParams{}},
 					},
 				},
 				UseVPC: true,
@@ -65,14 +65,14 @@ func TestInfraTemplateModification(t *testing.T) {
 			cfg: config.Application{
 				Provider: "aws",
 				ExecutionUnits: map[string]*config.ExecutionUnit{
-					"unit": {Type: eks, HelmChartOptions: &config.HelmChartOptions{Install: true}},
+					"unit": {Type: eks, HelmChartOptions: &config.HelmChartOptions{Install: true}, NetworkPlacement: "public"},
 				},
 			},
 			dependencies: []core.Dependency{},
 			data: TemplateData{
 				TemplateData: provider.TemplateData{
 					ExecUnits: []provider.ExecUnit{
-						{Name: "unit", Type: "eks", MemReqMB: 0, KeepWarm: false, Schedules: []provider.Schedule(nil),
+						{Name: "unit", Type: "eks", NetworkPlacement: "public", MemReqMB: 0, KeepWarm: false, Schedules: []provider.Schedule(nil),
 							Params: config.InfraParams{}, HelmOptions: config.HelmChartOptions{Install: true}},
 					},
 				},

--- a/pkg/provider/infra_template.go
+++ b/pkg/provider/infra_template.go
@@ -55,6 +55,7 @@ type (
 		Type                 string
 		MemReqMB             int
 		KeepWarm             bool
+		NetworkPlacement     string
 		Schedules            []Schedule
 		HelmOptions          config.HelmChartOptions
 		Params               config.InfraParams


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #28 

adds network_placement for exec units to allow the user to choose if they should live in public or private subnet. Trivial for most things except kubernetes of course.

### Standard checks

- **Unit tests**: Any special considerations?  integ test instead https://github.com/klothoplatform/sample-apps-pro/pull/10
- **Docs**: Do we need to update any docs, internal or public? https://github.com/klothoplatform/docs/pull/150
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
