### PR TITLE
allow for configurable update stream

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-
 	"github.com/klothoplatform/klotho/pkg/cli"
-	"github.com/klothoplatform/klotho/pkg/updater"
 )
 
 func main() {
 	km := cli.KlothoMain{
-		UpdateStream: updater.DefaultStream,
-		Version:      Version,
+		DefaultUpdateStream: "oss:latest",
+		Version:             Version,
 		PluginSetup: func(psb *cli.PluginSetBuilder) error {
 			return psb.AddAll()
 		},

--- a/pkg/cli/cli_options.go
+++ b/pkg/cli/cli_options.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/klothoplatform/klotho/pkg/cli_config"
+	"github.com/klothoplatform/klotho/pkg/yaml_util"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"io/fs"
+	"os"
+)
+
+const configFileName = "options.yaml"
+
+type (
+	Options struct {
+		Update UpdateOptions `yaml:",omitempty"`
+	}
+
+	UpdateOptions struct {
+		Stream string `yaml:",omitempty"`
+	}
+
+	mockableLog interface {
+		Warn(string, ...zap.Field)
+	}
+)
+
+func ReadOptions() (Options, error) {
+	var options Options
+	_, fileContents, err := readOptionsFileBytes()
+	if err != nil {
+		return options, err
+	}
+	err = yaml.Unmarshal(fileContents, &options)
+	return options, err
+}
+
+func SetOptions(options map[string]string) error {
+	if len(options) == 0 {
+		// This isn't just an optimization. If the existing file is invalid, then we don't want an error message coming
+		// from this path (since the user hasn't specified options to write, and would be confused by a message saying
+		// "couldn't write CLI options" or similar)
+		return nil
+	}
+	filePath, optionsYaml, err := readOptionsFileBytes()
+	if err != nil {
+		return err
+	}
+	optionsYaml, err = setOptions(optionsYaml, options, zap.L())
+
+	err = os.WriteFile(filePath, optionsYaml, 0600)
+	if err != nil {
+		err = errors.Wrap(err, "couldn't write CLI options file")
+	}
+	return err
+}
+
+// setOptions inserts the given options into the yaml, validating along the way that the options still form a valid
+// Options.
+func setOptions(optionsYaml []byte, options map[string]string, logger mockableLog) ([]byte, error) {
+	// First, a warning if the original file isn't valid
+	if err := yaml_util.CheckValid[Options](optionsYaml, yaml_util.Lenient); err != nil {
+		return nil, errors.Wrap(err, "existing options file is invalid")
+	} else if warns := yaml_util.CheckValid[Options](optionsYaml, yaml_util.Strict); warns != nil {
+		logger.Warn(`Existing options contain extra parameters:`)
+		for _, e := range yaml_util.YamlErrors(warns) {
+			logger.Warn(fmt.Sprintf(`▸ %s`, e))
+		}
+	}
+
+	// Validate of each option entry, in two passes: first a lenient check that errors out if it finds any issues, and
+	// then a strict check that warns on issues (and never errors out). We do the two passes so that you won't get
+	// warnings and then an error.
+	var warns []string
+	for k, v := range options {
+		yamlFragment, err := yaml_util.SetValue(nil, k, v)
+		if err != nil {
+			return nil, err
+		}
+		if err = yaml_util.CheckValid[Options](yamlFragment, yaml_util.Lenient); err != nil {
+			return nil, err
+		}
+		if warn := yaml_util.CheckValid[Options](yamlFragment, yaml_util.Strict); warn != nil {
+			warns = append(warns, fmt.Sprintf(`Unrecognized option "%s". We'll still set it, but it may not have any effect.`, k))
+		}
+	}
+	for _, msg := range warns {
+		logger.Warn(msg)
+	}
+
+	// Now add each value into the map. This isn't super efficient (it re-parses at each iteration), but it's not a
+	// critical path.
+	for k, v := range options {
+		modified, err := yaml_util.SetValue(optionsYaml, k, v)
+		if err != nil {
+			return nil, errors.Wrapf(err, `invalid option: %s`, k)
+		}
+		optionsYaml = modified
+	}
+	// final sanity check to make sure we're setting valid json
+	if err := yaml_util.CheckValid[Options](optionsYaml, yaml_util.Lenient); err != nil {
+		return nil, errors.Wrapf(err, `couldn't write options (unknown error)`)
+	}
+	return optionsYaml, nil
+}
+
+func readOptionsFileBytes() (string, []byte, error) {
+	path, err := cli_config.KlothoConfigPath(configFileName)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "couldn't find CLI options file path")
+	}
+	content, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return path, nil, nil // If the file isn't there, silently return the defaults
+	} else if err != nil {
+		return "", nil, errors.Wrap(err, "couldn't read CLI options file path")
+	}
+	return path, content, err
+}
+
+func OptionOrDefault(given string, defaultValue string) string {
+	if given == "" {
+		return defaultValue
+	}
+	return given
+}

--- a/pkg/cli/cli_options_test.go
+++ b/pkg/cli/cli_options_test.go
@@ -1,12 +1,10 @@
 package cli
 
 import (
-	"errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	"gopkg.in/yaml.v3"
-	"os"
 	"testing"
 )
 
@@ -88,9 +86,6 @@ func TestSetOptions(t *testing.T) {
 }
 
 func TestCliSerialization(t *testing.T) {
-	_, err := os.ReadFile("adslkfjadsf")
-	errors.Is(err, os.ErrNotExist)
-	println("%s", err)
 	cases := []struct {
 		name   string
 		given  Options

--- a/pkg/cli/cli_options_test.go
+++ b/pkg/cli/cli_options_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"os"
+	"testing"
+)
+
+func TestSetOptions(t *testing.T) {
+	cases := []struct {
+		name         string
+		set          string
+		to           string
+		originalYaml string
+		expectYaml   string
+		expectErr    bool
+		expectWarns  []string
+	}{
+		{
+			name: "valid option",
+			// blank vs non-blank isn't too interesting, because yaml_util handles that. See its tests for details.
+			originalYaml: "",
+			set:          "update.stream",
+			to:           "my-stream",
+			expectYaml:   "update:\n    stream: my-stream\n",
+		},
+		{
+			name:      "invalid option",
+			set:       "update",
+			to:        "this can't be a scalar",
+			expectErr: true,
+		},
+		{
+			name:        "unknown option",
+			set:         "foo.bar",
+			to:          "world",
+			expectYaml:  "foo:\n    bar: world\n",
+			expectWarns: []string{`Unrecognized option "foo.bar". We'll still set it, but it may not have any effect.`},
+		},
+		{
+			name:         "yaml starts with unknown option",
+			set:          "update.stream",
+			to:           "my-stream",
+			originalYaml: "extra: option",
+			expectYaml:   "extra: option\nupdate:\n    stream: my-stream\n",
+			expectWarns: []string{
+				`Existing options contain extra parameters:`,
+				`▸ line 1: field extra not found in type cli.Options`,
+			},
+		},
+		{
+			name:         "yaml starts invalid",
+			set:          "update.stream",
+			to:           "my-stream",
+			originalYaml: "update: this can't be a scalar",
+			expectErr:    true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			logger := mockedLogger{}
+			options := map[string]string{
+				tt.set: tt.to,
+			}
+
+			result, err := setOptions([]byte(tt.originalYaml), options, &logger)
+			assert.Equal(tt.expectWarns, logger.warns)
+			assert.Equal(tt.expectErr, err != nil)
+			if err != nil {
+				return
+			}
+			assert.Equal(tt.expectYaml, string(result))
+		})
+	}
+}
+
+type mockedLogger struct {
+	warns []string
+}
+
+func (ml *mockedLogger) Warn(msg string, fields ...zap.Field) {
+	ml.warns = append(ml.warns, msg)
+}
+
+func TestCliSerialization(t *testing.T) {
+	_, err := os.ReadFile("adslkfjadsf")
+	errors.Is(err, os.ErrNotExist)
+	println("%s", err)
+	cases := []struct {
+		name   string
+		given  Options
+		expect string
+	}{
+		{
+			name: "normal",
+			given: Options{
+				Update: UpdateOptions{
+					Stream: "my-stream",
+				},
+			},
+			expect: "update:\n    stream: my-stream\n",
+		},
+		{
+			name: "no update stream",
+			given: Options{
+				Update: UpdateOptions{},
+			},
+			expect: "{}\n",
+		},
+		{
+			name:   "no update options",
+			given:  Options{},
+			expect: "{}\n",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			actual, err := yaml.Marshal(tt.given)
+			if !assert.NoError(err) {
+				return
+			}
+			assert.Equal(tt.expect, string(actual))
+		})
+	}
+
+}
+func TestCliDeserialization(t *testing.T) {
+	cases := []struct {
+		name      string
+		given     string
+		expect    Options
+		expectErr bool
+	}{
+		{
+			name:  "normal",
+			given: "update:\n    stream: my-stream\n",
+			expect: Options{
+				Update: UpdateOptions{
+					Stream: "my-stream",
+				},
+			},
+		},
+		{
+			name:  "minimal",
+			given: "{}",
+			expect: Options{
+				Update: UpdateOptions{},
+			},
+		},
+		{
+			name:  "empty",
+			given: "",
+			expect: Options{
+				Update: UpdateOptions{},
+			},
+		},
+		{
+			name:  "extra values are ignored",
+			given: "hello: world",
+			expect: Options{
+				Update: UpdateOptions{},
+			},
+		},
+		{
+			name:      "invalid values", // ie an "update" key that doesn't point to a struct
+			given:     "update: yes",
+			expectErr: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			actual := Options{}
+			err := yaml.Unmarshal([]byte(tt.given), &actual)
+
+			assert.Equal(tt.expectErr, err != nil, "actual error: %s", err)
+			assert.Equal(tt.expect, actual)
+		})
+	}
+}

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -24,13 +24,11 @@ import (
 )
 
 type KlothoMain struct {
-	UpdateStream     string
-	Version          string
-	VersionQualifier string
-	PluginSetup      func(*PluginSetBuilder) error
+	DefaultUpdateStream string
+	Version             string
+	VersionQualifier    string
+	PluginSetup         func(*PluginSetBuilder) error
 }
-
-var klothoUpdater = updater.Updater{ServerURL: updater.DefaultServer, Stream: updater.DefaultStream}
 
 var cfg struct {
 	verbose       bool
@@ -48,6 +46,7 @@ var cfg struct {
 	update        bool
 	cfgFormat     string
 	login         string
+	setOption     map[string]string
 }
 
 var hadWarnings = atomic.NewBool(false)
@@ -91,6 +90,7 @@ func (km KlothoMain) Main() {
 	flags.BoolVar(&cfg.version, "version", false, "Print the version")
 	flags.BoolVar(&cfg.update, "update", false, "update the cli to the latest version")
 	flags.StringVar(&cfg.login, "login", "", "Login to Klotho with email. For anonymous login, use 'local'")
+	flags.StringToStringVar(&cfg.setOption, "set-option", nil, "Sets a CLI option")
 	_ = flags.MarkHidden("internalDebug")
 
 	err := root.Execute()
@@ -192,8 +192,18 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		InternalDebug: cfg.internalDebug,
 		Verbose:       cfg.verbose,
 	}
-
 	defer analyticsClient.PanicHandler(&err, errHandler)
+
+	// Save any config options. This should go before anything else, so that it always takes effect before any code
+	// that uses it (for example, we should save an update.stream option before we use it below to perform the update).
+	err = SetOptions(cfg.setOption)
+	if err != nil {
+		return err
+	}
+	options, err := ReadOptions()
+	if err != nil {
+		return err
+	}
 
 	if cfg.version {
 		var versionQualifier string
@@ -209,6 +219,8 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// if update is specified do the update in place
+	updateStream := OptionOrDefault(options.Update.Stream, km.DefaultUpdateStream)
+	var klothoUpdater = updater.Updater{ServerURL: updater.DefaultServer, Stream: updateStream}
 	if cfg.update {
 		if err := klothoUpdater.Update(km.Version); err != nil {
 			analyticsClient.Error(klothoName + " failed to update")
@@ -227,6 +239,12 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	if needsUpdate {
 		analyticsClient.Info(klothoName + "update is available")
 		zap.L().Info("new update is available, please run klotho --update to get the latest version")
+	}
+
+	if len(cfg.setOption) > 0 {
+		// Options were set above, and used to perform or check for update. Nothing else to do.
+		// We want to exit early, so that the user doesn't get an error about path not being provided.
+		return nil
 	}
 
 	appCfg, err := readConfig(args)

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -220,7 +220,11 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 
 	// if update is specified do the update in place
 	updateStream := OptionOrDefault(options.Update.Stream, km.DefaultUpdateStream)
-	var klothoUpdater = updater.Updater{ServerURL: updater.DefaultServer, Stream: updateStream}
+	var klothoUpdater = updater.Updater{
+		ServerURL:     updater.DefaultServer,
+		Stream:        updateStream,
+		CurrentStream: km.DefaultUpdateStream,
+	}
 	if cfg.update {
 		if err := klothoUpdater.Update(km.Version); err != nil {
 			analyticsClient.Error(klothoName + " failed to update")

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -23,7 +23,6 @@ var (
 
 var (
 	DefaultServer string = "http://srv.klo.dev"
-	DefaultStream string = "oss:latest"
 )
 
 type Updater struct {
@@ -87,12 +86,12 @@ func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 func (u *Updater) Update(currentVersion string) error {
 	doUpdate, err := u.CheckUpdate(currentVersion)
 	if err != nil {
-		zap.S().Errorf("error checking for updates: %v", err)
+		zap.S().Errorf(`error checking for updates on stream "%s": %v`, u.Stream, err)
 		return err
 	}
 
 	if !doUpdate {
-		zap.S().Info("already up to date.")
+		zap.S().Infof(`already up to date on stream "%s".`, u.Stream)
 		return nil
 	}
 
@@ -107,7 +106,7 @@ func (u *Updater) Update(currentVersion string) error {
 	if err := selfUpdate(body); err != nil {
 		return errors.Wrapf(err, "failed to update klotho")
 	}
-	zap.L().Info("updated to the latest version.")
+	zap.S().Infof(`updated to the latest version on stream "%s"`, u.Stream)
 	return nil
 }
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -27,7 +27,10 @@ var (
 
 type Updater struct {
 	ServerURL string
-	Stream    string
+	// Stream is the update stream to check
+	Stream string
+	// CurrentStream is the stream this binary came from
+	CurrentStream string
 }
 
 func selfUpdate(data io.ReadCloser) error {
@@ -74,11 +77,7 @@ func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 		return false, fmt.Errorf("invalid version %s: %v", currentVersion, err)
 	}
 
-	if currVersion.LessThan(*latestVersion) {
-		return true, nil
-	}
-
-	return false, nil
+	return currVersion.LessThan(*latestVersion) || u.CurrentStream != u.Stream, nil
 }
 
 // Update performs an update if a newer version is

--- a/pkg/yaml_util/yaml_util.go
+++ b/pkg/yaml_util/yaml_util.go
@@ -1,0 +1,129 @@
+package yaml_util
+
+import (
+	"bytes"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	"strings"
+)
+
+type CheckMode bool
+
+const (
+	Lenient = CheckMode(false)
+	Strict  = CheckMode(true)
+)
+
+// SetValue upserts the value the content yaml to a given value, specified by a dotted path. For example, setting
+// `foo.bar.baz` to `hello, world` is equivalent to upserting the following yaml:
+//
+//	foo:
+//	    bar:
+//	        baz: hello, world
+//
+// This method will make a best effort to preserve comments, as per the `yaml` package's abilities. You may overwrite
+// scalars, but you may not overwrite a non-scalar. You may also specify a path that doesn't exist in the source yaml,
+// as long as none of the paths correspond to existing elements other than yaml mappings.
+func SetValue(content []byte, optionPath string, optionValue string) ([]byte, error) {
+	// General approach:
+	// 1) convert the yaml into a map, using yaml
+	// 2a) find the node tree's value at the specified path
+	// 2b) set that node's value, assuming it's a scalar (or empty)
+	// 2) write the node tree back into bytes. this will preserve comments and such
+
+	// step 1
+	var tree yaml.Node
+	if err := yaml.Unmarshal(content, &tree); err != nil {
+		return nil, err
+	}
+
+	// step 2a
+	segments := strings.Split(optionPath, ".")
+	var topNode *yaml.Node
+	if len(tree.Content) == 0 {
+		topNode = &yaml.Node{Kind: yaml.MappingNode}
+	} else {
+		topNode = tree.Content[0] // the tree's root is a DocumentNode; we assume one document
+	}
+	setOptionAtNode := topNode
+	for _, segment := range segments[:len(segments)-1] {
+		if setOptionAtNode.Kind != yaml.MappingNode {
+			return nil, errors.Errorf(`can't set the path "%s"'`, optionPath)
+		}
+		if child := findChild(setOptionAtNode.Content, segment); child != nil {
+			setOptionAtNode = child
+		} else {
+			newSubMap := &yaml.Node{Kind: yaml.MappingNode}
+			setOptionAtNode.Content = append(setOptionAtNode.Content, &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: segment,
+			})
+			setOptionAtNode.Content = append(setOptionAtNode.Content, newSubMap)
+			setOptionAtNode = newSubMap
+		}
+	}
+
+	// step 2b
+	if setOptionAtNode.Kind != yaml.MappingNode {
+		return nil, errors.Errorf(`can't set the path "%s"'`, optionPath)
+	}
+	lastSegment := segments[len(segments)-1]
+	if currValue := findChild(setOptionAtNode.Content, lastSegment); currValue != nil {
+		if currValue.Kind != yaml.ScalarNode {
+			return nil, errors.Errorf(`"%s" cannot be a scalar`, optionPath)
+		}
+		currValue.Tag = "" // if the existing type isn't a string, we want to reset it
+		currValue.Value = optionValue
+	} else {
+		setOptionAtNode.Content = append(setOptionAtNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: lastSegment,
+		})
+		setOptionAtNode.Content = append(setOptionAtNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: optionValue,
+		})
+	}
+
+	// step 3
+	return yaml.Marshal(topNode)
+}
+
+// CheckValid validates that the given yaml actually represents the type provided, and returns a non-nil error
+// describing the problem if it doesn't. You need to explicitly provide the type to be checked:
+//
+//	CheckValid[MyCoolType](contents)
+//
+// The strict flag governs whether the check will allow unknown fields.
+func CheckValid[T any](content []byte, mode CheckMode) error {
+	if strings.TrimSpace(string(content)) == "" {
+		// the decoder will fail on this (EOF), but we want to consider it valid yaml
+		return nil
+	}
+	var ignored T
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(bool(mode))
+	return decoder.Decode(&ignored)
+}
+
+// YamlErrors returns the yaml.TypeError errors if the given err is a TypeError; otherwise, it just returns a
+// single-element array of the given error's string (disregarding any wrapped errors).
+func YamlErrors(err error) []string {
+	switch err := err.(type) {
+	case *yaml.TypeError:
+		return err.Errors
+	default:
+		return []string{err.Error()}
+	}
+
+}
+
+func findChild(within []*yaml.Node, named string) *yaml.Node {
+	for i := 0; i < len(within); i += 2 {
+		node := within[i]
+		if node.Kind == yaml.ScalarNode && node.Value == named {
+			return within[i+1]
+		}
+	}
+	return nil
+}

--- a/pkg/yaml_util/yaml_util_test.go
+++ b/pkg/yaml_util/yaml_util_test.go
@@ -1,0 +1,146 @@
+package yaml_util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetValue(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		set       string
+		to        string
+		expect    string
+		expectErr string
+	}{
+		{
+			name:   "happy path",
+			input:  "hello: world",
+			set:    "goodbye",
+			to:     "farewell",
+			expect: "hello: world\ngoodbye: farewell\n",
+		},
+		{
+			name:   "input is empty",
+			input:  "",
+			set:    "hello",
+			to:     "world",
+			expect: "hello: world\n",
+		},
+		{
+			name:  "new deep option",
+			input: "",
+			set:   "one.two.three",
+			to:    "123",
+			// note: the expected text uses string indentation, not tabs
+			expect: `one:
+    two:
+        three: 123
+`,
+		},
+		{
+			name:   "existing deep option",
+			input:  "one:\n  two: hello",
+			set:    "one.two",
+			to:     "goodbye",
+			expect: "one:\n    two: goodbye\n",
+		},
+		{
+			name:   "comments get preserved",
+			input:  "#top-comment\nhello: world # this is my comment",
+			set:    "hello",
+			to:     "earth",
+			expect: "#top-comment\nhello: earth # this is my comment\n",
+		},
+		{
+			name:      "doc is a scalar",
+			input:     "123",
+			set:       "hello",
+			to:        "world",
+			expectErr: `can't set the path "hello"'`,
+		},
+		{
+			name:   "overwrite scalar",
+			input:  "hello: world",
+			set:    "hello",
+			to:     "goodbye",
+			expect: "hello: goodbye\n",
+		},
+		{
+			name:   "overwrite scalar with different-typed scalar",
+			input:  "hello: 123",
+			set:    "hello",
+			to:     "world",
+			expect: "hello: world\n",
+		},
+		{
+			name:      "overwrite map with scalar",
+			input:     "hello:\n  greet_target: world",
+			set:       "hello",
+			to:        "world",
+			expectErr: "\"hello\" cannot be a scalar",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			actual, err := SetValue([]byte(tt.input), tt.set, tt.to)
+			assert.Equal(tt.expect, string(actual))
+			var errStr string
+			if err != nil {
+				errStr = err.Error()
+			}
+			assert.Equal(tt.expectErr, errStr)
+		})
+	}
+}
+
+func TestCheckValid(t *testing.T) {
+	// all cases validate against the dummyData struct
+	cases := []struct {
+		name           string
+		yaml           string
+		strict         bool
+		successLenient bool
+		successStrict  bool
+	}{
+		{
+			name:           "happy path",
+			yaml:           "str_value: hello\nint_value: 123",
+			successLenient: true,
+			successStrict:  true,
+		},
+		{
+			name:           "missing fields",
+			yaml:           "str_value: hello",
+			successLenient: true,
+			successStrict:  true,
+		},
+		{
+			name:           "extra fields",
+			yaml:           "bogus_value: hello",
+			successLenient: true,
+			successStrict:  false,
+		},
+		{
+			name:           "wrongly typed fields",
+			yaml:           "int_value: not a number",
+			successLenient: false,
+			successStrict:  false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.successLenient, CheckValid[dummyData]([]byte(tt.yaml), Lenient) == nil, "lenient check")
+			assert.Equal(tt.successStrict, CheckValid[dummyData]([]byte(tt.yaml), Strict) == nil, "strict check")
+		})
+	}
+}
+
+type dummyData struct {
+	StrValue string `yaml:"str_value"`
+	IntValue int    `yaml:"int_value"`
+}


### PR DESCRIPTION
This commit has a few components:

1. Some YAML utils: one for inserting values into generic YAML using dot-notation keys, and one for validating that YAML can be deserialized as a given object type.
2. Introduces a new ~/.klotho/options.yaml for CLI options. These are strictly typed within the code, but we're more lenient in terms of configs we allow setting. In particular, we allow setting configs that we don't yet know about; this can be helpful in cases where you want to set a config that's available in a subsequent version, before you upgrade to that version. We do warn on this though: in manual testing, I had done "upgrade.stream" instead of "update.stream" and was confused why this didn't work, so I figured I'd help out the next person who runs into that.
3. KlothoMain introduces a new flag, `--set-option name=value`. You can use it on its own, or inline it with `--update`.

I'm also getting rid of updater.go's DefaultStream var, because that really needs to be specified only by the KlothoMain instantiation.

This resolves #78

<!-- Describe the PR. 
• Does any part of it require special attention?
• Does it relate to or fix any issue?
-->

### Standard checks

- **Unit tests**: Note that I added a slightly ugly `mockableLog` to cli_options.go, so that I could test the warning messages. I consider these to be important from a usability perspective, but I'm open to opinions here — especially on how else to do it (would a func be better? or I could actually tap into the zap logger — it's possible to do that, though it's a bit messy)
- **Docs**: This introduces new functionality. We'd probably want to document it at some point, but not yet. It is available in the `--help` text
- **Backwards compatibility**: no issues
