### PR TITLE
rename fargate to ecs and remove hardcoded nlbs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/pelletier/go-toml/v2"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -148,6 +149,10 @@ func (cfg *KindDefaults) Merge(other KindDefaults) {
 func (cfg *ExecutionUnit) Merge(other ExecutionUnit) {
 	if other.Type != "" {
 		cfg.Type = other.Type
+	}
+	if cfg.Type == "fargate" {
+		zap.S().Warn("Execution unit type 'fargate' is now renamed to 'ecs'")
+		cfg.Type = "ecs"
 	}
 	cfg.NetworkPlacement = other.NetworkPlacement
 	if other.NetworkPlacement == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,16 @@ func ReadConfig(fpath string) (Application, error) {
 		err = toml.NewDecoder(f).Decode(&appCfg)
 		appCfg.Format = "toml"
 	}
+	postWarning := false
+	for _, unit := range appCfg.ExecutionUnits {
+		if unit.Type == "fargate" {
+			postWarning = true
+		}
+	}
+
+	if postWarning {
+		zap.S().Warn("Execution unit type 'fargate' is now renamed to 'ecs'")
+	}
 	return appCfg, err
 }
 
@@ -151,7 +161,6 @@ func (cfg *ExecutionUnit) Merge(other ExecutionUnit) {
 		cfg.Type = other.Type
 	}
 	if cfg.Type == "fargate" {
-		zap.S().Warn("Execution unit type 'fargate' is now renamed to 'ecs'")
 		cfg.Type = "ecs"
 	}
 	cfg.NetworkPlacement = other.NetworkPlacement

--- a/pkg/core/topology.go
+++ b/pkg/core/topology.go
@@ -72,7 +72,7 @@ var DiagramEntityToImgPath = TopoMap{
 	{Kind: string(PersistRedisClusterKind), Provider: ProviderAWS}:      "aws/database/elasticache-for-redis.png", // Theres no memoryDB at the moment
 	{Kind: PubSubKind, Provider: ProviderAWS}:                           "aws/integration/simple-notification-service-sns.png",
 	{Kind: NetworkLoadBalancerKind, Provider: ProviderAWS}:              "aws/network/elb-network-load-balancer.png",
-	{Kind: ExecutionUnitKind, Type: "fargate", Provider: ProviderAWS}:   "aws/compute/fargate.png",
+	{Kind: ExecutionUnitKind, Type: "ecs", Provider: ProviderAWS}:       "aws/compute/fargate.png",
 	{Kind: ExecutionUnitKind, Type: "eks", Provider: ProviderAWS}:       "aws/compute/elastic-kubernetes-service.png",
 	{Kind: ExecutionUnitKind, Type: "apprunner", Provider: ProviderAWS}: "aws/compute/app-runner.png",
 
@@ -119,7 +119,7 @@ var DiagramEntityToCode = TopoMap{
 	{Kind: string(PersistRedisClusterKind), Provider: ProviderAWS}: `aws_database.ElasticacheForRedis("%s")`, // Theres no memoryDB at the moment
 	{Kind: string(PubSubKind), Provider: ProviderAWS}:              `aws_integration.SNS("%s")`,
 
-	{Kind: ExecutionUnitKind, Type: "fargate", Provider: ProviderAWS}:   `aws_compute.Fargate("%s")`,
+	{Kind: ExecutionUnitKind, Type: "ecs", Provider: ProviderAWS}:       `aws_compute.Fargate("%s")`,
 	{Kind: ExecutionUnitKind, Type: "eks", Provider: ProviderAWS}:       `aws_compute.EKS("%s")`,
 	{Kind: ExecutionUnitKind, Type: "apprunner", Provider: ProviderAWS}: `generic_compute.Rack("AR: %s")`, // Using generic until mingrammer cuts a release with AppRunner
 	{Kind: NetworkLoadBalancerKind, Provider: ProviderAWS}:              `aws_network.ElbNetworkLoadBalancer("%s")`,

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -1429,15 +1429,12 @@ export class CloudCCLib {
             container: {
                 ...baseArgs,
                 image: image,
-                portMappings:
-                    listener != undefined
-                        ? [listener]
-                        : [
-                              {
-                                  containerPort: 3000,
-                                  protocol: 'tcp',
-                              },
-                          ],
+                portMappings: [
+                    {
+                        containerPort: 3000,
+                        protocol: 'tcp',
+                    },
+                ],
                 environment: [
                     { name: 'AWS_XRAY_CONTEXT_MISSING', value: 'LOG_ERROR' },
                     ...additionalEnvVars,

--- a/pkg/infra/pulumi_aws/iac/api_gateway.ts
+++ b/pkg/infra/pulumi_aws/iac/api_gateway.ts
@@ -348,7 +348,7 @@ export class ApiGateway {
             const integrationName = `${execUnit.type}-${r.verb.toUpperCase()}-${routeAndHash}`
             integrationNames.push(integrationName)
             if (execUnit.type == 'ecs') {
-                const nlb = this.lbPlugin.getExecUnitLoadBalancer(r.execUnitName)!
+                const nlb = this.lib.execUnitToNlb.get(r.execUnitName)!
                 const vpcLink = this.lib.execUnitToVpcLink.get(r.execUnitName)!
                 integrations.push(
                     new aws.apigateway.Integration(
@@ -362,7 +362,7 @@ export class ApiGateway {
                             type: 'HTTP_PROXY',
                             connectionType: 'VPC_LINK',
                             connectionId: vpcLink.id,
-                            uri: pulumi.interpolate`http://${nlb.dnsName}${r.path
+                            uri: pulumi.interpolate`http://${nlb.loadBalancer.dnsName}${r.path
                                 .replace(/:([^/]+)/g, '{$1}')
                                 .replace(/[*]\}/g, '+}')}`,
                             requestParameters:

--- a/pkg/infra/pulumi_aws/iac/load_balancing.ts
+++ b/pkg/infra/pulumi_aws/iac/load_balancing.ts
@@ -28,7 +28,6 @@ export interface Route {
 export interface Gateway {
     Name: string
     Routes: Route[]
-    Targets: any
 }
 
 export class LoadBalancerPlugin {
@@ -93,7 +92,7 @@ export class LoadBalancerPlugin {
                 const execUnit = this.lib.resourceIdToResource.get(
                     `${route.execUnitName}_exec_unit`
                 )
-                if (['fargate', 'eks'].includes(execUnit.type)) {
+                if (['ecs', 'eks'].includes(execUnit.type)) {
                     targetGroup = this.createTargetGroup(this.lib.name, route.execUnitName, {
                         port: 3000,
                         protocol: 'HTTP',

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -102,13 +102,6 @@ export = async () => {
     let keepWarm: string[] = [];
 
     {{- $cfg := . }}
-    {{- range .Gateways}}
-    {{- range $key, $value := .Targets}}
-    {{- if eq $value.Kind "nlb"}}
-    cloudLib.createNlb("{{$key}}")
-    {{- end}}
-    {{- end}}
-    {{- end}}
 
     const lbPlugin = new LoadBalancerPlugin(cloudLib)
 
@@ -117,8 +110,8 @@ export = async () => {
     const arUrls: any[] = [];
     {{range $unit := .ExecUnits -}}
 
-    {{- if eq $unit.Type "fargate"}}
-    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, "{{ $unit.NetworkPlacement }}", {{jsonPretty $unit.EnvironmentVariables | indent 4}});
+    {{- if eq $unit.Type "ecs"}}
+    cloudLib.createEcsService("{{$unit.Name}}",{{jsonPretty $unit.Params | indent 4}} as Partial<awsx.ecs.Container>, "{{ $unit.NetworkPlacement }}", {{jsonPretty $unit.EnvironmentVariables | indent 4}}, lbPlugin);
     {{else if eq $unit.Type "eks"}}
     eksUnits.push({name: "{{$unit.Name}}", params: {{jsonPretty $unit.Params | indent 4}}, helmOptions: {{jsonPretty $unit.HelmOptions | indent 4}}, network_placement: "{{ $unit.NetworkPlacement }}" {{- if $unit.EnvironmentVariables}}, envVars: {{jsonPretty $unit.EnvironmentVariables | indent 4}} {{end}}})
     {{else if eq $unit.Type "apprunner"}}

--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -113,7 +113,7 @@ func (h *restAPIHandler) handle(unit *core.ExecutionUnit) error {
 		}
 
 		for _, route := range routes {
-			existsInUnit, it := gw.AddRoute(route.Route, h.Unit, "")
+			existsInUnit := gw.AddRoute(route.Route, h.Unit)
 			if existsInUnit != "" {
 				h.log.Sugar().Infof("Not adding duplicate route %v for %v. Exists in %v", route.Path, route.ExecUnitName, existsInUnit)
 				continue
@@ -130,16 +130,7 @@ func (h *restAPIHandler) handle(unit *core.ExecutionUnit) error {
 				// if the target file is in all units, direct the API gateway to use the unit that defines the listener
 				targetUnit = unit.Name
 			}
-			if it.ExecUnitName == "" {
-				h.Deps.Add(gw.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
-			} else {
-				// If an integration target exists for an exec unit, create the cloud resource and set the deps as gw -> it -> route exec unit
-				if existing := h.Result.Get(it.Key()); existing == nil {
-					h.Result.Add(it)
-				}
-				h.Deps.Add(gw.Key(), it.Key())
-				h.Deps.Add(it.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
-			}
+			h.Deps.Add(gw.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
 		}
 	}
 

--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -177,7 +177,7 @@ func (r *AwsRuntime) AddProxyRuntimeFiles(unit *core.ExecutionUnit, proxyType st
 	switch proxyType {
 	case "eks":
 		proxyFile = proxyEks
-	case "fargate":
+	case "ecs":
 		proxyFile = proxyFargate
 	case "apprunner":
 		proxyFile = proxyApprunner
@@ -202,7 +202,7 @@ func (r *AwsRuntime) AddProxyRuntimeFiles(unit *core.ExecutionUnit, proxyType st
 func (r *AwsRuntime) AddExecRuntimeFiles(unit *core.ExecutionUnit, result *core.CompilationResult, deps *core.Dependencies) error {
 	var DockerFile, Dispatcher []byte
 	switch unit.Type() {
-	case "fargate", "eks", "apprunner":
+	case "ecs", "eks", "apprunner":
 		DockerFile = dockerfileFargate
 		Dispatcher = dispatcherFargate
 	case "lambda":

--- a/pkg/lang/python/aws_runtime/aws.go
+++ b/pkg/lang/python/aws_runtime/aws.go
@@ -99,7 +99,7 @@ func (r *AwsRuntime) AddExecRuntimeFiles(unit *core.ExecutionUnit, result *core.
 		dockerFile = dockerfileLambda
 		dispatcher = dispatcherLambda
 		requirements = execRequirementsLambda
-	case "fargate", "eks", "apprunner":
+	case "ecs", "eks", "apprunner":
 		dockerFile = dockerfileFargate
 		dispatcher = dispatcherFargate
 		requirements = execRequirementsFargate
@@ -162,8 +162,6 @@ func shouldAddExposeRuntimeFiles(unit *core.ExecutionUnit, result *core.Compilat
 	for _, dep := range deps.Upstream(unit.Key()) {
 		res := result.Get(dep)
 		if _, ok := res.(*core.Gateway); ok {
-			return true
-		} else if _, ok := res.(*core.GatewayTarget); ok {
 			return true
 		}
 	}
@@ -239,7 +237,7 @@ func (r *AwsRuntime) AddProxyRuntimeFiles(unit *core.ExecutionUnit, proxyType st
 	switch proxyType {
 	case "eks":
 		fileContents = proxyEksContents
-	case "fargate":
+	case "ecs":
 		fileContents = proxyFargateContents
 	case "lambda":
 		fileContents = proxyLambdaContents

--- a/pkg/lang/python/plugin_expose.go
+++ b/pkg/lang/python/plugin_expose.go
@@ -138,14 +138,7 @@ func (h *restAPIHandler) handle(unit *core.ExecutionUnit) error {
 		}
 
 		for _, route := range routes {
-			targetKind := ""
-			switch h.Unit.Type() {
-			// TODO: move these out of expose into runtime somehow
-			case "fargate":
-				targetKind = core.NetworkLoadBalancerKind
-			}
-
-			existsInUnit, it := gw.AddRoute(route.Route, h.Unit, targetKind)
+			existsInUnit := gw.AddRoute(route.Route, h.Unit)
 			if existsInUnit != "" {
 				h.log.Sugar().Infof("Not adding duplicate route %v for %v. Exists in %v", route.Path, route.ExecUnitName, existsInUnit)
 				continue
@@ -162,16 +155,7 @@ func (h *restAPIHandler) handle(unit *core.ExecutionUnit) error {
 				// if the target file is in all units, direct the API gateway to use the unit that defines the listener
 				targetUnit = unit.Name
 			}
-			if it.ExecUnitName == "" {
-				h.Deps.Add(gw.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
-			} else {
-				// If an integration target exists for an exec unit, create the cloud resource and set the deps as gw -> it -> route exec unit
-				if existing := h.Result.Get(it.Key()); existing == nil {
-					h.Result.Add(it)
-				}
-				h.Deps.Add(gw.Key(), it.Key())
-				h.Deps.Add(it.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
-			}
+			h.Deps.Add(gw.Key(), core.ResourceKey{Name: targetUnit, Kind: core.ExecutionUnitKind})
 		}
 	}
 

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -52,6 +52,7 @@ type GatewayType string
 // Enums for the types we allow in the aws provider so that we can reuse the same string within the provider
 const (
 	eks                                = "eks"
+	ecs                                = "ecs"
 	fargate                            = "fargate"
 	lambda                             = "lambda"
 	rds_postgres                       = "rds_postgres"
@@ -73,7 +74,7 @@ var defaultConfig = config.Defaults{
 				"memorySize": 512,
 				"timeout":    180,
 			},
-			fargate: {
+			ecs: {
 				"memory": 512,
 				"cpu":    256,
 			},
@@ -149,7 +150,7 @@ func (a *AWS) GetDefaultConfig() config.Defaults {
 func (a *AWS) GetKindTypeMappings(kind string) ([]string, bool) {
 	switch kind {
 	case core.ExecutionUnitKind:
-		return []string{eks, fargate, lambda}, true
+		return []string{eks, ecs, fargate, lambda}, true
 	case core.GatewayKind:
 		return []string{string(ApiGateway), string(Alb)}, true
 	case core.StaticUnitKind:

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -53,7 +53,6 @@ type GatewayType string
 const (
 	eks                                = "eks"
 	ecs                                = "ecs"
-	fargate                            = "fargate"
 	lambda                             = "lambda"
 	rds_postgres                       = "rds_postgres"
 	s3                                 = "s3"
@@ -150,7 +149,7 @@ func (a *AWS) GetDefaultConfig() config.Defaults {
 func (a *AWS) GetKindTypeMappings(kind string) ([]string, bool) {
 	switch kind {
 	case core.ExecutionUnitKind:
-		return []string{eks, ecs, fargate, lambda}, true
+		return []string{eks, ecs, lambda}, true
 	case core.GatewayKind:
 		return []string{string(ApiGateway), string(Alb)}, true
 	case core.StaticUnitKind:

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -53,7 +53,7 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 				unit.HelmOptions = *cfg.HelmChartOptions
 			}
 
-			if cfg.Type == "fargate" || cfg.Type == "eks" {
+			if cfg.Type == "ecs" || cfg.Type == "eks" {
 				data.UseVPC = true
 			}
 
@@ -100,8 +100,7 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 		case *core.Gateway:
 			cfg := a.Config.GetExposed(key.Name)
 			gw := provider.Gateway{
-				Name:    res.Name,
-				Targets: res.Targets,
+				Name: res.Name,
 			}
 			for _, route := range res.Routes {
 				gw.Routes = append(gw.Routes, provider.Route{

--- a/pkg/provider/aws/infra_template_test.go
+++ b/pkg/provider/aws/infra_template_test.go
@@ -48,7 +48,7 @@ func TestInfraTemplateModification(t *testing.T) {
 					},
 				},
 				APIGateways: []provider.Gateway{
-					{Name: "gw", Routes: []provider.Route{{ExecUnitName: "", Path: "/", Verb: ""}}, Targets: map[string]core.GatewayTarget(nil)},
+					{Name: "gw", Routes: []provider.Route{{ExecUnitName: "", Path: "/", Verb: ""}}},
 				},
 				UseVPC: true,
 			},

--- a/pkg/provider/infra_template.go
+++ b/pkg/provider/infra_template.go
@@ -76,9 +76,8 @@ type (
 	}
 
 	Gateway struct {
-		Name    string
-		Routes  []Route
-		Targets map[string]core.GatewayTarget
+		Name   string
+		Routes []Route
 	}
 
 	Route struct {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?
closes #116 and closes https://github.com/klothoplatform/klotho-history/issues/633

Renaming fargate to ECS so it aligns with the service name and we can build off of that.
- To do this we check in the Merge of config for exec units and just change the name while throwing a warning. This does log multiple times but we never have a singular place up front to do this (We should likely write the config class to be easier to interact with)

Removes the hardcoded NLBS (Regression of the NLB showing up in topology, however i think the tradeoff is worth it and correct as we wrote code in plugins just to make that happen, but that code wasnt even used in the IAC)

removes GatewayTargets - IMO A gateway target can be derived from dependencies at this stage and when we move AWS code back to compiler we can expand the actual links

For IAC, switched the ecs code off of awsx for load balancing stuff and making it use our LoadBalancing IaC class so that it resembles eks and other lb features in a standardized way

if anyone has a better place to put the warning, im all ears because this is what the output looks like
```sh
new update is available, please run klotho --update to get the latest version
Execution unit type 'fargate' is now renamed to 'ecs'
Execution unit type 'fargate' is now renamed to 'ecs'
Adding resource exec_unit:main
Found 2 route(s) for middleware 'router'                                                                                                                                           unit: main
Adding resource gateway:app
Adding resource persist_kv:users
Execution unit type 'fargate' is now renamed to 'ecs'
Execution unit type 'fargate' is now renamed to 'ecs'
Execution unit type 'fargate' is now renamed to 'ecs'
Execution unit type 'fargate' is now renamed to 'ecs'
Adding resource topology:ts-ms-ecs
Execution unit type 'fargate' is now renamed to 'ecs'
Execution unit type 'fargate' is now renamed to 'ecs'
Adding resource aws_template_data:ts-ms-ecs
Adding resource infra_as_code:Pulumi (AWS)
```




### Standard checks

- **Unit tests**: Any special considerations? this didnt break any unit tests and actually simplifies our code base
- **Docs**: Do we need to update any docs, internal or public? need to update to ecs instead of fargate
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yeah, fargate will still work, but will throw a warning about the renaming. Eventually we will want to remove fargate