### PR TITLE
Fixes python fs and adds basic support for file modes

### DIFF
--- a/pkg/lang/python/aws_runtime/fs.py
+++ b/pkg/lang/python/aws_runtime/fs.py
@@ -1,21 +1,23 @@
-import boto3
 import os
+
+import boto3
 
 payloadBucketPhysicalName = os.getenv("KLOTHO_S3_PREFIX") + "{{.PayloadsBucketName}}"
 
 
 def open(url: str, **kwargs):
-    return s3ContextManager(str(url))
+    return s3ContextManager(str(url), **kwargs)
 
 
 class s3ContextManager(object):
-    def __init__(self, file_name: str):
+    def __init__(self, file_name: str, **kwargs):
         self.client = boto3.client('s3')
         self.bucket_name = payloadBucketPhysicalName
         self.file_name = file_name
+        self.kwargs = kwargs
 
     async def __aenter__(self):
-        return FsItem(bucket_name=self.bucket_name, file_name=self.file_name, client=self.client)
+        return FsItem(bucket_name=self.bucket_name, file_name=self.file_name, client=self.client, **self.kwargs)
 
     async def __aexit__(self, exc_type, exc_val, traceback):
         pass
@@ -26,10 +28,26 @@ class FsItem(object):
         self.client = client
         self.bucket_name = bucket_name
         self.file_name = file_name
+        mode = kwargs.get("mode", "r")
+        self.is_readable = "r" in mode
+        self.is_writeable = "w" in mode or "+" in mode or "x" in mode
+        self.is_binary = "b" in mode
+
+        if "a" in mode:
+            raise IOError('@klotho::persist does not support append mode')
+
+        self.encoding = kwargs.get("encoding", "utf-8")
 
     async def write(self, content: str):
+        if not self.is_writeable:
+            raise IOError(f"{self.file_name} is not writeable")
         self.client.put_object(Key=self.file_name, Bucket=self.bucket_name, Body=content)
 
     async def read(self):
+        if not self.is_readable:
+            raise IOError(f"{self.file_name} is not readable")
         response = self.client.get_object(Key=self.file_name, Bucket=self.bucket_name)
-        return response["Body"]
+        body = response["Body"].read()
+        if not self.is_binary:
+            body = body.decode(self.encoding)
+        return body

--- a/pkg/lang/python/aws_runtime/fs.py.tmpl
+++ b/pkg/lang/python/aws_runtime/fs.py.tmpl
@@ -1,21 +1,23 @@
-import boto3
 import os
+
+import boto3
 
 payloadBucketPhysicalName = os.getenv("KLOTHO_S3_PREFIX") + "{{.PayloadsBucketName}}"
 
 
 def open(url: str, **kwargs):
-    return s3ContextManager(str(url))
+    return s3ContextManager(str(url), **kwargs)
 
 
 class s3ContextManager(object):
-    def __init__(self, file_name: str):
+    def __init__(self, file_name: str, **kwargs):
         self.client = boto3.client('s3')
         self.bucket_name = payloadBucketPhysicalName
         self.file_name = file_name
+        self.kwargs = kwargs
 
     async def __aenter__(self):
-        return FsItem(bucket_name=self.bucket_name, file_name=self.file_name, client=self.client)
+        return FsItem(bucket_name=self.bucket_name, file_name=self.file_name, client=self.client, **self.kwargs)
 
     async def __aexit__(self, exc_type, exc_val, traceback):
         pass
@@ -26,10 +28,26 @@ class FsItem(object):
         self.client = client
         self.bucket_name = bucket_name
         self.file_name = file_name
+        mode = kwargs.get("mode", "r")
+        self.is_readable = "r" in mode
+        self.is_writeable = "w" in mode or "+" in mode or "x" in mode
+        self.is_binary = "b" in mode
+
+        if "a" in mode:
+            raise IOError('@klotho::persist does not support append mode')
+
+        self.encoding = kwargs.get("encoding", "utf-8")
 
     async def write(self, content: str):
+        if not self.is_writeable:
+            raise IOError(f"{self.file_name} is not writeable")
         self.client.put_object(Key=self.file_name, Bucket=self.bucket_name, Body=content)
 
     async def read(self):
+        if not self.is_readable:
+            raise IOError(f"{self.file_name} is not readable")
         response = self.client.get_object(Key=self.file_name, Bucket=self.bucket_name)
-        return response["Body"]
+        body = response["Body"].read()
+        if not self.is_binary:
+            body = body.decode(self.encoding)
+        return body


### PR DESCRIPTION
This PR fixes python persist fs support for reading files and adds basic support for file modes to enable use with binary or text files.

The "a" mode flag (append) is unsupported.

<!-- Describe the PR. 
• Does any part of it require special attention?
• Does it relate to or fix any issue?
-->

### Standard checks

- **Unit tests**: Any special considerations? N/A
- **Docs**: Do we need to update any docs, internal or public? we should probably document supported/unsupported flags
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
