### PR TITLE
Update klotho checks

### DIFF
--- a/pkg/cli/cli_options.go
+++ b/pkg/cli/cli_options.go
@@ -129,15 +129,15 @@ func OptionOrDefault(given string, defaultValue string) string {
 	return given
 }
 
-func ShouldCheckForUpdate(given string, defaultValue string, currVersion string) bool {
-	if given == "" || given == defaultValue {
+func ShouldCheckForUpdate(updateStreamOverride string, defaultUpdateStream string, currVersion string) bool {
+	if updateStreamOverride == "" || updateStreamOverride == defaultUpdateStream {
 		return true
 	}
 
-	givenParts := strings.Split(given, ":")
-	if len(givenParts) == 2 {
-		givenVersion := givenParts[1]
-		if givenVersion != currVersion {
+	streamOverrideParts := strings.Split(updateStreamOverride, ":")
+	if len(streamOverrideParts) == 2 {
+		streamOverrideVersion := streamOverrideParts[1]
+		if streamOverrideVersion != currVersion {
 			return true
 		}
 	}

--- a/pkg/cli/cli_options.go
+++ b/pkg/cli/cli_options.go
@@ -2,13 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
 	"github.com/klothoplatform/klotho/pkg/cli_config"
 	"github.com/klothoplatform/klotho/pkg/yaml_util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"io/fs"
-	"os"
 )
 
 const configFileName = "options.yaml"
@@ -125,4 +127,20 @@ func OptionOrDefault(given string, defaultValue string) string {
 		return defaultValue
 	}
 	return given
+}
+
+func ShouldCheckForUpdate(given string, defaultValue string, currVersion string) bool {
+	if given == "" || given == defaultValue {
+		return true
+	}
+
+	givenParts := strings.Split(given, ":")
+	if len(givenParts) == 2 {
+		givenVersion := givenParts[1]
+		if givenVersion != currVersion {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -236,15 +236,19 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
-	// check daily for new updates and notify users if found
-	needsUpdate, err := klothoUpdater.CheckUpdate(km.Version)
-	if err != nil {
-		analyticsClient.Error(fmt.Sprintf(klothoName+"failed to check for updates: %v", err))
-		zap.S().Warnf("failed to check for updates: %v", err)
-	}
-	if needsUpdate {
-		analyticsClient.Info(klothoName + "update is available")
-		zap.L().Info("new update is available, please run klotho --update to get the latest version")
+	if ShouldCheckForUpdate(options.Update.Stream, km.DefaultUpdateStream, km.Version) {
+		// check daily for new updates and notify users if found
+		needsUpdate, err := klothoUpdater.CheckUpdate(km.Version)
+		if err != nil {
+			analyticsClient.Error(fmt.Sprintf(klothoName+"failed to check for updates: %v", err))
+			zap.S().Warnf("failed to check for updates: %v", err)
+		}
+		if needsUpdate {
+			analyticsClient.Info(klothoName + "update is available")
+			zap.L().Info("new update is available, please run klotho --update to get the latest version")
+		}
+	} else {
+		zap.S().Infof("Klotho is pinned to version: %s", options.Update.Stream)
 	}
 
 	if len(cfg.setOption) > 0 {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -77,7 +77,7 @@ func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 		return false, fmt.Errorf("invalid version %s: %v", currentVersion, err)
 	}
 
-	return currVersion.LessThan(*latestVersion), nil
+	return currVersion.LessThan(*latestVersion) || strings.Split(u.CurrentStream, ":")[0] != strings.Split(u.Stream, ":")[0], nil
 }
 
 // Update performs an update if a newer version is

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -44,6 +44,7 @@ func selfUpdate(data io.ReadCloser) error {
 func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 	timeout := 10 * time.Second
 	cli := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
+
 	endpoint := fmt.Sprintf("%s/update/check-latest-version?stream=%s", u.ServerURL, u.Stream)
 	res, err := cli.Get(endpoint, nil)
 	if err != nil {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -44,7 +44,6 @@ func selfUpdate(data io.ReadCloser) error {
 func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 	timeout := 10 * time.Second
 	cli := httpclient.NewClient(httpclient.WithHTTPTimeout(timeout))
-
 	endpoint := fmt.Sprintf("%s/update/check-latest-version?stream=%s", u.ServerURL, u.Stream)
 	res, err := cli.Get(endpoint, nil)
 	if err != nil {
@@ -77,7 +76,7 @@ func (u *Updater) CheckUpdate(currentVersion string) (bool, error) {
 		return false, fmt.Errorf("invalid version %s: %v", currentVersion, err)
 	}
 
-	return currVersion.LessThan(*latestVersion) || u.CurrentStream != u.Stream, nil
+	return currVersion.LessThan(*latestVersion), nil
 }
 
 // Update performs an update if a newer version is


### PR DESCRIPTION
I think the second stream check will result in false update messages being printed. 

Here's an example where I set my options to `oss:v0.5.19` 
```
Calling server w/ url + stream:  http://srv.klo.dev oss:v0.5.19
Current ver:  0.5.19       Latest Ver:  0.5.19
Current Stream:  oss:latest    User Stream:  oss:v0.5.19
```
If the user pins the version to the current version, it's just never going to match the stream check because the current stream is always the default value `oss:latest`

I'm pretty sure the first check for the semver is good enough since that takes the latest and converts it to the version number and compares that to the running builds version in the build file. 

Discussion: Not sure if the initial intention was to notify the user every time they run, that their pinned version is behind latest, but if that's the case, then this needs to be merged in https://github.com/klothoplatform/klotho-server/pull/27. The server was checking w/ the stream version provided instead of actual latest. 
