### PR TITLE
only join filepath if root path exists for filref

### DIFF
--- a/pkg/core/file_ref.go
+++ b/pkg/core/file_ref.go
@@ -21,7 +21,11 @@ func (r *FileRef) Path() string {
 }
 
 func (r *FileRef) WriteTo(w io.Writer) (int64, error) {
-	f, err := os.Open(filepath.Join(r.RootConfigPath, r.FPath))
+	pathToOpen := r.FPath
+	if r.RootConfigPath != "" {
+		pathToOpen = filepath.Join(r.RootConfigPath, r.FPath)
+	}
+	f, err := os.Open(pathToOpen)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #38 

This gives the option to not include the config root path for fileRef and be able to find the file correctly. 

This does give the ability to look at files outside of the klotho context, which may be useful in the future, but is the question of do we want to allow that? Is FileRef not using the content of input files really the right path?  It would then be up to the user to have proper permissions on the files in their local filesystem

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
