### PR TITLE
Changes the default release stream from "oss" to "open"

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	km := cli.KlothoMain{
-		DefaultUpdateStream: "oss:latest",
+		DefaultUpdateStream: "open:latest",
 		Version:             Version,
 		PluginSetup: func(psb *cli.PluginSetBuilder) error {
 			return psb.AddAll()


### PR DESCRIPTION
Renames the default release stream from the deprecated `oss` stream to `open`

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
