### PR TITLE
allow list of helm values to be passed in

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,9 +49,9 @@ type (
 
 	// A HelmChartOptions represents configuration for execution units attempting to generate helm charts
 	HelmChartOptions struct {
-		Directory  string `json:"directory,omitempty" yaml:"directory,omitempty" toml:"directory,omitempty"` // Directory signals the directory which will contain the helm chart outputs
-		Install    bool   `json:"install,omitempty" yaml:"install,omitempty" toml:"install,omitempty"`
-		ValuesFile string `json:"values_file,omitempty" yaml:"values_file,omitempty" toml:"values_file,omitempty"`
+		Directory   string   `json:"directory,omitempty" yaml:"directory,omitempty" toml:"directory,omitempty"` // Directory signals the directory which will contain the helm chart outputs
+		Install     bool     `json:"install,omitempty" yaml:"install,omitempty" toml:"install,omitempty"`
+		ValuesFiles []string `json:"values_files,omitempty" yaml:"values_files,omitempty" toml:"values_files,omitempty"`
 	}
 
 	PubSub struct {

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -15,7 +15,7 @@ import (
 
 type KlothoHelmChart struct {
 	Name           string
-	ValuesFile     string
+	ValuesFiles    []string
 	ExecutionUnits []*HelmExecUnit
 	Directory      string
 	Files          []core.File

--- a/pkg/infra/kubernetes/plugin_test.go
+++ b/pkg/infra/kubernetes/plugin_test.go
@@ -101,14 +101,14 @@ func Test_setHelmChartDirectory(t *testing.T) {
 	}
 }
 
-func Test_setValuesFile(t *testing.T) {
+func Test_setValuesFiles(t *testing.T) {
 
 	tests := []struct {
 		name     string
 		path     string
 		cfg      *config.ExecutionUnit
 		unitName string
-		want     string
+		want     []string
 	}{
 		{
 			name: "happy path yaml",
@@ -120,7 +120,7 @@ func Test_setValuesFile(t *testing.T) {
 				},
 			},
 			unitName: "testUnit",
-			want:     "somedir/values.yaml",
+			want:     []string{"somedir/values.yaml"},
 		},
 		{
 			name: "happy path yml",
@@ -132,7 +132,7 @@ func Test_setValuesFile(t *testing.T) {
 				},
 			},
 			unitName: "testUnit",
-			want:     "somedir/values.yml",
+			want:     []string{"somedir/values.yml"},
 		},
 		{
 			name: "happy path no directory",
@@ -143,7 +143,7 @@ func Test_setValuesFile(t *testing.T) {
 				},
 			},
 			unitName: "testUnit",
-			want:     "somedir/values.yml",
+			want:     []string{"somedir/values.yml"},
 		},
 		{
 			name: "no install",
@@ -152,19 +152,18 @@ func Test_setValuesFile(t *testing.T) {
 				HelmChartOptions: &config.HelmChartOptions{},
 			},
 			unitName: "testUnit",
-			want:     "",
 		},
 		{
 			name: "values override",
 			path: "somedir/values.yaml",
 			cfg: &config.ExecutionUnit{
 				HelmChartOptions: &config.HelmChartOptions{
-					ValuesFile: "override/values.yaml",
-					Install:    true,
+					ValuesFiles: []string{"override/values.yaml"},
+					Install:     true,
 				},
 			},
 			unitName: "testUnit",
-			want:     "override/values.yaml",
+			want:     []string{"override/values.yaml"},
 		},
 		{
 			name: "non yaml file no action",
@@ -175,7 +174,6 @@ func Test_setValuesFile(t *testing.T) {
 				},
 			},
 			unitName: "testUnit",
-			want:     "",
 		},
 	}
 	for _, tt := range tests {
@@ -188,7 +186,7 @@ func Test_setValuesFile(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			assert.Equal(tt.want, tt.cfg.HelmChartOptions.ValuesFile)
+			assert.Equal(tt.want, tt.cfg.HelmChartOptions.ValuesFiles)
 		})
 	}
 }
@@ -239,8 +237,8 @@ func Test_getKlothoCharts(t *testing.T) {
 			want: result{
 				klothoCharts: map[string]KlothoHelmChart{
 					"chart": {
-						Directory:  "chart",
-						ValuesFile: "chart/values.yaml",
+						Directory:   "chart",
+						ValuesFiles: []string{"chart/values.yaml"},
 					},
 				},
 				chartsUnits: map[string][]string{
@@ -276,8 +274,8 @@ func Test_getKlothoCharts(t *testing.T) {
 			want: result{
 				klothoCharts: map[string]KlothoHelmChart{
 					"chart": {
-						Directory:  "chart",
-						ValuesFile: "chart/values.yaml",
+						Directory:   "chart",
+						ValuesFiles: []string{"chart/values.yaml"},
 					},
 				},
 				chartsUnits: map[string][]string{
@@ -387,11 +385,10 @@ func Test_getKlothoCharts(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			fmt.Println(klothoCharts)
 			for dir, c := range tt.want.klothoCharts {
 				resultChart := klothoCharts[dir]
 				assert.Equal(c.Directory, resultChart.Directory)
-				assert.Equal(c.ValuesFile, resultChart.ValuesFile)
+				assert.Equal(c.ValuesFiles, resultChart.ValuesFiles)
 
 				assert.Len(resultChart.ExecutionUnits, len(tt.want.chartsUnits[dir]))
 				for _, u := range resultChart.ExecutionUnits {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #75 

this is a breaking change, but i dont think anyone outside of komodor is using helm functionality and we will walk them through it.

Allows a list of values file paths to be passed in rather than singular path. 


### Standard checks

- **Unit tests**: Any special considerations? updated 
- **Docs**: Do we need to update any docs, internal or public? https://github.com/klothoplatform/docs/pull/153
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? no, the config of valuesFile changed to valuesFiles
