### PR TITLE
Fixes formula class name

### DIFF
--- a/.github/workflows/update_klotho_oss_formula.yaml
+++ b/.github/workflows/update_klotho_oss_formula.yaml
@@ -52,7 +52,7 @@ jobs:
           
           echo "Preparing formula for klotho release: ${VERSION}"
           
-          export FORMULA_NAME=KlothoOSS
+          export FORMULA_NAME=KlothoOss
           export OUTPUT_FILE_NAME=klotho-oss.rb
           export BINARY_BASE_URL="https://github.com/klothoplatform/klotho/releases/download"
           ./update_formula.sh


### PR DESCRIPTION
Changes the name of the `klotho-oss` formula's class from `KlothoOSS` -> `KlothoOss` to match the format expected by homebrew.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
