### PR TITLE
fix rolename length and node groups when no exec units

### DIFF
--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -435,7 +435,6 @@ export class Eks {
             }
         }
 
-        console.log(diskSizeMin)
         for (const unit of execUnits) {
             if (unit.params.nodeType === 'fargate') {
                 continue
@@ -485,6 +484,9 @@ export class Eks {
         const publicNodeGroupSpecs = this.determineNodeGroupSpecs(
             execUnits.filter((unit) => unit.network_placement === 'public')
         )
+        if (privateNodeGroupSpecs.size == 0 && publicNodeGroupSpecs.size == 0) {
+            privateNodeGroupSpecs.set('t3.medium', { diskSize: 20, instanceType: 't3.medium' })
+        }
 
         privateNodeGroupSpecs.forEach((specs, name) => {
             const nodeGroup = this.createNodeGroup(
@@ -1147,7 +1149,11 @@ export class Eks {
     }
 
     private createNodeIamRole(name: string): aws.iam.Role {
-        return new aws.iam.Role(`${this.clusterName}-${name}-EksNodeRole`, {
+        let roleName = `${this.clusterName}-${name}-EksNodeRole`
+        if (roleName.length > 63) {
+            roleName = roleName.substring(0, 63)
+        }
+        return new aws.iam.Role(roleName, {
             assumeRolePolicy: {
                 Version: '2012-10-17',
                 Statement: [


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

Checks the length of node roles for now while we dont have sanitazation

Ensures we create at least 1 private node group if none are supposed to be created

### Standard checks

- **Unit tests**: Any special considerations? none needed
- **Docs**: Do we need to update any docs, internal or public? no update needed
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yes
