### PR TITLE
allow any extension 5 chars or fewer

### DIFF
--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -18,8 +18,8 @@ type fileField struct {
 
 func (field fileField) Sanitize(hasher func(any) string) SanitizedField {
 	extension := "unknown"
-	if ext := filepath.Ext(field.f.Path()); len(ext) <= 5 {
-		extension = ext
+	if _, isFileRef := field.f.(*core.FileRef); !isFileRef {
+		extension = filepath.Ext(field.f.Path())
 	}
 	return SanitizedField{
 		Key: "FileExtension",

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -18,8 +18,7 @@ type fileField struct {
 
 func (field fileField) Sanitize(hasher func(any) string) SanitizedField {
 	extension := "unknown"
-	switch ext := filepath.Ext(field.f.Path()); ext {
-	case ".json", ".js", ".ts", ".yaml":
+	if ext := filepath.Ext(field.f.Path()); len(ext) <= 5 {
 		extension = ext
 	}
 	return SanitizedField{


### PR DESCRIPTION
We had originally allowlisted the extensions to prevent any sensitive data, but I think the risk of that happening with a 1-4 letter file extension (the `.` already accounts for 1 of the 5) is very low. This way we don't need to keep adding more extensions as we support various file types.

### Standard checks

- **Unit tests**: no tests
- **Docs**: our analytics isn't currently documented, so no changes applicable
- **Backwards compatibility**: no issues
