### PR TITLE
update client.js to v3 imports

### DIFF
--- a/pkg/lang/javascript/aws_runtime/clients.js
+++ b/pkg/lang/javascript/aws_runtime/clients.js
@@ -1,8 +1,8 @@
-import {S3Client} from '@aws-sdk/client-s3'
-import {LambdaClient} from '@aws-sdk/client-lambda'
-import {SecretsManagerClient} from '@aws-sdk/client-secrets-manager'
-import { SNSClient } from '@aws-sdk/client-sns'
-import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
+const {S3Client} = require('@aws-sdk/client-s3')
+const {LambdaClient}  = require('@aws-sdk/client-lambda')
+const {SecretsManagerClient}  = require('@aws-sdk/client-secrets-manager')
+const { SNSClient }  = require('@aws-sdk/client-sns')
+const {DynamoDBClient}  = require('@aws-sdk/client-dynamodb')
 const AWSXRay = require('aws-xray-sdk-core')
 
 const endpoint = process.env['AWS_ENDPOINT']

--- a/pkg/lang/javascript/aws_runtime/clients.js
+++ b/pkg/lang/javascript/aws_runtime/clients.js
@@ -1,8 +1,8 @@
-const S3 = require('aws-sdk/clients/s3')
-const Lambda = require('aws-sdk/clients/lambda')
-const Secrets = require('aws-sdk/clients/secretsmanager')
-const SNS = require('aws-sdk/clients/sns')
-const Dynamo = require('aws-sdk/clients/dynamodb')
+import {S3Client} from '@aws-sdk/client-s3'
+import {LambdaClient} from '@aws-sdk/client-lambda'
+import {SecretsManagerClient} from '@aws-sdk/client-secrets-manager'
+import { SNSClient } from '@aws-sdk/client-sns'
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb'
 const AWSXRay = require('aws-xray-sdk-core')
 
 const endpoint = process.env['AWS_ENDPOINT']
@@ -25,12 +25,12 @@ exports.AWSConfig = {
 }
 
 exports.clients = (() => {
-    let secrets = new Secrets(exports.AWSConfig)
+    let secrets = new SecretsManagerClient(exports.AWSConfig)
 
-    let s3 = new S3(exports.AWSConfig)
-    let lambda = new Lambda(exports.AWSConfig)
-    let sns = new SNS(exports.AWSConfig)
-    let dynamo = new Dynamo(exports.AWSConfig)
+    let s3 = new S3Client(exports.AWSConfig)
+    let lambda = new LambdaClient(exports.AWSConfig)
+    let sns = new SNSClient(exports.AWSConfig)
+    let dynamo = new DynamoDBClient(exports.AWSConfig)
 
     s3 = AWSXRay.captureAWSClient(s3)
     lambda = AWSXRay.captureAWSClient(lambda)

--- a/pkg/lang/javascript/aws_runtime/clients.js
+++ b/pkg/lang/javascript/aws_runtime/clients.js
@@ -32,10 +32,10 @@ exports.clients = (() => {
     let sns = new SNSClient(exports.AWSConfig)
     let dynamo = new DynamoDBClient(exports.AWSConfig)
 
-    s3 = AWSXRay.captureAWSClient(s3)
-    lambda = AWSXRay.captureAWSClient(lambda)
-    dynamo = AWSXRay.captureAWSClient(dynamo)
-    secrets = AWSXRay.captureAWSClient(secrets)
+    s3 = AWSXRay.captureAWSv3Client(s3)
+    lambda = AWSXRay.captureAWSv3Client(lambda)
+    dynamo = AWSXRay.captureAWSv3Client(dynamo)
+    secrets = AWSXRay.captureAWSv3Client(secrets)
 
     return { lambda, s3, secrets, sns, dynamo }
 })()


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

should fix the eks failures. Filed another ticket to remove the clients.js altogether but for now upgraded to aws sdk v3

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
