### PR TITLE
always create GWspec if we see an annotation

### DIFF
--- a/pkg/lang/javascript/express.go
+++ b/pkg/lang/javascript/express.go
@@ -210,6 +210,7 @@ func (h *ExpressHandler) assignRoutesToGateway(info *execUnitExposeInfo, result 
 			AppVarName: listener.appName,
 			gatewayId:  listener.annotationId,
 		}
+		info.RoutesByGateway[gwSpec] = []gatewayRouteDefinition{}
 
 		localRoutes := h.handleLocalRoutes(listener.f, listenVarName, "", info.Unit.Name)
 		if len(localRoutes) > 0 {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

if theres only middleware in the local file we wont end up creating the GW. https://github.com/tigoe/websocket-examples/tree/main/ExpressWsServer is how i ran into this 

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
