### PR TITLE
Resource name sanitization

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -1,7 +1,6 @@
-import { Region } from '@pulumi/aws'
 import * as aws from '@pulumi/aws'
+import { Region } from '@pulumi/aws'
 import * as awsx from '@pulumi/awsx'
-import * as k8s from '@pulumi/kubernetes'
 
 import * as pulumi from '@pulumi/pulumi'
 import * as sha256 from 'simple-sha256'
@@ -11,9 +10,11 @@ import * as crypto from 'crypto'
 import { setupElasticacheCluster } from './iac/elasticache'
 import * as analytics from './iac/analytics'
 
+import { h, sanitized, validate } from './iac/sanitization/sanitizer'
 import { LoadBalancerPlugin } from './iac/load_balancing'
 import { DefaultEksClusterOptions, Eks, EksExecUnit, HelmChart } from './iac/eks'
 import { setupMemoryDbCluster } from './iac/memorydb'
+import AwsSanitizer from './iac/sanitization/aws'
 
 export enum Resource {
     exec_unit = 'exec_unit',
@@ -112,7 +113,12 @@ export class CloudCCLib {
         if (this.createVPC) {
             this.getVpcSgSubnets()
         }
-        const resolvedBucketName = pulumi.interpolate`${this.account.accountId}${physicalPayloadsBucketName}`
+        const resolvedBucketName = this.account.accountId.apply(
+            (accountId) =>
+                sanitized(
+                    AwsSanitizer.S3.bucket.nameValidation()
+                )`${accountId}${physicalPayloadsBucketName}`
+        )
         this.createBuckets([resolvedBucketName], true)
         this.addSharedPolicyStatement({
             Effect: 'Allow',
@@ -140,7 +146,6 @@ export class CloudCCLib {
             this.createVpcEndpoints()
             return
         }
-
         if (
             klothoVPC.id == undefined ||
             klothoVPC.sgId == undefined ||
@@ -176,8 +181,11 @@ export class CloudCCLib {
         this.publicSubnetIds = this.klothoVPC.publicSubnetIds
         this.privateSubnetIds = this.klothoVPC.privateSubnetIds
 
-        const klothoSG = new aws.ec2.SecurityGroup(this.name, {
-            name: this.name,
+        const sgName = sanitized(AwsSanitizer.EC2.vpc.securityGroup.nameValidation())`${h(
+            this.name
+        )}`
+        const klothoSG = new aws.ec2.SecurityGroup(sgName, {
+            name: sgName,
             vpcId: this.klothoVPC.id,
             egress: [
                 {
@@ -319,8 +327,11 @@ export class CloudCCLib {
                     .forEach((item) => combinedPolicyStatements.add(item))
             }
             if (combinedPolicyStatements.size > 0) {
+                const policyName = sanitized(AwsSanitizer.IAM.policy.nameValidation())`${h(
+                    this.name
+                )}-${h(physicalName)}-exec`
                 const policy = new aws.iam.Policy(
-                    `${this.name}-${physicalName}-exec`,
+                    policyName,
                     {
                         policy: {
                             Version: '2012-10-17',
@@ -330,7 +341,7 @@ export class CloudCCLib {
                     { parent: role }
                 )
                 new aws.iam.RolePolicyAttachment(
-                    `${this.name}-${physicalName}-exec`,
+                    policyName,
                     {
                         role: role,
                         policyArn: policy.arn,
@@ -355,7 +366,10 @@ export class CloudCCLib {
             Resource: ['*'],
         })
 
-        const accessRole = new aws.iam.Role(`${execUnitName}-ar-access-role`, {
+        const roleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(this.name)}-${h(
+            execUnitName
+        )}-ar-access-role`
+        const accessRole = new aws.iam.Role(roleName, {
             assumeRolePolicy: {
                 Version: '2012-10-17',
                 Statement: [
@@ -371,7 +385,9 @@ export class CloudCCLib {
         })
 
         const policy = new aws.iam.Policy(
-            `${execUnitName}-ar-access-policy`,
+            sanitized(AwsSanitizer.IAM.policy.nameValidation())`${h(this.name)}-${h(
+                execUnitName
+            )}-ar-access-policy`,
             {
                 description: 'Role to grant AppRunner service access to ECR',
                 policy: {
@@ -414,9 +430,11 @@ export class CloudCCLib {
         const additionalEnvVars: { [key: string]: pulumi.Input<string> } =
             this.generateExecUnitEnvVars(execUnitName, envVars)
 
-        const logGroupName = `/aws/apprunner/${this.name}-${execUnitName}-apprunner`
+        const logGroupName = sanitized(
+            AwsSanitizer.CloudWatch.logGroup.nameValidation()
+        )`/aws/apprunner/${h(this.name)}-${h(execUnitName)}-apprunner`
         let cloudwatchGroup = new aws.cloudwatch.LogGroup(`${this.name}-${execUnitName}-lg`, {
-            name: `${logGroupName}`,
+            name: logGroupName,
             retentionInDays: 1,
         })
 
@@ -429,8 +447,9 @@ export class CloudCCLib {
             }
         })
 
-        const serviceName = `${this.name}-${execUnitName}-apprunner`
-
+        const serviceName = sanitized(AwsSanitizer.AppRunner.service.nameValidation())`${h(
+            this.name
+        )}-${h(execUnitName)}-apprunner`
         const service = new aws.apprunner.Service(serviceName, {
             serviceName: serviceName,
             sourceConfiguration: {
@@ -478,12 +497,16 @@ export class CloudCCLib {
             network_placement === 'public' ? this.publicSubnetIds : this.privateSubnetIds
 
         const lambdaRole = this.createRoleForName(execUnitName)
+        const lambdaName = sanitized(AwsSanitizer.Lambda.lambdaFunction.nameValidation())`${h(
+            this.name
+        )}-${h(execUnitName)}`
+
         const lambdaConfig: aws.lambda.FunctionArgs = {
             ...baseArgs,
             packageType: 'Image',
             imageUri: image,
             role: lambdaRole.arn,
-            name: `${this.name}-${execUnitName}`,
+            name: lambdaName,
             tags: {
                 env: 'production',
                 service: execUnitName,
@@ -501,8 +524,11 @@ export class CloudCCLib {
             }
         }
 
+        const logGroupName = sanitized(
+            AwsSanitizer.CloudWatch.logGroup.nameValidation()
+        )`/aws/lambda/${lambdaName}-function-api-lg`
         let cloudwatchGroup = new aws.cloudwatch.LogGroup(`${execUnitName}-function-api-lg`, {
-            name: pulumi.interpolate`/aws/lambda/${lambdaConfig.name}`,
+            name: logGroupName,
             retentionInDays: 1,
         })
 
@@ -644,6 +670,8 @@ export class CloudCCLib {
         subscribers: string[]
     ): aws.sns.Topic {
         let topic = `${this.name}_${name}_${event}`
+        // validate rather than sanitize since the PubSub runtime depends on a specific topic format
+        validate(topic, AwsSanitizer.SNS.topic.nameValidation())
         if (topic.length > 256) {
             const hash = crypto.createHash('sha256')
             hash.update(topic)
@@ -693,8 +721,9 @@ export class CloudCCLib {
     }
 
     setupKV(): aws.dynamodb.Table {
+        const tableName = sanitized(AwsSanitizer.DynamoDB.table.nameValidation())`${h(this.name)}`
         const db = new aws.dynamodb.Table(
-            `KV_${this.name}`,
+            `KV_${tableName}`,
             {
                 attributes: [
                     { name: 'pk', type: 'S' },
@@ -709,7 +738,7 @@ export class CloudCCLib {
                     attributeName: 'expiration',
                     enabled: true,
                 },
-                name: this.name,
+                name: tableName,
             },
             { protect: this.protect }
         )
@@ -789,38 +818,38 @@ export class CloudCCLib {
     }
 
     private createExecutionRole(execUnitPhysicalName: string) {
-        const lambdaExecRole = new aws.iam.Role(
-            `${this.name}_${this.generateHashFromPhysicalName(execUnitPhysicalName)}_LambdaExec`,
-            {
-                assumeRolePolicy: {
-                    Version: '2012-10-17',
-                    Statement: [
-                        {
-                            Action: 'sts:AssumeRole',
-                            Principal: {
-                                Service: 'lambda.amazonaws.com',
-                            },
-                            Effect: 'Allow',
-                            Sid: '',
+        const roleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(
+            this.name
+        )}_${this.generateHashFromPhysicalName(execUnitPhysicalName)}_LambdaExec`
+        const lambdaExecRole = new aws.iam.Role(roleName, {
+            assumeRolePolicy: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Action: 'sts:AssumeRole',
+                        Principal: {
+                            Service: 'lambda.amazonaws.com',
                         },
-                        {
-                            Action: 'sts:AssumeRole',
-                            Principal: {
-                                Service: 'ecs-tasks.amazonaws.com',
-                            },
-                            Effect: 'Allow',
+                        Effect: 'Allow',
+                        Sid: '',
+                    },
+                    {
+                        Action: 'sts:AssumeRole',
+                        Principal: {
+                            Service: 'ecs-tasks.amazonaws.com',
                         },
-                        {
-                            Action: 'sts:AssumeRole',
-                            Principal: {
-                                Service: 'tasks.apprunner.amazonaws.com',
-                            },
-                            Effect: 'Allow',
+                        Effect: 'Allow',
+                    },
+                    {
+                        Action: 'sts:AssumeRole',
+                        Principal: {
+                            Service: 'tasks.apprunner.amazonaws.com',
                         },
-                    ],
-                },
-            }
-        )
+                        Effect: 'Allow',
+                    },
+                ],
+            },
+        })
         // https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs.html#monitoring-cloudwatchlogs-prereqs
         new aws.iam.RolePolicyAttachment(`${this.name}-${execUnitPhysicalName}-lambdabasic`, {
             role: lambdaExecRole,
@@ -836,9 +865,11 @@ export class CloudCCLib {
         const lambdaNames = execUnitNames.map((n) => `${this.name}-${n}`)
 
         const warmerRole = this.createRoleForName(name)
-
+        const warmerFuncName = sanitized(AwsSanitizer.Lambda.lambdaFunction.nameValidation())`${h(
+            this.name
+        )}-lambdawarmer`
         let warmerLambda = new aws.lambda.CallbackFunction(name, {
-            name: `${this.name}-lambdaWarmer`,
+            name: warmerFuncName,
             memorySize: 128 /*MB*/,
             timeout: 60,
             runtime: 'nodejs14.x',
@@ -886,13 +917,18 @@ export class CloudCCLib {
             aws.cloudwatch.onSchedule('warmUpLambda', 'cron(0/5 * * * ? *)', warmUpLambda)
     }
 
-    public scheduleFunction(execGroupName, moduleName, functionName, cronExpression) {
+    public scheduleFunction(execUnitName, moduleName, functionName, cronExpression) {
+        const execGroupName = `${this.name}/${execUnitName}`
         const key = sha256.sync(cronExpression).slice(0, 5)
         const name = `${execGroupName}.${functionName}:${key}`
         const scheduleRole = this.createRoleForName(name)
 
+        const schedulerFuncName = sanitized(
+            AwsSanitizer.Lambda.lambdaFunction.nameValidation()
+        )`${h(this.name)}/${h(execUnitName)}_${h(functionName)}-${key}`
+
         let lambdaScheduler = new aws.lambda.CallbackFunction(name, {
-            name: `${this.name}-${execGroupName}_${functionName}-${key}`,
+            name: schedulerFuncName,
             memorySize: 128 /*MB*/,
             timeout: 300,
             runtime: 'nodejs14.x',
@@ -929,15 +965,22 @@ export class CloudCCLib {
             })
         }
 
-        let cloudwatchLogs = new aws.cloudwatch.LogGroup(`${name}-function-api-lg`, {
-            name: pulumi.interpolate`/aws/lambda/${lambdaScheduler.id}`,
+        let cloudwatchLogs = new aws.cloudwatch.LogGroup(`${name}`, {
+            name: lambdaScheduler.id.apply(
+                (id) =>
+                    sanitized(AwsSanitizer.CloudWatch.logGroup.nameValidation())`/aws/lambda/${h(
+                        name
+                    )}-function-api-lg`
+            ),
             retentionInDays: 1,
         })
 
         const schedulerLambda: aws.cloudwatch.EventRuleEventHandler = lambdaScheduler
         const warmUpLambdaSchedule: aws.cloudwatch.EventRuleEventSubscription =
             aws.cloudwatch.onSchedule(
-                `${execGroupName}_${functionName}_act`,
+                sanitized(AwsSanitizer.EventBridge.rule.nameValidation())`${h(execGroupName)}_${h(
+                    functionName
+                )}_act`,
                 `cron(${cronExpression})`,
                 schedulerLambda
             )
@@ -945,6 +988,8 @@ export class CloudCCLib {
 
     public setupSecrets(secrets: string[]) {
         for (const secret of secrets) {
+            const secretName = `${this.name}-${secret}`
+            validate(secretName, AwsSanitizer.SecretsManager.secret.nameValidation())
             let awsSecret: aws.secretsmanager.Secret
             if (this.secrets.has(secret)) {
                 awsSecret = this.secrets.get(secret)!
@@ -952,7 +997,7 @@ export class CloudCCLib {
                 awsSecret = new aws.secretsmanager.Secret(
                     `${secret}`,
                     {
-                        name: `${this.name}-${secret}`,
+                        name: secretName,
                         recoveryWindowInDays: 0,
                     },
                     { protect: this.protect }
@@ -990,7 +1035,10 @@ export class CloudCCLib {
 
     public setupRDS(orm: string, args: Partial<aws.rds.InstanceArgs>) {
         if (!this.subnetGroup) {
-            this.subnetGroup = new aws.rds.SubnetGroup(this.name, {
+            const subnetGroupName = sanitized(AwsSanitizer.RDS.dbSubnetGroup.nameValidation())`${h(
+                this.name
+            )}`
+            this.subnetGroup = new aws.rds.SubnetGroup(subnetGroupName, {
                 subnetIds: this.privateSubnetIds,
                 tags: {
                     Name: 'Klotho DB subnet group',
@@ -998,12 +1046,15 @@ export class CloudCCLib {
             })
         }
 
-        const dbName = orm.toLowerCase()
+        const dbName = sanitized(
+            AwsSanitizer.RDS.engine.pg.database.nameValidation()
+        )`${orm.toLowerCase()}`
         const config = new pulumi.Config()
         const username = config.require(`${dbName}_username`)
         const password = config.requireSecret(`${dbName}_password`)
 
         // create the db resources
+        validate(dbName, AwsSanitizer.RDS.instance.nameValidation())
         const rds = new aws.rds.Instance(
             dbName,
             {
@@ -1022,9 +1073,10 @@ export class CloudCCLib {
 
         // setup secrets for the proxy
         const secretName = `${dbName}_secret`
-
+        const ssmSecretName = `${this.name}-${secretName}`
+        validate(ssmSecretName, AwsSanitizer.SecretsManager.secret.nameValidation())
         let rdsSecret = new aws.secretsmanager.Secret(`${secretName}`, {
-            name: `${this.name}-${secretName}`,
+            name: ssmSecretName,
             recoveryWindowInDays: 0,
         })
 
@@ -1061,8 +1113,11 @@ export class CloudCCLib {
             }
         })
 
+        // prettier-ignore
+        const ormRoleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(dbName)}-ormsecretrole`
         //setup role for proxy
         const role = new aws.iam.Role(`${dbName}-ormsecretrole`, {
+            name: ormRoleName,
             assumeRolePolicy: {
                 Version: '2012-10-17',
                 Statement: [
@@ -1077,7 +1132,9 @@ export class CloudCCLib {
             },
         })
 
-        const policy = new aws.iam.Policy(`${dbName}-ormsecretpolicy`, {
+        // prettier-ignore
+        const ormPolicyName = sanitized(AwsSanitizer.IAM.policy.nameValidation())`${h(dbName)}-ormsecretpolicy`
+        const policy = new aws.iam.Policy(ormPolicyName, {
             description: 'klotho orm secret policy',
             policy: {
                 Version: '2012-10-17',
@@ -1097,7 +1154,8 @@ export class CloudCCLib {
         })
 
         // setup the rds proxy
-        const proxy = new aws.rds.Proxy(`${dbName}`, {
+        const proxyName = sanitized(AwsSanitizer.RDS.dbProxy.nameValidation())`${h(dbName)}`
+        const proxy = new aws.rds.Proxy(proxyName, {
             debugLogging: false,
             engineFamily: 'POSTGRESQL',
             idleClientTimeout: 1800,
@@ -1268,8 +1326,9 @@ export class CloudCCLib {
     }
 
     createRoleForName(name: string): aws.iam.Role {
-        const role: aws.iam.Role = this.createExecutionRole(name)
-        this.execUnitToRole.set(name, role)
+        const roleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${name}`
+        const role: aws.iam.Role = this.createExecutionRole(roleName)
+        this.execUnitToRole.set(roleName, role)
         return role
     }
 
@@ -1294,17 +1353,22 @@ export class CloudCCLib {
         this.privateDnsNamespace = new aws.servicediscovery.PrivateDnsNamespace(
             `${this.name}-privateDns`,
             {
-                name: `${this.name}-privateDns`,
+                name: sanitized(
+                    AwsSanitizer.ServiceDiscovery.privateDnsNamespace.nameValidation()
+                )`${h(this.name)}-privateDns`,
                 description: 'Used for service discovery',
                 vpc: this.klothoVPC.id,
             }
         )
 
-        this.cluster = new awsx.ecs.Cluster(`${this.name}-cluster`, {
-            vpc: this.klothoVPC,
-            cluster: providedClustername,
-            securityGroups: [], // otherwise, awsx creates a default one with 0.0.0.0/0. See #314
-        })
+        this.cluster = new awsx.ecs.Cluster(
+            sanitized(AwsSanitizer.ECS.cluster.nameValidation())`${h(this.name)}-cluster`,
+            {
+                vpc: this.klothoVPC,
+                cluster: providedClustername,
+                securityGroups: [], // otherwise, awsx creates a default one with 0.0.0.0/0. See #314
+            }
+        )
     }
 
     createEksResources = async (
@@ -1312,7 +1376,9 @@ export class CloudCCLib {
         charts?: HelmChart[],
         lbPlugin?: LoadBalancerPlugin
     ) => {
-        let clusterName = `${this.name}-eks-cluster`
+        let clusterName = sanitized(AwsSanitizer.EKS.cluster.nameValidation())`${h(
+            this.name
+        )}-eks-cluster`
         const providedClustername = kloConfig.get<string>('eks-cluster')
         const existingCluster = undefined
         for (const execUnit of execUnits) {
@@ -1404,7 +1470,10 @@ export class CloudCCLib {
             this.execUnitToVpcLink.set(execUnitName, vpcLink)
         }
 
-        const logGroupName = `/aws/fargate/${this.name}-${execUnitName}-task`
+        const logGroupName = sanitized(
+            AwsSanitizer.CloudWatch.logGroup.nameValidation()
+        )`/aws/fargate/${h(this.name)}-${h(execUnitName)}-task`
+
         let cloudwatchGroup = new aws.cloudwatch.LogGroup(`${this.name}-${execUnitName}-lg`, {
             name: `${logGroupName}`,
             retentionInDays: 1,
@@ -1436,7 +1505,9 @@ export class CloudCCLib {
 
         const task = new awsx.ecs.FargateTaskDefinition(`${execUnitName}-task`, {
             logGroup: cloudwatchGroup,
-            family: `${execUnitName}-family`,
+            family: sanitized(AwsSanitizer.ECS.taskDefinition.familyValidation())`${h(
+                execUnitName
+            )}-family`,
             executionRole: role,
             taskRole: role,
             container: {
@@ -1478,6 +1549,9 @@ export class CloudCCLib {
         const service = new awsx.ecs.FargateService(
             `${execUnitName}-service`,
             {
+                name: sanitized(AwsSanitizer.ECS.service.nameValidation())`${h(
+                    execUnitName
+                )}-service}`,
                 cluster: this.cluster,
                 taskDefinition: task,
                 desiredCount: 1,
@@ -1500,7 +1574,9 @@ export class CloudCCLib {
     ) => {
         if (type === 'elasticache') {
             const subnetGroup = new aws.elasticache.SubnetGroup(
-                `${this.name}-${name}-subnetgroup`.replace('_', '-').toLocaleLowerCase(),
+                sanitized(
+                    AwsSanitizer.Elasticache.cacheSubnetGroup.cacheSubnetGroupNameValidation()
+                )`${h(this.name)}-${h(name)}-subnetgroup`,
                 {
                     subnetIds: this.privateSubnetIds,
                     tags: {
@@ -1549,7 +1625,9 @@ export class CloudCCLib {
             }
 
             const subnetGroup = new aws.memorydb.SubnetGroup(
-                `${this.name}-${name}-subnetgroup`.replace('_', '-').toLocaleLowerCase(),
+                sanitized(AwsSanitizer.MemoryDB.subnetGroup.subnetGroupNameValidation())`${
+                    this.name
+                }-${h(name)}-subnetgroup`,
                 {
                     subnetIds: subnets,
                     tags: {

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -1444,17 +1444,25 @@ export class CloudCCLib {
 
         let nlb
         if (needsLoadBalancer) {
-            nlb = new awsx.lb.NetworkLoadBalancer(`${execUnitName}-nlb`, {
-                external: false,
-                vpc: this.klothoVPC,
-                subnets: this.privateSubnetIds,
-            })
+            nlb = new awsx.lb.NetworkLoadBalancer(
+                sanitized(AwsSanitizer.ELB.loadBalancer.nameValidation())`${h(execUnitName)}-nlb`,
+                {
+                    external: false,
+                    vpc: this.klothoVPC,
+                    subnets: this.privateSubnetIds,
+                }
+            )
             this.execUnitToNlb.set(execUnitName, nlb)
 
             const targetGroup: awsx.elasticloadbalancingv2.NetworkTargetGroup =
-                nlb.createTargetGroup(`${execUnitName}-tg`, {
-                    port: 3000,
-                })
+                nlb.createTargetGroup(
+                    sanitized(AwsSanitizer.ELB.targetGroup.nameValidation())`${h(
+                        execUnitName
+                    )})-tg`,
+                    {
+                        port: 3000,
+                    }
+                )
 
             const listener = targetGroup.createListener(`${execUnitName}-listener`, {
                 port: 80,
@@ -1483,8 +1491,11 @@ export class CloudCCLib {
             additionalEnvVars.push({ name, value })
         }
 
-        const discoveryService = new aws.servicediscovery.Service(execUnitName, {
-            name: execUnitName,
+        const serviceName = sanitized(AwsSanitizer.ServiceDiscovery.service.nameValidation())`${h(
+            execUnitName
+        )}`
+        const discoveryService = new aws.servicediscovery.Service(serviceName, {
+            name: serviceName,
             dnsConfig: {
                 namespaceId: this.privateDnsNamespace.id,
                 dnsRecords: [

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -10,7 +10,7 @@ import * as crypto from 'crypto'
 import { setupElasticacheCluster } from './iac/elasticache'
 import * as analytics from './iac/analytics'
 
-import { h, sanitized, validate } from './iac/sanitization/sanitizer'
+import { hash as h, sanitized, validate } from './iac/sanitization/sanitizer'
 import { LoadBalancerPlugin } from './iac/load_balancing'
 import { DefaultEksClusterOptions, Eks, EksExecUnit, HelmChart } from './iac/eks'
 import { setupMemoryDbCluster } from './iac/memorydb'

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -1403,8 +1403,7 @@ export class CloudCCLib {
             this,
             execUnits,
             charts || [],
-            existingCluster,
-            lbPlugin
+            existingCluster
         )
     }
 

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -964,13 +964,12 @@ export class CloudCCLib {
                 Resource: [this.execUnitToFunctions.get(execGroupName)!.arn],
             })
         }
-
-        let cloudwatchLogs = new aws.cloudwatch.LogGroup(`${name}`, {
+        let cloudwatchLogs = new aws.cloudwatch.LogGroup(`${name}-function-api-lg`, {
             name: lambdaScheduler.id.apply(
                 (id) =>
                     sanitized(AwsSanitizer.CloudWatch.logGroup.nameValidation())`/aws/lambda/${h(
-                        name
-                    )}-function-api-lg`
+                        id
+                    )}`
             ),
             retentionInDays: 1,
         })
@@ -1116,8 +1115,7 @@ export class CloudCCLib {
         // prettier-ignore
         const ormRoleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(dbName)}-ormsecretrole`
         //setup role for proxy
-        const role = new aws.iam.Role(`${dbName}-ormsecretrole`, {
-            name: ormRoleName,
+        const role = new aws.iam.Role(ormRoleName, {
             assumeRolePolicy: {
                 Version: '2012-10-17',
                 Statement: [

--- a/pkg/infra/pulumi_aws/files.go
+++ b/pkg/infra/pulumi_aws/files.go
@@ -6,7 +6,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/templateutils"
 )
 
-//go:embed *.tmpl *.ts *.json iac/*.ts iac/k8s/*
+//go:embed *.tmpl *.ts *.json iac/*.ts iac/k8s/* iac/sanitization/*
 var files embed.FS
 
 var index = templateutils.MustTemplate(files, "index.ts.tmpl")

--- a/pkg/infra/pulumi_aws/iac/elasticache.ts
+++ b/pkg/infra/pulumi_aws/iac/elasticache.ts
@@ -1,7 +1,8 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
-import { PulumiFn } from '@pulumi/pulumi/automation'
-import { Resource, CloudCCLib } from '../deploylib'
+import { Resource } from '../deploylib'
+import * as validators from './sanitization/aws/elasticache'
+import { sanitized } from './sanitization/sanitizer'
 
 const ELASTICACHE_ENGINE = 'redis'
 
@@ -46,7 +47,10 @@ export const setupElasticacheCluster = (
         retentionInDays: 0,
     })
 
-    const clusterName = sanitizeClusterName(appName, dbName)
+    // TODO: look into removing sanitizeClusterName when making other breaking changes to resource names
+    const clusterName = sanitized(
+        validators.cacheCluster.cacheClusterIdValidation()
+    )`${sanitizeClusterName(appName, dbName)}`
     // create the db resources
     const redis = new aws.elasticache.Cluster(
         clusterName,

--- a/pkg/infra/pulumi_aws/iac/load_balancing.ts
+++ b/pkg/infra/pulumi_aws/iac/load_balancing.ts
@@ -8,7 +8,7 @@ import {
     TargetGroupAttachmentArgs,
 } from '@pulumi/aws/lb'
 import { ListenerRuleArgs } from '@pulumi/aws/alb'
-import { h, sanitized } from './sanitization/sanitizer'
+import { hash as h, sanitized } from './sanitization/sanitizer'
 import { CloudCCLib } from '../deploylib'
 
 export interface Route {

--- a/pkg/infra/pulumi_aws/iac/load_balancing.ts
+++ b/pkg/infra/pulumi_aws/iac/load_balancing.ts
@@ -1,3 +1,4 @@
+import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 import * as validators from './sanitization/aws/elb'
 import {

--- a/pkg/infra/pulumi_aws/iac/memorydb.ts
+++ b/pkg/infra/pulumi_aws/iac/memorydb.ts
@@ -1,6 +1,8 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import { Resource } from '../deploylib'
+import { sanitized } from './sanitization/sanitizer'
+import { cacheCluster } from './sanitization/aws/memorydb'
 
 const sanitizeClusterName = (appName: string, dbName: string): string => {
     let cluster = `${appName}-${dbName}`
@@ -37,7 +39,11 @@ export const setupMemoryDbCluster = (
     securityGroupIds: pulumi.Output<string>[],
     appName: string
 ) => {
-    const clusterName = sanitizeClusterName(appName, dbName)
+    // TODO: look into removing sanitizeClusterName when making other breaking changes to resource names
+    const clusterName = sanitized(cacheCluster.clusterNameValidation())`${sanitizeClusterName(
+        appName,
+        dbName
+    )}`
     const memdbCluster = new aws.memorydb.Cluster(
         clusterName,
         {

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/app_runner.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/app_runner.ts
@@ -1,0 +1,11 @@
+import { regexpMatch } from '../sanitizer'
+
+export const service = {
+    nameValidation() {
+        return {
+            minLength: 4,
+            maxLength: 40,
+            rules: [regexpMatch('', /^[\w-]+$/, (n) => n.replace(/[^\w-]/g, '-'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/cloud_watch.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/cloud_watch.ts
@@ -1,0 +1,17 @@
+import { regexpMatch } from '../sanitizer'
+
+export const logGroup = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 512,
+            rules: [
+                regexpMatch(
+                    "Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), '.' (period), and '#' (number sign).",
+                    /^[-._/#A-Za-z\d]+$/,
+                    (n) => n.replace(/[^-._/#A-Za-z\d]/g, '_')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
@@ -1,0 +1,33 @@
+import { regexpMatch } from '../sanitizer'
+
+export const tag = {
+    keyValidation() {
+        return {
+            minLength: 1,
+            maxLength: 128,
+            rules: [
+                regexpMatch('', /^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$/u, (n) =>
+                    n.replace(/[\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
+                ),
+            ],
+        }
+    },
+
+    valueValidation() {
+        return {
+            minLength: 0,
+            maxLength: 256,
+            rules: [
+                regexpMatch('', /^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$/u, (n) =>
+                    n.replace(/[\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
+                ),
+                {
+                    description:
+                        "The aws: prefix is prohibited for tags; it's reserved for AWS use.",
+                    apply: (v) => !v.startsWith('aws:'),
+                    fix: (v) => v.replace(/^aws:/, ''),
+                },
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
@@ -23,7 +23,7 @@ export const tag = {
                 ),
                 {
                     description:
-                        "The aws: prefix is prohibited for tags; it's reserved for AWS use.",
+                        "The \"aws:\" prefix is prohibited for tags; it's reserved for AWS use.",
                     apply: (v) => !v.startsWith('aws:'),
                     fix: (v) => v.replace(/^aws:/, ''),
                 },

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
@@ -23,7 +23,7 @@ export const tag = {
                 ),
                 {
                     description:
-                        "The \"aws:\" prefix is prohibited for tags; it's reserved for AWS use.",
+                        'The "aws:" prefix is prohibited for tags; it\'s reserved for AWS use.',
                     apply: (v) => !v.startsWith('aws:'),
                     fix: (v) => v.replace(/^aws:/, ''),
                 },

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/common.ts
@@ -7,7 +7,7 @@ export const tag = {
             maxLength: 128,
             rules: [
                 regexpMatch('', /^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$/u, (n) =>
-                    n.replace(/[\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
+                    n.replace(/[^\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
                 ),
             ],
         }
@@ -19,7 +19,7 @@ export const tag = {
             maxLength: 256,
             rules: [
                 regexpMatch('', /^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$/u, (n) =>
-                    n.replace(/[\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
+                    n.replace(/[^\p{L}\p{Z}\p{N}_.:/=+\-@]/gu, '_')
                 ),
                 {
                     description:

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/dynamodb.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/dynamodb.ts
@@ -1,0 +1,13 @@
+import { regexpMatch } from '../sanitizer'
+
+export const table = {
+    nameValidation() {
+        return {
+            minLength: 3,
+            maxLength: 255,
+            rules: [
+                regexpMatch('', /^[a-zA-Z0-9_.-]+$/, (n) => n.replace(/[^a-zA-Z0-9_.-]/g, '_')),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/ec2.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/ec2.ts
@@ -1,0 +1,40 @@
+import { regexpMatch } from '../sanitizer'
+
+export const vpc = {
+    securityGroup: {
+        nameValidation() {
+            return {
+                minLength: 1,
+                maxLength: 255,
+                rules: [
+                    regexpMatch(
+                        'a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*',
+                        /^[\w -.:/()#,@\[\]+=&;{}!$*]+$/,
+                        (s) => s.replace(/[^\w -.:/()#,@\[\]+=&;{}!$*]/g, '_')
+                    ),
+                ],
+            }
+        },
+    },
+}
+
+export const classic = {
+    securityGroup: {
+        nameValidation() {
+            return {
+                minLength: 1,
+                maxLength: 255,
+                rules: [
+                    regexpMatch('Must only containASCII characters', /^[[:ascii:]]+$/, (s) =>
+                        s.replace(/[^[:ascii:]]/g, '_')
+                    ),
+                    {
+                        description: "Cannot start with 'sg-'",
+                        validate: (s) => !s.startsWith('sg-'),
+                        fix: (s) => s.substring(3),
+                    },
+                ],
+            }
+        },
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/ecs.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/ecs.ts
@@ -1,0 +1,31 @@
+import { regexpMatch } from '../sanitizer'
+
+export const cluster = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [regexpMatch('', /^[\w-]+$/, (s) => s.replace(/[^\w-]/g, '_'))],
+        }
+    },
+}
+
+export const taskDefinition = {
+    familyValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [regexpMatch('', /^[\w-]+$/, (s) => s.replace(/[^\w-]/g, '_'))],
+        }
+    },
+}
+
+export const service = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [regexpMatch('', /^[\w-]+$/, (s) => s.replace(/[^\w-]/g, '_'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/eks.ts
@@ -1,0 +1,20 @@
+import { regexpMatch } from '../sanitizer'
+
+export const cluster = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 100,
+            rules: [
+                regexpMatch(
+                    'The name can contain only alphanumeric characters (case-sensitive) and hyphens.',
+                    /^[a-zA-Z\d-]+$/,
+                    (s) => s.replace(/[^a-zA-Z\d-]/g, '_')
+                ),
+                regexpMatch('The name must start with an alphabetic character', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/elasticache.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/elasticache.ts
@@ -1,0 +1,50 @@
+import { regexpMatch, regexpNotMatch } from '../sanitizer'
+
+export const cacheCluster = {
+    cacheClusterIdValidation() {
+        return {
+            minLength: 1,
+            maxLength: 50,
+            rules: [
+                regexpMatch('', /[a-zA-Z0-9-]/, (s) => s.replace(/[^a-zA-Z0-9-]/g, '-')),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+            ],
+        }
+    },
+}
+export const cacheSubnetGroup = {
+    cacheSubnetGroupNameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [
+                regexpMatch(
+                    '',
+                    /^[a-z\d-]+$/, // uppercase is technically valid, but AWS will convert the value to lowercase
+                    (s) => s.toLocaleLowerCase().replace(/[^a-z\d-]/g, '-')
+                ),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
@@ -1,0 +1,58 @@
+import { regexpMatch } from '../sanitizer'
+
+export const loadBalancer = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 32,
+            rules: [
+                regexpMatch(
+                    'The name can contain only alphanumeric characters and hyphens.',
+                    /^[a-zA-Z\d-]+$/,
+                    (s) => s.replace(/[^a-zA-Z\d-]/g, '_')
+                ),
+                {
+                    description: 'The name must not begin with a hyphen',
+                    validate: (s) => !s.startsWith('-'),
+                    fix: (s) => s.replace(/^-/, ''),
+                },
+                {
+                    description: 'The name must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-$/, ''),
+                },
+                {
+                    description: "The name must start with 'internal-'",
+                    validate: (s) => !s.startsWith('internal-'),
+                    fix: (s) => s.replace(/^internal-/, ''),
+                },
+            ],
+        }
+    },
+}
+
+export const targetGroup = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 32,
+            rules: [
+                regexpMatch(
+                    'The name can contain only alphanumeric characters and hyphens.',
+                    /^[a-zA-Z\d-]+$/,
+                    (s) => s.replace(/[^a-zA-Z\d-]/g, '_')
+                ),
+                {
+                    description: 'The name must not begin with a hyphen',
+                    validate: (s) => !s.startsWith('-'),
+                    fix: (s) => s.replace(/^-/, ''),
+                },
+                {
+                    description: 'The name must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-$/, ''),
+                },
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
@@ -45,12 +45,12 @@ export const targetGroup = {
                 {
                     description: 'The name must not begin with a hyphen',
                     validate: (s) => !s.startsWith('-'),
-                    fix: (s) => s.replace(/^-/, ''),
+                    fix: (s) => s.replace(/^-+/, ''),
                 },
                 {
                     description: 'The name must not end with a hyphen',
                     validate: (s) => !s.endsWith('-'),
-                    fix: (s) => s.replace(/-$/, ''),
+                    fix: (s) => s.replace(/-+$/, ''),
                 },
             ],
         }

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/eventbridge.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/eventbridge.ts
@@ -1,0 +1,11 @@
+import { regexpMatch } from '../sanitizer'
+
+export const rule = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 64,
+            rules: [regexpMatch('', /^[\w-.]+$/, (n) => n.replace(/[^\w-.]/g, '_'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/iam.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/iam.ts
@@ -1,0 +1,21 @@
+import { regexpMatch } from '../sanitizer'
+
+export const role = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 64,
+            rules: [regexpMatch('', /^[\w+=,.@-]+$/, (s) => s.replace(/[^\w+=,.@-]/g, '_'))],
+        }
+    },
+}
+
+export const policy = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 128,
+            rules: [regexpMatch('', /^[\w+=,.@-]+$/, (s) => s.replace(/[^\w+=,.@-]/g, '_'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/index.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/index.ts
@@ -1,0 +1,39 @@
+import * as AppRunner from './app_runner'
+import * as CloudWatch from './cloud_watch'
+import * as Common from './common'
+import * as DynamoDB from './dynamodb'
+import * as EC2 from './ec2'
+import * as ECS from './ecs'
+import * as EKS from './eks'
+import * as Elasticache from './elasticache'
+import * as ELB from './elb'
+import * as EventBridge from './eventbridge'
+import * as IAM from './iam'
+import * as Lambda from './lambda'
+import * as MemoryDB from './memorydb'
+import * as RDS from './rds'
+import * as S3 from './s3'
+import * as SecretsManager from './secrets_manager'
+import * as ServiceDiscovery from './service_discovery'
+import * as SNS from './sns'
+
+export default {
+    AppRunner,
+    CloudWatch,
+    Common,
+    DynamoDB,
+    EC2,
+    ECS,
+    EKS,
+    Elasticache,
+    ELB,
+    EventBridge,
+    IAM,
+    Lambda,
+    MemoryDB,
+    RDS,
+    S3,
+    SecretsManager,
+    ServiceDiscovery,
+    SNS,
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/lambda.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/lambda.ts
@@ -1,0 +1,11 @@
+import { regexpMatch } from '../sanitizer'
+
+export const lambdaFunction = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 64,
+            rules: [regexpMatch('', /^[\w-]+$/, (s) => s.replace(/[^\w-]/g, '_'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/memorydb.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/memorydb.ts
@@ -1,0 +1,52 @@
+import { regexpMatch, regexpNotMatch } from '../sanitizer'
+
+export const cacheCluster = {
+    clusterNameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 40,
+            rules: [
+                regexpMatch('', /[a-zA-Z0-9-]/, (s) => s.replace(/[^a-zA-Z0-9-]/g, '-')),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+            ],
+        }
+    },
+}
+
+// subnetGroupNameValidation are not documented and are inferred from Elasticache's CacheSubnetGroupName
+export const subnetGroup = {
+    subnetGroupNameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [
+                regexpMatch(
+                    '',
+                    /^[a-z\d-]+$/, // uppercase is technically valid, but AWS will convert the value to lowercase
+                    (s) => s.toLocaleLowerCase().replace(/[^a-z\d-]/g, '-')
+                ),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
@@ -1,0 +1,79 @@
+import { regexpMatch } from '../sanitizer'
+
+export const dbSubnetGroup = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 255,
+            rules: [
+                regexpMatch('', /^[\w -.]+$/, (s) => s.replace(/[^\w -.]/g, '_')),
+                regexpMatch('Name must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+                {
+                    description: "Name must not be 'default'",
+                    validate: (s) => s.toLowerCase() !== 'default',
+                },
+            ],
+        }
+    },
+}
+
+export const engine = {
+    pg: {
+        database: {
+            nameValidation() {
+                return {
+                    minLength: 1,
+                    maxLength: 63,
+                    rules: [],
+                }
+            },
+        },
+    },
+}
+
+export const dbProxy = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            rules: [
+                regexpMatch('', /^[\da-zA-Z-]+$/, (s) => s.replace(/[^\da-zA-Z-]/g, '-')),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+            ],
+        }
+    },
+}
+
+export const instance = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 63,
+            rules: [
+                regexpMatch('', /^[\da-zA-Z-]+$/, (s) => s.replace(/[^\da-zA-Z-]/g, '-')),
+                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
+                    s.replace(/^[^a-zA-Z]+/, '')
+                ),
+                {
+                    description: 'Identifier must not end with a hyphen',
+                    validate: (s) => !s.endsWith('-'),
+                    fix: (s) => s.replace(/-+$/, ''),
+                },
+                regexpMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                    s.replace(/--+/g, '-')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
@@ -1,4 +1,4 @@
-import { regexpMatch } from '../sanitizer'
+import { regexpMatch, regexpNotMatch } from '../sanitizer'
 
 export const dbSubnetGroup = {
     nameValidation() {
@@ -47,7 +47,7 @@ export const dbProxy = {
                     validate: (s) => !s.endsWith('-'),
                     fix: (s) => s.replace(/-+$/, ''),
                 },
-                regexpMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
                     s.replace(/--+/g, '-')
                 ),
             ],
@@ -70,7 +70,7 @@ export const instance = {
                     validate: (s) => !s.endsWith('-'),
                     fix: (s) => s.replace(/-+$/, ''),
                 },
-                regexpMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
+                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
                     s.replace(/--+/g, '-')
                 ),
             ],

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/s3.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/s3.ts
@@ -1,0 +1,42 @@
+import { regexpMatch, regexpNotMatch, SanitizationOptions } from '../sanitizer'
+
+export const bucket = {
+    nameValidation(): SanitizationOptions {
+        return {
+            minLength: 3,
+            maxLength: 63,
+            rules: [
+                regexpMatch(
+                    'Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).',
+                    /^[a-z\d.-]+$/,
+                    (n) => n.toLowerCase().replace(/[^a-z\d-.]+/g, '-')
+                ),
+                {
+                    description: 'Bucket names must not start with the prefix "xn--".',
+                    validate: (n) => !n.startsWith('xn--'),
+                    fix: (n) => n.replace(/^xn--/, ''),
+                },
+                {
+                    description: 'Bucket names must not end with the suffix "-s3alias".',
+                    validate: (n) => !n.endsWith('-s3alias'),
+                    fix: (n) => n.replace(/-s3alias$/, ''),
+                },
+                regexpMatch(
+                    'Bucket names must begin and end with a letter or number.',
+                    /^[a-z\d].+[a-z\d]$/,
+                    (n) => n.replace(/^[^a-zA-Z\d]+/, '').replace(/[^a-zA-Z\d]+$/g, '')
+                ),
+                {
+                    description: 'Bucket names must not contain two adjacent periods.',
+                    validate: (n) => !n.includes('..'),
+                    fix: (n) => n.replaceAll('..', '.'),
+                },
+                regexpNotMatch(
+                    'Bucket names must not be formatted as an IP address.',
+                    /^(?:\d{1,3}\.){3}\d{1,3}$/,
+                    (n) => n.replaceAll('.', '-')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/secrets_manager.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/secrets_manager.ts
@@ -1,0 +1,11 @@
+import { regexpMatch } from '../sanitizer'
+
+export const secret = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 512,
+            rules: [regexpMatch('', /^[\w/+=.@-]+$/, (n) => n.replace(/[^\w/+=.@-]/g, '_'))],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/service_discovery.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/service_discovery.ts
@@ -1,0 +1,34 @@
+import { regexpMatch, regexpNotMatch, SanitizationOptions } from '../sanitizer'
+
+export const privateDnsNamespace = {
+    nameValidation(): SanitizationOptions {
+        return {
+            minLength: 1,
+            maxLength: 253,
+            rules: [regexpMatch('', /^[!-~]+$/, (s) => s.replace(/[^!-~]/g, '_'))],
+        }
+    },
+}
+
+export const service = {
+    nameValidation(): SanitizationOptions {
+        return {
+            minLength: 1,
+            maxLength: 127,
+            rules: [
+                regexpMatch(
+                    '',
+                    /((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(\.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^\.$)/
+                ),
+                regexpMatch(
+                    'Name can only contain alphanumeric characters, underscores, hyphens, and periods',
+                    /^[\w.-]$/,
+                    (s) => s.replace(/[^\w.-]/g, '_')
+                ),
+                regexpNotMatch('Name component must not start with a hyphen', /(^-)|(\.-)/, (s) =>
+                    s.replace(/(^-+)|((?<=\.)-+)/g, '')
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/sns.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/sns.ts
@@ -1,0 +1,33 @@
+import { regexpMatch } from '../sanitizer'
+
+export const topic = {
+    nameValidation() {
+        return {
+            minLength: 1,
+            maxLength: 256,
+            rules: [regexpMatch('', /^[\w-]+$/, (s) => s.replace(/[^\w-]/g))],
+        }
+    },
+}
+
+export const fifoTopic = {
+    nameValidation() {
+        return {
+            minLength: 6,
+            maxLength: 256,
+            rules: [
+                regexpMatch(
+                    "The FIFO topic name must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must end with the '.fifo' suffix",
+                    /^[\w-]{1,251}\.fifo$/,
+                    (s) => {
+                        if (!s.endsWith('.fifo')) {
+                            s = s.substring(0, s.length - 6)
+                        }
+                        s = `${s.replace(/[^\w-]/g, '-')}.fifo`
+                        return s
+                    }
+                ),
+            ],
+        }
+    },
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
@@ -33,7 +33,7 @@ export function sanitize(s: string, options: Partial<SanitizationOptions>): Sani
         failedRules?.forEach((f) => console.debug(f))
         if (options.minLength != null && result.length < options.minLength) {
             throw new Error(
-                `The sanitized value, "${result}", is shorten than minLength: ${options.minLength}`
+                `The sanitized value, "${result}", is shorter than minLength: ${options.minLength}`
             )
         }
         if (options.maxLength != null && result.length > options.maxLength) {

--- a/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
@@ -1,0 +1,197 @@
+import Multimap = require('multimap')
+import * as sha256 from 'simple-sha256'
+
+export interface SanitizationOptions {
+    maxLength?: number
+    minLength?: number
+    rules: Array<SanitizationRule>
+    maxPasses?: number
+}
+
+export interface SanitizationResult {
+    result: string
+    violations: Array<string>
+}
+
+export interface SanitizationRule extends ValidationRule {
+    fix?: FixFunc
+}
+
+type FixFunc = (string) => string
+
+export interface ValidationRule {
+    description: string
+
+    validate(string): boolean
+}
+
+export function sanitize(s: string, options: Partial<SanitizationOptions>): SanitizationResult {
+    let result = s
+    let failedRules = new Array<SanitizationRule>()
+    for (let i = 0; i < (options.maxPasses || 5); i++) {
+        let failedRules = options.rules?.filter((r) => !r.validate(result))
+        failedRules?.forEach((f) => console.debug(f))
+        if (options.minLength != null && result.length < options.minLength) {
+            throw new Error(
+                `The sanitized value, "${result}", is shorten than minLength: ${options.minLength}`
+            )
+        }
+        if (options.maxLength != null && result.length > options.maxLength) {
+            result = result.substring(0, options.maxLength)
+        }
+        if (failedRules?.length === 0) {
+            return { result: result, violations: [] }
+        }
+        failedRules?.forEach((r) => (result = r.fix?.apply(this, [result]) || result))
+        failedRules = options.rules?.filter((r) => !r.validate(result))
+        failedRules?.forEach((f) => console.debug(f))
+        if (failedRules?.length === 0) {
+            return { result, violations: [] }
+        }
+    }
+    return { result, violations: failedRules.map((r) => r.description) }
+}
+
+export function validate(input: string, options: Partial<SanitizationOptions>) {
+    const violations = doValidate(input, options)
+    if (violations.length > 0) {
+        throw new Error(`Invalid input '${input}':\n\t${violations.join('\n\t')}`)
+    }
+}
+
+function doValidate(input: string, options: Partial<SanitizationOptions>): Array<string> {
+    const violations = new Array<string>()
+    if (options.minLength != null && input.length < options.minLength) {
+        violations.push(`Invalid input: "${input}": length < minLength (${options.minLength})`)
+    }
+    if (options.maxLength != null && input.length > options.maxLength) {
+        violations.push(`Invalid input: "${input}": length > maxLength (${options.maxLength})`)
+    }
+
+    violations.push(
+        ...(options.rules
+            ?.filter((r) => !r.validate(input))
+            .map((r) => `validation rule violated: ${r.description}`) || [])
+    )
+    return violations
+}
+
+function hashComponent(input: string, maxLength: number): string {
+    maxLength = maxLength > 5 ? 5 : maxLength
+    const hash = sha256.sync(input)
+    return hash.substring(0, maxLength <= input.length ? maxLength : input.length)
+}
+
+export function regexpMatch(
+    description: string,
+    pattern: RegExp,
+    fix: FixFunc | undefined = undefined
+): SanitizationRule {
+    return {
+        description: description
+            ? description
+            : `The supplied string must match the following pattern: ${pattern.source}`,
+        validate: (input) => pattern.test(input),
+        fix,
+    }
+}
+
+export function regexpNotMatch(
+    input: string,
+    pattern: RegExp,
+    fix: FixFunc | undefined = undefined
+): SanitizationRule {
+    return {
+        description: input,
+        validate: (input) => !pattern.test(input),
+        fix,
+    }
+}
+
+type ShorteningStrategy = (input: string, maxLength: number) => string
+
+export interface Component {
+    content: string
+    priority?: number
+    shorteningStrategy?: ShorteningStrategy
+}
+
+function shortenString(
+    strings: TemplateStringsArray,
+    components: Array<string | Component>,
+    options: SanitizationOptions
+) {
+    const resolvedComponents: Array<Component> = components.map((c) => {
+        return typeof c === 'string' ? { content: c } : { ...c } // clone each component to avoid unintended modification to inputs
+    })
+    let length =
+        arrTextLen([...strings.raw], (s) => s.length) +
+        arrTextLen(resolvedComponents, (a) => a.content.length)
+
+    let componentsByPriority = new Multimap<number, Component>()
+    resolvedComponents.forEach((c) =>
+        componentsByPriority.set(c.priority === undefined ? 100 : c.priority, c)
+    )
+    const sorted = [...componentsByPriority.keys()].sort()
+
+    if (options.maxLength != null) {
+        for (const p of sorted) {
+            if (length <= options.maxLength) {
+                break
+            }
+            for (const c of componentsByPriority.get(p)) {
+                if (length <= options.maxLength) {
+                    break
+                }
+                const oldCLen = c.content.length
+                c.content = c.shorteningStrategy
+                    ? c.shorteningStrategy(
+                          c.content,
+                          options.maxLength - (length - c.content.length)
+                      )
+                    : c.content
+                length -= oldCLen - c.content.length
+            }
+        }
+    }
+
+    let result = ''
+    for (let i = 0; i < strings.length; i++) {
+        result += (strings[i] || '') + (resolvedComponents[i]?.content || '')
+    }
+    return result
+}
+
+export function sanitized(options: SanitizationOptions) {
+    return function (
+        strings: TemplateStringsArray,
+        ...components: Array<string | Component>
+    ): string {
+        const shortenedString = shortenString(strings, components, options)
+        const { result, violations } = sanitize(shortenedString, options)
+        if (violations.length > 0) {
+            throw new Error(`sanitization failed:\n\t${violations.join('\n\t')}`)
+        }
+        return result
+    }
+}
+
+function arrTextLen<T>(arr: Array<T>, lenFunc: (arg0: T) => number): number {
+    return arr.reduce((p, c, i) => p + lenFunc(c), 0)
+}
+
+export function h(content: string, priority: number | undefined = undefined): Component {
+    return {
+        content,
+        priority,
+        shorteningStrategy: hashComponent,
+    }
+}
+
+export function t(content: string, priority: number | undefined = undefined): Component {
+    return {
+        content,
+        priority,
+        shorteningStrategy: (t, m) => t.substring(0, m),
+    }
+}

--- a/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
@@ -104,12 +104,14 @@ export function regexpMatch(
 }
 
 export function regexpNotMatch(
-    input: string,
+    description: string,
     pattern: RegExp,
     fix: FixFunc | undefined = undefined
 ): SanitizationRule {
     return {
-        description: input,
+        description: description
+            ? description
+            : `The supplied string must not match the following pattern: ${pattern.source}`,
         validate: (input) => !pattern.test(input),
         fix,
     }

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -124,7 +124,7 @@ export = async () => {
     keepWarm.push("{{$unit.Name}}");
     {{end}}
     {{range $idx, $s := .Schedules}}
-    cloudLib.scheduleFunction("{{$cfg.AppName}}/{{$unit.Name}}", "{{$s.ModulePath}}", "{{$s.FuncName}}}", "{{$s.Cron}}");
+    cloudLib.scheduleFunction("{{$unit.Name}}", "{{$s.ModulePath}}", "{{$s.FuncName}}}", "{{$s.Cron}}");
     {{end -}}
     {{end -}}
 

--- a/pkg/infra/pulumi_aws/package-lock.json
+++ b/pkg/infra/pulumi_aws/package-lock.json
@@ -16,11 +16,13 @@
                 "@pulumi/pulumi": "^3.40.2",
                 "axios": "^0.27.2",
                 "cdk8s-cli": "^2.1.4",
+                "multimap": "^1.1.0",
                 "patch-package": "^6.4.7",
                 "requestretry": "^7.0.2",
                 "simple-sha256": "^1.1.0"
             },
             "devDependencies": {
+                "@types/multimap": "^1.1.2",
                 "@types/node": "^16.11.64",
                 "@types/uuid": "^8.3.4"
             }
@@ -579,6 +581,12 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+        },
+        "node_modules/@types/multimap": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/multimap/-/multimap-1.1.2.tgz",
+            "integrity": "sha512-PDcGED9ZnrMI+A4ZiAZ8R7VkM2Uj+THkZ8vhbjXtfjJ5lLnr2kRI6hXo378hJTMQjEKMeXiJsf2P5H58uZDpyw==",
+            "dev": true
         },
         "node_modules/@types/node": {
             "version": "16.11.64",
@@ -3007,6 +3015,11 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/multimap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+            "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw=="
+        },
         "node_modules/ncp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -4856,6 +4869,12 @@
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
+        "@types/multimap": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@types/multimap/-/multimap-1.1.2.tgz",
+            "integrity": "sha512-PDcGED9ZnrMI+A4ZiAZ8R7VkM2Uj+THkZ8vhbjXtfjJ5lLnr2kRI6hXo378hJTMQjEKMeXiJsf2P5H58uZDpyw==",
+            "dev": true
+        },
         "@types/node": {
             "version": "16.11.64",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.64.tgz",
@@ -6637,6 +6656,11 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "multimap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+            "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw=="
         },
         "ncp": {
             "version": "2.0.0",

--- a/pkg/infra/pulumi_aws/package.json
+++ b/pkg/infra/pulumi_aws/package.json
@@ -13,10 +13,12 @@
         "cdk8s-cli": "^2.1.4",
         "patch-package": "^6.4.7",
         "requestretry": "^7.0.2",
-        "simple-sha256": "^1.1.0"
+        "simple-sha256": "^1.1.0",
+        "multimap": "^1.1.0"
     },
     "devDependencies": {
         "@types/node": "^16.11.64",
-        "@types/uuid": "^8.3.4"
+        "@types/uuid": "^8.3.4",
+        "@types/multimap": "^1.1.2"
     }
 }

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/bmatcuk/doublestar/v4"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"text/template"
@@ -151,6 +153,50 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 	addFile("iac/k8s/add_ons/cloud_map_controller/index.ts")
 	addFile("iac/k8s/add_ons/external_dns/index.ts")
 	addFile("iac/k8s/add_ons/index.ts")
+
+	addDir := func(dir string, exclusions ...string) {
+		var unreadEntries []string
+		dirContents, err := files.ReadDir(dir)
+
+		addEntries := func(parentDir string, entries []fs.DirEntry) {
+			for _, entry := range entries {
+				dirSuffix := ""
+				if entry.IsDir() {
+					dirSuffix = "/"
+				}
+				path := strings.TrimSuffix(parentDir, "/") + "/" + entry.Name() + dirSuffix
+				shouldInclude := true
+				for _, exclusion := range exclusions {
+					if shouldExclude, _ := doublestar.Match(exclusion, path); shouldExclude {
+						shouldInclude = false
+					}
+				}
+				if shouldInclude {
+					unreadEntries = append(unreadEntries, path)
+				}
+			}
+		}
+		addEntries(dir, dirContents)
+
+		for len(unreadEntries) > 0 {
+			if err != nil {
+				return
+			}
+
+			entry := unreadEntries[0]
+			unreadEntries = unreadEntries[1:]
+			if strings.HasSuffix(entry, "/") {
+				var childEntries []os.DirEntry
+				childEntries, err = files.ReadDir(strings.TrimSuffix(entry, "/"))
+				addEntries(entry, childEntries)
+
+			} else {
+				addFile(entry)
+			}
+		}
+	}
+
+	addDir("iac/sanitization", "**/*.{test,spec}.{ts,js}")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolves #49 (minus the actual namespacing piece)

This PR adds sanitization for the identifiers of AWS resources specified for creation via Klotho's IAC layer. This change should not change any happy path identifiers (resource names or Pulumi URNs)

Resource names are generated using tagged string templates as in the following examples using the `sanitized()` tag function:
```typescript
let appName = 'my-very-long-app-name'
let resourceId = 'my-load-balancer'
​
// ensure that the output is a valid load balancer name
// from left to right, hash appName and then resourceId if the name is too long
sanitized(loadBalancer.nameValidation())`${h(appName)}-${h(resourceId)}-lb`
// 2d958-my-load-balancer-lb
​
// prioritize hashing resourceId before appName since its priority is 1 (default is 100)
sanitized(loadBalancer.nameValidation())`${h(appName)}-${h(resourceId, 1)}-lb`
// my-very-long-app-name-0ea7a-lb
```

When shortening resource names, raw text or template expressions of type `string` are not modified. Expressions of type `Component` are shortened from left to right based on priority (default priority is `100`) using the `Component` instance's configured `ShorteningStrategy`. In the examples above, the `h()` function returns a `Component` with a `ShorteningStrategy` that converts the supplied text into a 5 character truncated SHA256 hash.  


The process of generating a valid resource name is as follows:
1) Shorten `Component`s from left to right ranked by priority until the name's length <= `maxLength`.
2) Sanitize the generated string in one or more passes (up to 5 passes by default):
   1) Truncate the string if it's longer than max length (arguably, we might want this to be an error).
   2) Throw an error if the string is shorter than the min length.
   3) Apply the supplied `SanitizationRule`s and capture any violations.
   4) For any violations, sequentially apply the violated rules' supplied `FixFunc` (if present) to resolve any issues.
   5) Revalidate the string if it's been fixed
   6) Return the valid string or start another pass if the string is still invalid
3) return the sanitized result or throw an exception if any constraint violations are present in the result.

### Standard checks

- **Unit tests**: Any special considerations? We don't have a pattern for testing IAC-related code at the moment, but we should really figure that out.
- **Docs**: Do we need to update any docs, internal or public? No
- **Backwards compatibility**: Will this break existing apps? This PR aims to avoid changing "happy path" resource names so there should be no issue there.
