### PR TITLE
docs: add instructions to install from aur

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,28 @@ Klotho ensures that developers/operators are able to select and adapt the underl
 
 To install the latest Klotho release, run the following (see [full installation instructions](https://klo.dev/docs/download-klotho) for additional installation options):
 
-Mac:
+**Mac:**
 
 ```sh
 brew install klothoplatform/tap/klotho
 ```
 
-Linux/WSL2:
+**Linux/WSL2:**
+
 ```sh
 curl -fsSL "https://github.com/klothoplatform/klotho/releases/latest/download/klotho_linux_amd64" -o klotho
 chmod +x klotho
-  ```
+```
+
+**Arch Linux (from AUR):**
+
+Install the `klotho` package from AUR using your favourite AUR helper -
+
+```
+yay -S klotho
+paru -S klotho
+```
+
 ## IDE Plugins & Extensions
 
 Get syntax highlighting and snippets for Klotho annotations in your favorite IDE.


### PR DESCRIPTION
Hi,

I noticed that there was no [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) package for Klotho, and made one for it - https://aur.archlinux.org/packages/klotho. The PKGBUILD can be found [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klotho).

### Standard checks

- **Unit tests**: None to be updated
- **Docs**: Public documentation that contain the installation instructions need to be updated.
- **Backwards compatibility**: No breaking changes
