### PR TITLE
adding alb as a gateway type

### DIFF
--- a/pkg/infra/pulumi_aws/iac/api_gateway.ts
+++ b/pkg/infra/pulumi_aws/iac/api_gateway.ts
@@ -41,11 +41,7 @@ export class ApiGateway {
         }
 
         gateways.forEach((gateway) => {
-            //   if (gateway.ProtocolType === "websocket") {
-            this.createWebSocketGateway(gateway)
-            //   } else if (gateway.ProtocolType === "http") {
-            //     this.createDockerBasedAPIGateway(gateway.Routes, gateway.Name)
-            //   }
+            this.createDockerBasedAPIGateway(gateway.Routes, gateway.Name)
         })
     }
 

--- a/pkg/infra/pulumi_aws/iac/api_gateway.ts
+++ b/pkg/infra/pulumi_aws/iac/api_gateway.ts
@@ -1,0 +1,499 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import { CloudCCLib, ResourceKey, Resource } from '../deploylib'
+import * as sha256 from 'simple-sha256'
+import { LoadBalancerPlugin } from './load_balancing'
+
+export interface Route {
+    verb: string
+    path: string
+    execUnitName: string
+}
+
+export interface Gateway {
+    Name: string
+    Routes: Route[]
+    Targets: any
+}
+
+export class ApiGateway {
+    private readonly vpcLink: aws.apigatewayv2.VpcLink
+    public readonly invokeUrls: pulumi.Output<string>[] = []
+    private readonly execUnitToIntegration: Map<string, aws.apigatewayv2.Integration> = new Map<
+        string,
+        aws.apigatewayv2.Integration
+    >()
+
+    constructor(
+        private readonly lib: CloudCCLib,
+        private readonly lbPlugin: LoadBalancerPlugin,
+        gateways: Gateway[]
+    ) {
+        if (lib.klothoVPC != undefined) {
+            this.vpcLink = this.createVpcLink(
+                lib.sgs,
+                pulumi
+                    .all([lib.publicSubnetIds || [], lib.privateSubnetIds || []])
+                    .apply(([publicIds, privateIds]) => {
+                        return [...publicIds, ...privateIds]
+                    })
+            )
+        }
+
+        gateways.forEach((gateway) => {
+            //   if (gateway.ProtocolType === "websocket") {
+            this.createWebSocketGateway(gateway)
+            //   } else if (gateway.ProtocolType === "http") {
+            //     this.createDockerBasedAPIGateway(gateway.Routes, gateway.Name)
+            //   }
+        })
+    }
+
+    createWebSocketApiGateway(providedName): aws.apigatewayv2.Api {
+        return new aws.apigatewayv2.Api(`${this.lib.name}-${providedName}`, {
+            protocolType: 'WEBSOCKET',
+            routeSelectionExpression: `$request.body.action`,
+        })
+    }
+
+    createVpcLink(
+        securityGroupIds: pulumi.Output<string>[],
+        subnetIds: pulumi.Output<string[]>
+    ): aws.apigatewayv2.VpcLink {
+        return new aws.apigatewayv2.VpcLink(`${this.lib.name}`, {
+            securityGroupIds,
+            subnetIds,
+        })
+    }
+
+    createLambdaIntegration(
+        gwName: string,
+        api: aws.apigatewayv2.Api,
+        invokeArn: pulumi.Output<string>,
+        createVPC: boolean,
+        verb: string,
+        execUnitName: string
+    ): aws.apigatewayv2.Integration {
+        return new aws.apigatewayv2.Integration(
+            `${this.lib.name}-${gwName}-${execUnitName}`,
+            {
+                apiId: api.id,
+                integrationType: 'AWS_PROXY',
+                connectionType: createVPC ? 'VPC_LINK' : 'INTERNET',
+                contentHandlingStrategy: 'CONVERT_TO_TEXT',
+                integrationMethod: verb,
+                integrationUri: invokeArn,
+            },
+            {
+                parent: api,
+            }
+        )
+    }
+
+    createPrivateIntegration(
+        gwName: string,
+        api: aws.apigatewayv2.Api,
+        vpcLink: aws.apigatewayv2.VpcLink,
+        integrationUri: pulumi.Output<string>,
+        verb: string,
+        execUnitName: string
+    ): aws.apigatewayv2.Integration {
+        return new aws.apigatewayv2.Integration(
+            `${this.lib.name}-${gwName}-${execUnitName}`,
+            {
+                apiId: api.id,
+                description: 'Example with a load balancer',
+                integrationType: 'HTTP_PROXY',
+                integrationUri,
+                integrationMethod: verb,
+                connectionId: '${stageVariables.vpcLinkId}',
+                connectionType: 'VPC_LINK',
+                passthroughBehavior: 'WHEN_NO_MATCH',
+            },
+            {
+                dependsOn: [vpcLink],
+                parent: api,
+            }
+        )
+    }
+
+    createRoute(
+        gwName: string,
+        api: aws.apigatewayv2.Api,
+        route: string,
+        integration: aws.apigatewayv2.Integration
+    ): aws.apigatewayv2.Route {
+        return new aws.apigatewayv2.Route(
+            `${this.lib.name}-${gwName}-${route}`,
+            {
+                apiId: api.id,
+                routeKey: route,
+                target: pulumi.interpolate`integrations/${integration.id}`,
+            },
+            {
+                parent: api,
+            }
+        )
+    }
+
+    createDeployment(gwName: string, api: aws.apigatewayv2.Api, routes: aws.apigatewayv2.Route[]) {
+        return new aws.apigatewayv2.Deployment(
+            `${this.lib.name}-${gwName}`,
+            {
+                apiId: api.id,
+            },
+            {
+                dependsOn: routes,
+                parent: api,
+            }
+        )
+    }
+
+    createStage(
+        gwName: string,
+        api: aws.apigatewayv2.Api,
+        deployment: aws.apigatewayv2.Deployment,
+        vpcLink: aws.apigatewayv2.VpcLink,
+        stageName: string
+    ) {
+        return new aws.apigatewayv2.Stage(
+            `${this.lib.name}-${gwName}-${stageName}`,
+            {
+                apiId: api.id,
+                name: stageName,
+                deploymentId: deployment.id,
+                stageVariables: {
+                    vpcLinkId: vpcLink.id,
+                },
+            },
+            {
+                dependsOn: [vpcLink],
+                parent: api,
+            }
+        )
+    }
+
+    createWebSocketGateway(gateway: Gateway) {
+        const gwName = gateway.Name.replace(/[^a-zA-Z0-9_-]/g, '-')
+        const api: aws.apigatewayv2.Api = this.createWebSocketApiGateway(gwName)
+        const apiRoutes: aws.apigatewayv2.Route[] = []
+        const units = new Set<string>()
+        gateway.Routes.forEach((gw) => units.add(gw.execUnitName))
+        if (units.size > 1) {
+            throw new Error('only one exec unit is supported for websocket API Gateway')
+        }
+        for (const route of gateway.Routes) {
+            const execUnit = this.lib.resourceIdToResource.get(`${route.execUnitName}_exec_unit`)
+            if (execUnit.type == 'fargate') {
+                let integration: aws.apigatewayv2.Integration | undefined =
+                    this.execUnitToIntegration.get(route.execUnitName)
+                if (!integration) {
+                    const nlb = this.lib.execUnitToNlb.get(route.execUnitName)!
+                    const integrationUri = pulumi.interpolate`http://${
+                        nlb.loadBalancer.dnsName
+                    }${route.path.replace(/:([^/]+)/g, '{$1}').replace(/[*]\}/g, '+}')}`
+                    integration = this.createPrivateIntegration(
+                        gwName,
+                        api,
+                        this.vpcLink,
+                        integrationUri,
+                        route.verb,
+                        route.execUnitName
+                    )
+                    this.execUnitToIntegration.set(route.execUnitName, integration)
+                }
+                apiRoutes.push(this.createRoute(gwName, api, '$default', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$connect', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$disconnect', integration))
+            } else if (execUnit.type == 'lambda') {
+                let integration: aws.apigatewayv2.Integration | undefined =
+                    this.execUnitToIntegration.get(route.execUnitName)
+                if (!integration) {
+                    const lambda: aws.lambda.Function = this.lib.execUnitToFunctions.get(
+                        route.execUnitName
+                    )!
+                    integration = this.createLambdaIntegration(
+                        gwName,
+                        api,
+                        lambda.invokeArn,
+                        this.lib.klothoVPC != undefined,
+                        route.verb,
+                        route.execUnitName
+                    )
+                    this.execUnitToIntegration.set(route.execUnitName, integration)
+                }
+                apiRoutes.push(this.createRoute(gwName, api, '$default', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$connect', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$disconnect', integration))
+            } else if (execUnit.type == 'eks') {
+                let integration: aws.apigatewayv2.Integration | undefined =
+                    this.execUnitToIntegration.get(route.execUnitName)
+                if (!integration) {
+                    const nlb = this.lbPlugin.getExecUnitLoadBalancer(route.execUnitName)!
+                    const integrationUri = pulumi.interpolate`http://${nlb.dnsName}${route.path
+                        .replace(/:([^/]+)/g, '{$1}')
+                        .replace(/[*]\}/g, '+}')}`
+                    integration = this.createPrivateIntegration(
+                        gwName,
+                        api,
+                        this.vpcLink,
+                        integrationUri,
+                        route.verb,
+                        route.execUnitName
+                    )
+                    this.execUnitToIntegration.set(route.execUnitName, integration)
+                }
+                apiRoutes.push(this.createRoute(gwName, api, '$default', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$connect', integration))
+                apiRoutes.push(this.createRoute(gwName, api, '$disconnect', integration))
+            } else {
+                throw new Error('Unsuppotred integration time for api gateway')
+            }
+        }
+
+        const deployment: aws.apigatewayv2.Deployment = this.createDeployment(
+            gwName,
+            api,
+            apiRoutes
+        )
+        const stage: aws.apigatewayv2.Stage = this.createStage(
+            gwName,
+            api,
+            deployment,
+            this.vpcLink,
+            'stage'
+        )
+        this.invokeUrls.push(stage.invokeUrl)
+    }
+
+    createDockerBasedAPIGateway(routes: Route[], providedName: string): void {
+        const gwName = providedName.replace(/[^a-zA-Z0-9_-]/g, '-')
+        const restAPI: aws.apigateway.RestApi = new aws.apigateway.RestApi(gwName, {
+            binaryMediaTypes: ['application/octet-stream', 'image/*'],
+        })
+        const resourceMap = new Map<string, aws.apigateway.Resource>()
+        const methods: aws.apigateway.Method[] = []
+        const integrations: aws.apigateway.Integration[] = []
+        const integrationNames: string[] = []
+        const permissions: aws.lambda.Permission[] = []
+        // create the resources and methods needed for the provided routes
+        for (const r of routes) {
+            const execUnit = this.lib.resourceIdToResource.get(`${r.execUnitName}_exec_unit`)
+            const pathSegments = r.path.split('/').filter(Boolean)
+            let methodPathLastPart = pathSegments.at(-1) ?? '/' // get the last part of the path
+            let routeAndHash = `${methodPathLastPart.replace(':', '').replace('*', '')}-${sha256
+                .sync(r.path)
+                .slice(0, 5)}`
+            // create the resources first
+            // parent resource starts off null since we don't create the root resource
+            let parentResource: aws.apigateway.Resource | null = null
+            const methodRequestParams = {}
+            const integrationRequestParams = {}
+            let currPathSegments = ''
+            for (let segment of pathSegments) {
+                // Handle path parameters defined in express as :<param>
+                if (segment.includes(':')) {
+                    const pathParam = `request.path.${segment.replace(':', '').replace('*', '')}`
+                    methodRequestParams[`method.${pathParam}`] = true
+                    integrationRequestParams[`integration.${pathParam}`] = `method.${pathParam}`
+                }
+
+                segment = segment
+                    .replace(/:([^/]+)/g, '{$1}') // convert express params :arg to AWS gateway {arg}
+                    .replace(/[*]\}/g, '+}') // convert express greedy flag {arg*} to AWS gateway {arg+}
+                    .replace(/\/\//g, '/') // collapse double '//' to single '/'
+                currPathSegments += `${segment}/`
+                if (resourceMap.has(currPathSegments)) {
+                    parentResource = resourceMap.get(currPathSegments)!
+                } else {
+                    const resource = new aws.apigateway.Resource(
+                        gwName + currPathSegments,
+                        {
+                            restApi: restAPI.id,
+                            parentId:
+                                parentResource == null ? restAPI.rootResourceId : parentResource.id,
+                            pathPart: segment,
+                        },
+                        {
+                            parent: restAPI,
+                        }
+                    )
+                    resourceMap.set(currPathSegments, resource)
+                    parentResource = resource
+                }
+            }
+
+            //create the methods
+            // We use the combination of the aws method property operationName alongside pulumi properties
+            // replaceOnChanges and deleteBeforeReplace in order to correctly trigger swapping integrations
+            // when infra is changed, for example from lambda to fargate. All three properties are required
+            // to trigger a replace action of the method, which is required to correctly swap integrations
+            // while preventing resource collisions on the method.
+            const method = new aws.apigateway.Method(
+                `${r.verb.toUpperCase()}-${routeAndHash}`,
+                {
+                    restApi: restAPI.id,
+                    resourceId: parentResource?.id ?? restAPI.rootResourceId,
+                    httpMethod: r.verb.toUpperCase(),
+                    authorization: 'NONE',
+                    operationName: `${execUnit.type}-${r.verb.toUpperCase()}-${routeAndHash}`,
+                    requestParameters:
+                        Object.keys(methodRequestParams).length == 0
+                            ? undefined
+                            : methodRequestParams,
+                },
+                {
+                    parent: parentResource ?? restAPI,
+                    replaceOnChanges: ['*'],
+                    deleteBeforeReplace: true,
+                }
+            )
+            methods.push(method)
+
+            const integrationName = `${execUnit.type}-${r.verb.toUpperCase()}-${routeAndHash}`
+            integrationNames.push(integrationName)
+            if (execUnit.type == 'fargate') {
+                const nlb = this.lib.execUnitToNlb.get(r.execUnitName)!
+                const vpcLink = this.lib.execUnitToVpcLink.get(r.execUnitName)!
+                integrations.push(
+                    new aws.apigateway.Integration(
+                        integrationName,
+                        {
+                            restApi: restAPI.id,
+                            resourceId:
+                                parentResource == null ? restAPI.rootResourceId : parentResource.id,
+                            httpMethod: method.httpMethod,
+                            integrationHttpMethod: method.httpMethod,
+                            type: 'HTTP_PROXY',
+                            connectionType: 'VPC_LINK',
+                            connectionId: vpcLink.id,
+                            uri: pulumi.interpolate`http://${nlb.loadBalancer.dnsName}${r.path
+                                .replace(/:([^/]+)/g, '{$1}')
+                                .replace(/[*]\}/g, '+}')}`,
+                            requestParameters:
+                                Object.keys(integrationRequestParams).length == 0
+                                    ? undefined
+                                    : integrationRequestParams,
+                        },
+                        {
+                            parent: method,
+                        }
+                    )
+                )
+            } else if (execUnit.type == 'eks') {
+                const nlb = this.lbPlugin.getExecUnitLoadBalancer(r.execUnitName)!
+                const vpcLink = this.lib.execUnitToVpcLink.get(r.execUnitName)!
+                integrations.push(
+                    new aws.apigateway.Integration(
+                        integrationName,
+                        {
+                            restApi: restAPI.id,
+                            resourceId:
+                                parentResource == null ? restAPI.rootResourceId : parentResource.id,
+                            httpMethod: method.httpMethod,
+                            integrationHttpMethod: method.httpMethod,
+                            type: 'HTTP_PROXY',
+                            connectionType: 'VPC_LINK',
+                            connectionId: vpcLink.id,
+                            uri: pulumi.interpolate`http://${nlb.dnsName}${r.path
+                                .replace(/:([^/]+)/g, '{$1}')
+                                .replace(/[*]\}/g, '+}')}`,
+                            requestParameters:
+                                Object.keys(integrationRequestParams).length == 0
+                                    ? undefined
+                                    : integrationRequestParams,
+                        },
+                        {
+                            parent: method,
+                        }
+                    )
+                )
+            } else if (execUnit.type == 'lambda') {
+                const lambda = this.lib.execUnitToFunctions.get(r.execUnitName)!
+                integrations.push(
+                    new aws.apigateway.Integration(
+                        integrationName,
+                        {
+                            restApi: restAPI.id,
+                            resourceId:
+                                parentResource == null ? restAPI.rootResourceId : parentResource.id,
+                            httpMethod: method.httpMethod,
+                            integrationHttpMethod: 'POST',
+                            type: 'AWS_PROXY',
+                            uri: lambda.invokeArn,
+                        },
+                        {
+                            parent: method,
+                        }
+                    )
+                )
+
+                const permissionName = `${r.verb}-${r.path.replace(/[^a-z0-9]/gi, '')}-permission`
+                permissions.push(
+                    new aws.lambda.Permission(permissionName, {
+                        action: 'lambda:InvokeFunction',
+                        function: lambda.name,
+                        principal: 'apigateway.amazonaws.com',
+                        sourceArn: pulumi.interpolate`arn:aws:execute-api:${this.lib.region}:${
+                            this.lib.account.accountId
+                        }:${restAPI.id}/*/${
+                            r.verb.toUpperCase() === 'ANY' ? '*' : r.verb.toUpperCase()
+                        }${parentResource == null ? '/' : parentResource.path}`,
+                    })
+                )
+            }
+        }
+
+        // Create the deployment and stage
+        const deployment = new aws.apigateway.Deployment(
+            `${providedName}-deployment`,
+            {
+                restApi: restAPI,
+                triggers: {
+                    routes: sha256.sync(
+                        routes
+                            .map((r) => `${r.execUnitName}:${r.path}:${r.verb}`)
+                            .sort()
+                            .join()
+                    ),
+                    integrations: sha256.sync(
+                        integrationNames
+                            .map((i) => i)
+                            .sort()
+                            .join()
+                    ),
+                },
+            },
+            {
+                dependsOn: [...methods, ...integrations, ...permissions],
+                parent: restAPI,
+            }
+        )
+
+        const stage = new aws.apigateway.Stage(
+            `${providedName}-stage`,
+            {
+                deployment: deployment.id,
+                restApi: restAPI.id,
+                stageName: this.lib.stage,
+            },
+            {
+                parent: deployment,
+            }
+        )
+
+        this.lib.topologySpecOutputs.push(
+            pulumi.all([restAPI.id, restAPI.urn]).apply(([id, urn]) => ({
+                id: id,
+                urn: urn,
+                kind: '', // TODO
+                type: 'AWS API Gateway',
+                url: `https://console.aws.amazon.com/apigateway/home?region=${this.lib.region}#/apis/${id}/resources/`,
+            }))
+        )
+
+        this.lib.gatewayToUrl.set(providedName, stage.invokeUrl)
+
+        this.invokeUrls.push(stage.invokeUrl)
+    }
+}

--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -654,7 +654,6 @@ export class Eks {
         }
 
         if (image) {
-            console.log(needsLoadBalancer)
             if (needsGatewayLink) {
                 if (!this.lbPlugin) {
                     throw new Error(

--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -17,6 +17,7 @@ import {
 } from './k8s/horizontal-pod-autoscaling'
 import { installMetricsServer } from './k8s/add_ons/metrics_server'
 import { applyChart, Value } from './k8s/helm_chart'
+import { LoadBalancerPlugin } from './load_balancing'
 
 export interface EksExecUnitArgs {
     nodeType: 'fargate' | 'node'
@@ -200,7 +201,8 @@ export class Eks {
         lib: CloudCCLib,
         execUnits: EksExecUnit[],
         charts: HelmChart[],
-        existingCluster?: aws.eks.GetClusterResult
+        existingCluster?: aws.eks.GetClusterResult,
+        private readonly lbPlugin?: LoadBalancerPlugin
     ) {
         this.lib = lib
         this.options = options
@@ -435,7 +437,6 @@ export class Eks {
             }
         }
 
-        console.log(diskSizeMin)
         for (const unit of execUnits) {
             if (unit.params.nodeType === 'fargate') {
                 continue
@@ -561,6 +562,33 @@ export class Eks {
         let dependencyParent
         let serviceName
         let role
+        const execUnitEdgeId = `${execUnit}_exec_unit`
+        let needsProxy = false
+        let needsGatewayLink = false
+        let needsLoadBalancer = false
+
+        lib.topology.topologyIconData.forEach((resource) => {
+            if (resource.kind === Resource.gateway) {
+                lib.topology.topologyEdgeData.forEach((edge) => {
+                    if (edge.source == resource.id && edge.target === execUnitEdgeId) {
+                        // We know that this exec unit is exposed and must create the necessary resources
+                        needsGatewayLink = true
+                        if (resource.type == 'apigateway') {
+                            needsLoadBalancer = true
+                        }
+                    }
+                })
+            }
+            if (resource.kind === Resource.exec_unit) {
+                lib.topology.topologyEdgeData.forEach((edge) => {
+                    if (edge.source == resource.id && edge.target === execUnitEdgeId) {
+                        // We know that this exec unit is proxied to from another exec unit and must create the necessary resources
+                        needsProxy = true
+                    }
+                })
+            }
+        })
+        const protocol = needsLoadBalancer ? 'TCP' : 'HTTP'
 
         let additionalEnvVars: { name: string; value: pulumi.Input<string> }[] = []
         for (const [name, value] of Object.entries(
@@ -626,64 +654,70 @@ export class Eks {
         }
 
         if (image) {
-            const execUnitEdgeId = `${execUnit}_exec_unit`
-            let needsProxy = false
-            let needsGatewayLink = false
-
-            lib.topology.topologyIconData.forEach((resource) => {
-                if (resource.kind === Resource.gateway) {
-                    lib.topology.topologyEdgeData.forEach((edge) => {
-                        if (edge.source == resource.id && edge.target === execUnitEdgeId) {
-                            // We know that this exec unit is exposed and must create the necessary resources
-                            needsGatewayLink = true
-                        }
-                    })
-                }
-                if (resource.kind === Resource.exec_unit) {
-                    lib.topology.topologyEdgeData.forEach((edge) => {
-                        if (edge.source == resource.id && edge.target === execUnitEdgeId) {
-                            // We know that this exec unit is proxied to from another exec unit and must create the necessary resources
-                            needsProxy = true
-                        }
-                    })
-                }
-            })
-
+            console.log(needsLoadBalancer)
             if (needsGatewayLink) {
-                const lb = lib.lbPlugin.createLoadBalancer(lib.name, execUnit, {
-                    subnets: lib.privateSubnetIds,
-                    loadBalancerType: 'network',
-                })
+                if (!this.lbPlugin) {
+                    throw new Error(
+                        'EKS Plugin needs the LoadBalancer Plugin to connect expose with execution units.'
+                    )
+                }
+                if (needsLoadBalancer) {
+                    const lb = this.lbPlugin!.createLoadBalancer(lib.name, execUnit, {
+                        subnets: lib.privateSubnetIds,
+                        loadBalancerType: 'network',
+                    })
+                    const targetGroup = this.lbPlugin!.createTargetGroup(lib.name, execUnit, {
+                        port: 3000,
+                        protocol,
+                        vpcId: lib.klothoVPC.id,
+                        targetType: 'ip',
+                    })
 
-                const targetGroup = lib.lbPlugin.createTargetGroup(lib.name, execUnit, {
-                    port: 3000,
-                    protocol: 'TCP',
-                    vpcId: lib.klothoVPC.id,
-                    targetType: 'ip',
-                })
-                this.execUnitToTargetGroupArn.set(execUnit, targetGroup.arn)
+                    this.lbPlugin!.createListener(lib.name, execUnit, {
+                        port: 80,
+                        protocol,
+                        loadBalancerArn: lb.arn,
+                        defaultActions: [
+                            {
+                                type: 'forward',
+                                targetGroupArn: targetGroup.arn,
+                            },
+                        ],
+                    })
 
-                lib.lbPlugin.createListener(lib.name, execUnit, {
-                    port: 80,
-                    protocol: 'TCP',
-                    loadBalancerArn: lb.arn,
-                    defaultActions: [
-                        {
-                            type: 'forward',
-                            targetGroupArn: targetGroup.arn,
-                        },
-                    ],
-                })
+                    const vpcLink = new aws.apigateway.VpcLink(`${execUnit}-vpc-link`, {
+                        targetArn: lb.arn,
+                    })
+                    lib.execUnitToVpcLink.set(execUnit, vpcLink)
+                } else {
+                    this.lbPlugin!.createTargetGroup(lib.name, execUnit, {
+                        port: 3000,
+                        protocol,
+                        vpcId: lib.klothoVPC.id,
+                        targetType: 'ip',
+                    })
 
-                const vpcLink = new aws.apigateway.VpcLink(`${execUnit}-vpc-link`, {
-                    targetArn: lb.arn,
-                })
-                lib.execUnitToVpcLink.set(execUnit, vpcLink)
+                    pulumi.output(this.lib.klothoVPC.publicSubnets).apply((ps) => {
+                        const cidrBlocks: any = ps.map((subnet) => subnet.subnet.cidrBlock)
+                        new aws.ec2.SecurityGroupRule(
+                            `${this.lib.name}-${this.clusterName}-public-ingress`,
+                            {
+                                type: 'ingress',
+                                cidrBlocks: cidrBlocks,
+                                fromPort: 0,
+                                protocol: '-1',
+                                toPort: 0,
+                                securityGroupId: this.cluster.vpcConfig.clusterSecurityGroupId,
+                            }
+                        )
+                    })
+                }
 
                 if (
                     this.installedPlugins.get(plugins.AWS_LOAD_BALANCER_CONTROLLER) &&
                     !unit.helmOptions?.install
                 ) {
+                    const targetGroup = this.lbPlugin!.execUnitToTargetGroup.get(execUnit)!
                     this.createTargetBinding(execUnit, serviceName, targetGroup.arn, [
                         targetGroup,
                         dependencyParent,

--- a/pkg/infra/pulumi_aws/iac/load_balancing.ts
+++ b/pkg/infra/pulumi_aws/iac/load_balancing.ts
@@ -17,10 +17,131 @@ import {
     TargetGroupAttachmentArgs,
 } from '@pulumi/aws/lb'
 import { ListenerRuleArgs } from '@pulumi/aws/alb'
+import { CloudCCLib } from '../deploylib'
+
+export interface Route {
+    verb: string
+    path: string
+    execUnitName: string
+}
+
+export interface Gateway {
+    Name: string
+    Routes: Route[]
+    Targets: any
+}
 
 export class LoadBalancerPlugin {
     // A map of all resources which are going to be fronted by a load balancer
     private resourceIdToLB = new Map<string, aws.lb.LoadBalancer>()
+    // A map of exec units to their target groups
+    public readonly execUnitToTargetGroup: Map<string, aws.lb.TargetGroup> = new Map<
+        string,
+        aws.lb.TargetGroup
+    >()
+
+    public readonly execUnitToListner: Map<string, aws.lb.Listener> = new Map<
+        string,
+        aws.lb.Listener
+    >()
+    public readonly invokeUrls: pulumi.Output<string>[] = []
+
+    constructor(private readonly lib: CloudCCLib) {}
+
+    public createALBasGateways = (gateways: Gateway[]) => {
+        gateways.forEach((gateway) => {
+            this.invokeUrls.push(this.createALBasGateway(gateway))
+        })
+    }
+
+    private createALBasGateway = (gateway: Gateway): pulumi.Output<string> => {
+        const albSG = new aws.ec2.SecurityGroup(`${this.lib.name}-${gateway.Name}`, {
+            name: `${this.lib.name}-${gateway.Name}`,
+            vpcId: this.lib.klothoVPC.id,
+            egress: [
+                {
+                    cidrBlocks: ['0.0.0.0/0'],
+                    description: 'Allows all outbound IPv4 traffic.',
+                    fromPort: 0,
+                    protocol: '-1',
+                    toPort: 0,
+                },
+            ],
+            ingress: [
+                {
+                    cidrBlocks: ['0.0.0.0/0'],
+                    description: 'Allows all inbound IPv4 traffic.',
+                    fromPort: 0,
+                    protocol: '-1',
+                    toPort: 0,
+                },
+            ],
+        })
+
+        const alb = this.createLoadBalancer(this.lib.name, gateway.Name, {
+            internal: false,
+            loadBalancerType: 'application',
+            tags: { AppName: this.lib.name },
+            subnets: this.lib.publicSubnetIds,
+            securityGroups: [albSG.id],
+        })
+
+        for (const route of gateway.Routes) {
+            let targetGroup = this.execUnitToTargetGroup.get(route.execUnitName)
+            let listener = this.execUnitToListner.get(route.execUnitName)
+            if (!targetGroup) {
+                const execUnit = this.lib.resourceIdToResource.get(
+                    `${route.execUnitName}_exec_unit`
+                )
+                if (['fargate', 'eks'].includes(execUnit.type)) {
+                    targetGroup = this.createTargetGroup(this.lib.name, route.execUnitName, {
+                        port: 3000,
+                        protocol: 'HTTP',
+                        vpcId: this.lib.klothoVPC.id,
+                        targetType: 'ip',
+                        tags: { AppName: this.lib.name },
+                    })
+                } else if (execUnit.type == 'lambda') {
+                    targetGroup = this.createTargetGroup(this.lib.name, route.execUnitName, {
+                        tags: { AppName: this.lib.name },
+                    })
+                } else {
+                    throw new Error('unsupported execution unit type for ALB Gateway')
+                }
+            }
+            if (!listener) {
+                listener = this.createListener(this.lib.name, route.execUnitName, {
+                    port: 80,
+                    protocol: 'HTTP',
+                    loadBalancerArn: alb.arn,
+                    defaultActions: [
+                        {
+                            type: 'forward',
+                            targetGroupArn: targetGroup.arn,
+                        },
+                    ],
+                })
+            }
+
+            this.createListenerRule(this.lib.name, route.execUnitName + route.path, {
+                listenerArn: listener!.arn,
+                actions: [
+                    {
+                        type: 'forward',
+                        targetGroupArn: targetGroup.arn,
+                    },
+                ],
+                conditions: [
+                    {
+                        pathPattern: {
+                            values: [route.path],
+                        },
+                    },
+                ],
+            })
+        }
+        return alb.dnsName
+    }
 
     public getExecUnitLoadBalancer = (execUnit: string): aws.lb.LoadBalancer | undefined => {
         return this.resourceIdToLB.get(execUnit)
@@ -34,8 +155,7 @@ export class LoadBalancerPlugin {
         let lb: aws.lb.LoadBalancer
         switch (params.loadBalancerType) {
             case 'application':
-                lb = new aws.lb.LoadBalancer(`${appName}-${resourceId}-alb`, {
-                    name: `${appName}-${resourceId}`,
+                lb = new aws.lb.LoadBalancer(`${appName}-${resourceId}`, {
                     internal: params.internal || false,
                     loadBalancerType: 'application',
                     securityGroups: params.securityGroups,
@@ -45,8 +165,7 @@ export class LoadBalancerPlugin {
                 })
                 break
             case 'network':
-                lb = new aws.lb.LoadBalancer(`${appName}-${resourceId}-nlb`, {
-                    name: `${appName}-${resourceId}`,
+                lb = new aws.lb.LoadBalancer(`${appName}-${resourceId}`, {
                     internal: params.internal || true,
                     loadBalancerType: 'network',
                     subnets: params.subnets,
@@ -66,12 +185,14 @@ export class LoadBalancerPlugin {
         resourceId: string,
         params: ListenerArgs
     ): aws.lb.Listener => {
-        return new aws.lb.Listener(`${appName}-${resourceId}-listener`, {
+        const listener = new aws.lb.Listener(`${appName}-${resourceId}`, {
             loadBalancerArn: params.loadBalancerArn,
             defaultActions: params.defaultActions,
             port: params.port,
             protocol: params.protocol,
         })
+        this.execUnitToListner.set(resourceId, listener)
+        return listener
     }
 
     public createListenerRule = (
@@ -79,7 +200,7 @@ export class LoadBalancerPlugin {
         resourceId: string,
         params: ListenerRuleArgs
     ): aws.lb.ListenerRule => {
-        return new aws.lb.ListenerRule(`${appName}-${resourceId}-listenerRule`, {
+        return new aws.lb.ListenerRule(`${appName}-${resourceId}`, {
             listenerArn: params.listenerArn,
             actions: params.actions,
             conditions: params.conditions,
@@ -89,7 +210,7 @@ export class LoadBalancerPlugin {
 
     public createTargetGroup = (
         appName: string,
-        resourceId,
+        execUnitName: string,
         params: TargetGroupArgs
     ): aws.lb.TargetGroup => {
         let targetGroup: aws.lb.TargetGroup
@@ -98,8 +219,7 @@ export class LoadBalancerPlugin {
         }
         switch (params.targetType) {
             case 'ip':
-                targetGroup = new aws.lb.TargetGroup(`${appName}-${resourceId}-targetGroup`, {
-                    name: `${appName}-${resourceId}`,
+                targetGroup = new aws.lb.TargetGroup(`${appName}-${execUnitName}`, {
                     port: params.port,
                     protocol: params.protocol,
                     targetType: 'ip',
@@ -108,8 +228,7 @@ export class LoadBalancerPlugin {
                 })
                 break
             case 'instance':
-                targetGroup = new aws.lb.TargetGroup(`${appName}-${resourceId}-targetGroup`, {
-                    name: `${appName}-${resourceId}`,
+                targetGroup = new aws.lb.TargetGroup(`${appName}-${execUnitName}`, {
                     port: params.port,
                     protocol: params.protocol,
                     vpcId: params.vpcId,
@@ -117,8 +236,7 @@ export class LoadBalancerPlugin {
                 })
                 break
             case 'alb':
-                targetGroup = new aws.lb.TargetGroup(`${appName}-${resourceId}-targetGroup`, {
-                    name: `${appName}-${resourceId}`,
+                targetGroup = new aws.lb.TargetGroup(`${appName}-${execUnitName}`, {
                     targetType: 'alb',
                     port: params.port,
                     protocol: params.protocol,
@@ -128,8 +246,7 @@ export class LoadBalancerPlugin {
                 })
                 break
             case 'lambda':
-                targetGroup = new aws.lb.TargetGroup(`${appName}-${resourceId}-targetGroup`, {
-                    name: `${appName}-${resourceId}`,
+                targetGroup = new aws.lb.TargetGroup(`${appName}-${execUnitName}`, {
                     targetType: 'lambda',
                     tags: params.tags,
                 })
@@ -137,6 +254,7 @@ export class LoadBalancerPlugin {
             default:
                 throw new Error('Unsupported target group target type')
         }
+        this.execUnitToTargetGroup.set(execUnitName, targetGroup)
         return targetGroup
     }
 
@@ -145,7 +263,7 @@ export class LoadBalancerPlugin {
         resourceId: string,
         params: TargetGroupAttachmentArgs
     ): aws.lb.TargetGroupAttachment => {
-        return new aws.lb.TargetGroupAttachment(`${appName}-${resourceId}-targetGroupAttachment`, {
+        return new aws.lb.TargetGroupAttachment(`${appName}-${resourceId}`, {
             targetGroupArn: params.targetGroupArn,
             targetId: params.targetId,
             port: params.port,

--- a/pkg/infra/pulumi_aws/iac/load_balancing.ts
+++ b/pkg/infra/pulumi_aws/iac/load_balancing.ts
@@ -116,8 +116,11 @@ export class LoadBalancerPlugin {
                     loadBalancerArn: alb.arn,
                     defaultActions: [
                         {
-                            type: 'forward',
-                            targetGroupArn: targetGroup.arn,
+                            type: 'fixed-response',
+                            fixedResponse: {
+                                contentType: 'application/json',
+                                statusCode: '4XX',
+                            },
                         },
                     ],
                 })

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -15,6 +15,10 @@ import { v4 as uuidv4 } from "uuid";
 import {CloudCCLib, kloConfig} from './deploylib'
 import {EksExecUnitArgs, EksExecUnit} from './iac/eks'
 import {CockroachDB} from './iac/cockroachdb'
+{{- if .APIGateways}}
+import {ApiGateway, Gateway, Route } from './iac/api_gateway'
+{{end}}
+import { LoadBalancerPlugin } from './iac/load_balancing'
 
 {{- if .StaticUnits}}
 import {createStaticS3Website} from './iac/static_s3_website'
@@ -106,6 +110,8 @@ export = async () => {
     {{- end}}
     {{- end}}
 
+    const lbPlugin = new LoadBalancerPlugin(cloudLib)
+
 
     const eksUnits: EksExecUnit[] = []
     const arUrls: any[] = [];
@@ -130,10 +136,10 @@ export = async () => {
     {{end -}}
 
     {{- if .HelmCharts }}
-        await cloudLib.createEksResources(eksUnits, {{jsonPretty .HelmCharts | indent 4}});
+        await cloudLib.createEksResources(eksUnits, {{jsonPretty .HelmCharts | indent 4}}, lbPlugin);
     {{else}}
     if (eksUnits.length > 0 ) {
-        await cloudLib.createEksResources(eksUnits);
+        await cloudLib.createEksResources(eksUnits, [], lbPlugin);
     }
     {{end}}
 
@@ -151,18 +157,15 @@ export = async () => {
 
     const apprunnerUrls = arUrls.filter(url => { return url != null});;
 
-
     const gatewayUrls: any[] = [];
-    {{- range .Gateways}}
-    gatewayUrls.push(cloudLib.createDockerBasedAPIGateway(
-        [
-        {{- range .Routes}}
-            {{json .}},
-        {{- end}}
-        ],
-        "{{.Name}}",
-    ));
-    {{- end}}
+    {{- if .ALBs}}
+    lbPlugin.createALBasGateways({{ jsonPretty .ALBs | indent 4}})
+    gatewayUrls.push(...lbPlugin.invokeUrls)
+    {{end}}
+    {{- if .APIGateways}}
+    const apiGatewayUrls = new ApiGateway(cloudLib, lbPlugin, {{ jsonPretty .APIGateways | indent 4}})
+    gatewayUrls.push(...apiGatewayUrls.invokeUrls)
+    {{end}}
 
     const apiUrls = gatewayUrls;
 

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -127,6 +127,10 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 		addFile("iac/static_s3_website.ts")
 	}
 
+	if len(data.APIGateways) > 0 {
+		addFile("iac/api_gateway.ts")
+	}
+
 	addFile("deploylib.ts")
 	addFile("package.json")
 	addFile("tsconfig.json")

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -18,6 +18,8 @@ type (
 		TemplateConfig
 		UseVPC                  bool
 		CloudfrontDistributions []*resources.CloudfrontDistribution
+		APIGateways             []provider.Gateway
+		ALBs                    []provider.Gateway
 	}
 )
 
@@ -45,19 +47,22 @@ func NewTemplateData(config *config.Application) *TemplateData {
 
 func (c *AWS) Name() string { return "aws" }
 
+type GatewayType string
+
 // Enums for the types we allow in the aws provider so that we can reuse the same string within the provider
 const (
-	eks                    = "eks"
-	fargate                = "fargate"
-	lambda                 = "lambda"
-	apigateway             = "apigateway"
-	rds_postgres           = "rds_postgres"
-	s3                     = "s3"
-	dynamodb               = "dynamodb"
-	elasticache            = "elasticache"
-	memorydb               = "memorydb"
-	sns                    = "sns"
-	cockroachdb_serverless = "cockroachdb_serverless"
+	eks                                = "eks"
+	fargate                            = "fargate"
+	lambda                             = "lambda"
+	rds_postgres                       = "rds_postgres"
+	s3                                 = "s3"
+	dynamodb                           = "dynamodb"
+	elasticache                        = "elasticache"
+	memorydb                           = "memorydb"
+	sns                                = "sns"
+	cockroachdb_serverless             = "cockroachdb_serverless"
+	ApiGateway             GatewayType = "apigateway"
+	Alb                    GatewayType = "alb"
 )
 
 var defaultConfig = config.Defaults{
@@ -87,7 +92,7 @@ var defaultConfig = config.Defaults{
 		},
 	},
 	Expose: config.KindDefaults{
-		Type: apigateway,
+		Type: string(ApiGateway),
 	},
 	PubSub: config.KindDefaults{
 		Type: sns,
@@ -146,7 +151,7 @@ func (a *AWS) GetKindTypeMappings(kind string) ([]string, bool) {
 	case core.ExecutionUnitKind:
 		return []string{eks, fargate, lambda}, true
 	case core.GatewayKind:
-		return []string{apigateway}, true
+		return []string{string(ApiGateway), string(Alb)}, true
 	case core.StaticUnitKind:
 		return []string{s3}, true
 	case string(core.PersistFileKind):

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -98,6 +98,7 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 			data.StaticUnits = append(data.StaticUnits, unit)
 
 		case *core.Gateway:
+			cfg := a.Config.GetExposed(key.Name)
 			gw := provider.Gateway{
 				Name:    res.Name,
 				Targets: res.Targets,
@@ -109,7 +110,11 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 					Verb:         string(route.Verb),
 				})
 			}
-			data.Gateways = append(data.Gateways, gw)
+			if cfg.Type == string(Alb) {
+				data.ALBs = append(data.ALBs, gw)
+			} else if cfg.Type == string(ApiGateway) {
+				data.APIGateways = append(data.APIGateways, gw)
+			}
 
 		case *core.Persist:
 			cfg := a.Config.GetPersisted(key.Name, res.Kind)

--- a/pkg/provider/aws/infra_template_test.go
+++ b/pkg/provider/aws/infra_template_test.go
@@ -36,16 +36,19 @@ func TestInfraTemplateModification(t *testing.T) {
 				ExecutionUnits: map[string]*config.ExecutionUnit{
 					"unit": {Type: eks},
 				},
+				Exposed: map[string]*config.Expose{
+					"gw": {Type: string(ApiGateway)},
+				},
 			},
 			dependencies: []core.Dependency{},
 			data: TemplateData{
 				TemplateData: provider.TemplateData{
-					Gateways: []provider.Gateway{
-						{Name: "gw", Routes: []provider.Route{{ExecUnitName: "", Path: "/", Verb: ""}}, Targets: map[string]core.GatewayTarget(nil)},
-					},
 					ExecUnits: []provider.ExecUnit{
 						{Name: "unit", Type: "eks", NetworkPlacement: "private", MemReqMB: 0, KeepWarm: false, Schedules: []provider.Schedule(nil), Params: config.InfraParams{}},
 					},
+				},
+				APIGateways: []provider.Gateway{
+					{Name: "gw", Routes: []provider.Route{{ExecUnitName: "", Path: "/", Verb: ""}}, Targets: map[string]core.GatewayTarget(nil)},
 				},
 				UseVPC: true,
 			},
@@ -122,6 +125,7 @@ func TestInfraTemplateModification(t *testing.T) {
 				return
 			}
 			assert.Equal(tt.data.ExecUnits, awsData.ExecUnits)
+			assert.Equal(tt.data.APIGateways, awsData.APIGateways)
 			assert.Equal(tt.data.Gateways, awsData.Gateways)
 			assert.Equal(tt.data.UseVPC, awsData.UseVPC)
 		})


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

closes #109  

Adding ALB as a type for expose, which will work with lambda and EKS today (ECS still hardcodes NLBs in the code of the compiler so we need some serious cleanup there.

We add our public subnets to our SG so we can enable the delivery of ALB requests to our backend (These are the private cidr blocks of those subnets)

Because i went down the route of Websocket APIs first i had refactored the APIGateway class to use the LB Plugin in a similar manner. I would have to back out a lot of changes to deploy lib and the index.ts.tmpl file to get the ALB Functionality to work and remove the web socket funcitonality. 

The web socket functionality does allow us to create a websocket API GW and a single exec, but isnt too useable outside of that. Cut #117 to dive into that more

Also modularizes all the API Gateway code out of deploylib as a part of these changes.




### Standard checks

- **Unit tests**: Any special considerations? changed the provider unit test, will change some integ tests to
- **Docs**: Do we need to update any docs, internal or public? https://github.com/klothoplatform/docs/pull/152
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yes, this is a new type, i do not believe our IaC should have anything which is not backwards compatible but our logic is very use case based which isnt great (We talked about it in sync and the need to move it to the compiler)
