### PR TITLE
Changes trigger event type for brew workflow to 'released'

### DIFF
--- a/.github/workflows/update_klotho_oss_formula.yaml
+++ b/.github/workflows/update_klotho_oss_formula.yaml
@@ -3,7 +3,7 @@ name: Update the klotho-oss homebrew formula
 on:
   release:
     types:
-      - published
+      - released
   workflow_dispatch:
     inputs:
       klotho-tap:


### PR DESCRIPTION
This PR changes the trigger event type for brew workflow to `released` to ensure that this workflow doesn't get triggered by prerelease versions.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
