### PR TITLE
when providing app overrides, match the full line

### DIFF
--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -90,7 +90,7 @@ jobs:
           )"
           if [[ -n "$APP_NAME_OVERRIDES" ]]; then
             echo "Applying overrides: $APP_NAME_OVERRIDES"
-            dirs_with_tests="$(echo "$dirs_with_tests" | grep -Ff <(echo "$APP_NAME_OVERRIDES" | tr , "\n"))"
+            dirs_with_tests="$(echo "$dirs_with_tests" | grep -xFf <(echo "$APP_NAME_OVERRIDES" | tr , "\n"))"
           else
             echo "No app name overrides."
           fi


### PR DESCRIPTION
For instance, if you have:

    ts-eks
    ts-eks-helm

... then an app name of "ts-eks" should only match the first of them.

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: no issues
