### PR TITLE
Update to use klothoplatform/go-tree-sitter

### DIFF
--- a/cmd/ast/main.go
+++ b/cmd/ast/main.go
@@ -85,14 +85,14 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 			for i, capture := range match.Captures {
 				fmt.Printf("[%d.%d] ", matchNum, i)
-				err := lang.WriteAST(capture.Node, jsFile.Program(), os.Stdout)
+				err := lang.WriteAST(capture.Node, os.Stdout)
 				if err != nil {
 					return err
 				}
 			}
 		}
 	} else {
-		err := lang.WriteAST(jsFile.Tree().RootNode(), jsFile.Program(), os.Stdout)
+		err := lang.WriteAST(jsFile.Tree().RootNode(), os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+replace github.com/smacker/go-tree-sitter => github.com/klothoplatform/go-tree-sitter v0.1.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.15.14 h1:i7WCKDToww0wA+9qrUZ1xOjp218vfFo3nTU6UHp+gOc=
 github.com/klauspost/compress v1.15.14/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klothoplatform/go-tree-sitter v0.1.0 h1:sMGZSTGOVNC8R4Jo6J0HKJpCqlFoKhiXZLbHxrN9QsI=
+github.com/klothoplatform/go-tree-sitter v0.1.0/go.mod h1:q99oHDsbP0xRwmn7Vmob8gbSMNyvJ83OauXPSuHQuKE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54 h1:0SMHxjkLKNawqUjjnMlCtEdj6uWZjv0+qDZ3F6GOADI=
@@ -630,8 +632,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3 h1:WrsSqod9T70HFyq8hjL6wambOKb4ISUXzFUuNTJHDwo=
-github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3/go.mod h1:EiUuVMUfLQj8Sul+S8aKWJwQy7FRYnJCO2EWzf8F5hk=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -673,6 +673,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -31,7 +31,7 @@ func OutputAST(input *core.InputFiles, outDir string) error {
 			if err != nil {
 				return errors.Wrapf(err, "could not create ast file %s", efile.Path())
 			}
-			err = lang.WriteAST(astFile.Tree().RootNode(), astFile.Program(), f)
+			err = lang.WriteAST(astFile.Tree().RootNode(), f)
 			f.Close()
 			if err != nil {
 				return errors.Wrapf(err, "could not write ast file content for %s", efile.Path())

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -55,7 +55,7 @@ func OutputCapabilities(input *core.InputFiles, outDir string) error {
 			return errors.Wrapf(err, "could not create caps file %s", efile.Path())
 		}
 		if astFile, ok := efile.(*core.SourceFile); ok {
-			err = lang.PrintCapabilities(astFile.Program(), astFile.Annotations(), f)
+			err = lang.PrintCapabilities(astFile.Annotations(), f)
 		}
 		f.Close()
 		if err != nil {

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -93,7 +93,7 @@ func (err *CompileError) Format(s fmt.State, verb rune) {
 			fmt.Fprintf(s, "\nin %s\n", err.File.Path())
 			fnode := &NodeContent{
 				Endpoints: err.Annotation.Node,
-				Content:   err.Annotation.Node.Content(err.File.Program()),
+				Content:   err.Annotation.Node.Content(),
 			}
 			fnode.Format(s, verb)
 		}

--- a/pkg/lang/ast.go
+++ b/pkg/lang/ast.go
@@ -11,20 +11,18 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-func WriteAST(node *sitter.Node, program []byte, out io.Writer) error {
+func WriteAST(node *sitter.Node, out io.Writer) error {
 	w := ASTWriter{
-		program: program,
-		node:    node,
-		out:     out,
+		node: node,
+		out:  out,
 	}
 	w.WriteAST()
 	return w.Err()
 }
 
 type ASTWriter struct {
-	program []byte
-	out     io.Writer
-	node    *sitter.Node
+	out  io.Writer
+	node *sitter.Node
 
 	errors multierr.Error
 }
@@ -101,7 +99,7 @@ func (w *ASTWriter) WriteAST() {
 			w.writeLine(n, fmt.Sprintf("%s: (%s)", name, n.Type()))
 		} else {
 			if n.Parent() != nil && n.Parent().NamedChildCount() > 0 {
-				content := n.Content(w.program)
+				content := n.Content()
 				if n.Type() == content {
 					w.writeLine(n, fmt.Sprintf("%s = %s", name, content))
 				} else {

--- a/pkg/lang/capabilities.go
+++ b/pkg/lang/capabilities.go
@@ -98,7 +98,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 			break
 		}
 		capture := match[fullCaptureName]
-		comment := capture.Content(f.Program())
+		comment := capture.Content()
 		comment = c.preprocessor(comment)
 
 		combineWithNext := capture.NextSibling() != nil && capture.NextSibling().Type() == capture.Type()
@@ -120,7 +120,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 
 func PrintCapabilities(program []byte, caps core.AnnotationMap, out io.Writer) error {
 	for _, cap := range caps {
-		fmt.Fprintln(out, cap.Capability, cap.Node.Content(program))
+		fmt.Fprintln(out, cap.Capability, cap.Node.Content())
 	}
 	return nil
 }

--- a/pkg/lang/capabilities.go
+++ b/pkg/lang/capabilities.go
@@ -101,7 +101,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 		comment := capture.Content()
 		comment = c.preprocessor(comment)
 
-		combineWithNext := capture.NextSibling() != nil && capture.NextSibling().Type() == capture.Type()
+		combineWithNext := capture.NextSibling() != nil && capture.NextNamedSibling().Type() == capture.Type()
 		node := capture.NextNamedSibling()
 		if node == nil {
 			continue // this is the last node in the AST, so it's effectively a break :)
@@ -118,7 +118,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 	return blocks
 }
 
-func PrintCapabilities(program []byte, caps core.AnnotationMap, out io.Writer) error {
+func PrintCapabilities(caps core.AnnotationMap, out io.Writer) error {
 	for _, cap := range caps {
 		fmt.Fprintln(out, cap.Capability, cap.Node.Content())
 	}

--- a/pkg/lang/capabilities_test.go
+++ b/pkg/lang/capabilities_test.go
@@ -64,6 +64,7 @@ const y = 456`,
 			assert.Equal(tt.Want, found)
 		})
 	}
+
 	t.Run("sitter query has capture", func(t *testing.T) {
 		assert := assert.New(t)
 

--- a/pkg/lang/capabilities_test_helper.go
+++ b/pkg/lang/capabilities_test_helper.go
@@ -38,7 +38,7 @@ func FindAllCommentBlocksForTest(language core.SourceLanguage, source string) ([
 	for _, block := range blocks {
 		found = append(found, FindAllCommentBlocksExpected{
 			Comment: block.comment,
-			Node:    block.node.Content([]byte(source))})
+			Node:    block.node.Content()})
 	}
 	return found, nil
 

--- a/pkg/lang/debug.go
+++ b/pkg/lang/debug.go
@@ -6,10 +6,10 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-func PrintNodes(n map[string]*sitter.Node, src []byte) string {
+func PrintNodes(n map[string]*sitter.Node) string {
 	s := make(map[string]string)
 	for k, v := range n {
-		s[k] = fmt.Sprintf(`(%s) "%s"`, v.Type(), v.Content(src))
+		s[k] = fmt.Sprintf(`(%s) "%s"`, v.Type(), v.Content())
 	}
 	return fmt.Sprintf("%v", s)
 }

--- a/pkg/lang/golang/dispatcher.go
+++ b/pkg/lang/golang/dispatcher.go
@@ -55,7 +55,7 @@ func UpdateImportWithHandlerRequirements(oldFileContent string, imports *sitter.
 
 	newFileContent := oldFileContent
 	var importsToAdd []string
-	importsCode := imports.Content(f.Program())
+	importsCode := imports.Content()
 	// Determine which imports already exist and which we need to add
 	for _, i := range handlerRequirements {
 		if !strings.Contains(importsCode, i) {
@@ -72,7 +72,7 @@ func UpdateImportWithHandlerRequirements(oldFileContent string, imports *sitter.
 	newImportCode = newImportCode + "\n)"
 
 	// Specifically handle removing the old chi import to ensure we only use chi/v5
-	oldNodeContent := imports.Content(f.Program())
+	oldNodeContent := imports.Content()
 	newNodeContent := strings.ReplaceAll(oldNodeContent, "\"github.com/go-chi/chi\"", "")
 
 	newNodeContent = newNodeContent + newImportCode

--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -175,7 +175,7 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 			log.Warn("No http listen found")
 			continue
 		}
-		routerName := listener.Identifier.Content(f.Program())
+		routerName := listener.Identifier.Content()
 
 		importsNode, err := h.FindImports(f)
 		if err != nil {
@@ -187,7 +187,7 @@ func (h *restAPIHandler) handleFile(f *core.SourceFile) (*core.SourceFile, error
 			//TODO: Will likely need to move this into a separate plugin of some sort
 			// Instead of having a dispatcher file, the dipatcher logic is injected into the main.go file. By having that
 			// logic in the expose plugin though, it will only happen if they use the expose annotation for the lambda case.
-			updatedListenContent := UpdateListenWithHandlerCode(string(f.Program()), listener.Expression.Content(f.Program()), routerName)
+			updatedListenContent := UpdateListenWithHandlerCode(string(f.Program()), listener.Expression.Content(), routerName)
 
 			updatedImportContent := UpdateImportWithHandlerRequirements(updatedListenContent, importsNode, f)
 
@@ -268,8 +268,8 @@ func (h *restAPIHandler) findChiRouterDefinition(f *core.SourceFile, appName str
 
 		identifier, definition, declaration := match["identifier"], match["definition"], match["declaration"]
 
-		if definition.Content(f.Program()) == "chi.NewRouter()" {
-			foundName := identifier.Content(f.Program())
+		if definition.Content() == "chi.NewRouter()" {
+			foundName := identifier.Content()
 			if foundName == appName {
 				rootPath := ""
 				return chiRouterDefResult{
@@ -296,14 +296,14 @@ func (h *restAPIHandler) findHttpListenAndServe(cap *core.Annotation, f *core.So
 
 		listenExp, addr, router, expression := match["sel_exp"], match["addr"], match["router"], match["expression"]
 
-		if listenExp.Content(f.Program()) == "http.ListenAndServe" {
+		if listenExp.Content() == "http.ListenAndServe" {
 			return httpListener{
 				Identifier: router,
 				Expression: expression,
 				Address:    addr,
 			}, nil
 		} else {
-			return httpListener{}, errors.Errorf("Expected http.ListenAndServe but found %s", listenExp.Content(f.Program()))
+			return httpListener{}, errors.Errorf("Expected http.ListenAndServe but found %s", listenExp.Content())
 		}
 	}
 
@@ -314,7 +314,7 @@ func (h *restAPIHandler) findChiRoutesForVar(f *core.SourceFile, varName string,
 	var routes = make([]gatewayRouteDefinition, 0)
 	log := h.log.With(logging.FileField(f))
 
-	verbFuncs, err := h.findVerbFuncs(f.Tree().RootNode(), f.Program(), varName)
+	verbFuncs, err := h.findVerbFuncs(f.Tree().RootNode(), varName)
 	if err != nil {
 		return routes, err
 	}
@@ -337,7 +337,7 @@ func (h *restAPIHandler) findChiRoutesForVar(f *core.SourceFile, varName string,
 	return routes, err
 }
 
-func (h *restAPIHandler) findVerbFuncs(root *sitter.Node, source []byte, varName string) ([]routeMethodPath, error) {
+func (h *restAPIHandler) findVerbFuncs(root *sitter.Node, varName string) ([]routeMethodPath, error) {
 	nextMatch := doQuery(root, findExposeVerb)
 	var route []routeMethodPath
 	var err error
@@ -351,20 +351,20 @@ func (h *restAPIHandler) findVerbFuncs(root *sitter.Node, source []byte, varName
 		verb := match["verb"]
 		routePath := match["path"]
 
-		if !query.NodeContentEquals(appName, source, varName) {
+		if !query.NodeContentEquals(appName, varName) {
 			continue // wrong var (not the Chi router we're looking for)
 		}
 
-		funcName := verb.Content(source)
+		funcName := verb.Content()
 
 		if _, supported := core.Verbs[core.Verb(strings.ToUpper(funcName))]; !supported {
 			continue // unsupported verb
 		}
 
-		pathContent := stringLiteralContent(routePath, source)
+		pathContent := stringLiteralContent(routePath)
 
 		route = append(route, routeMethodPath{
-			Verb: verb.Content(source),
+			Verb: verb.Content(),
 			Path: pathContent,
 		})
 	}
@@ -391,7 +391,6 @@ func (h *restAPIHandler) FindImports(f *core.SourceFile) (*sitter.Node, error) {
 }
 
 func (h *restAPIHandler) findChiRouterMounts(f *core.SourceFile, routerName string) []routerMount {
-	source := f.Program()
 	nextMatch := doQuery(f.Tree().RootNode(), findRouterMounts)
 	var mounts = make([]routerMount, 0)
 
@@ -403,15 +402,15 @@ func (h *restAPIHandler) findChiRouterMounts(f *core.SourceFile, routerName stri
 
 		router_name, mount, path, package_name, package_func := match["router_name"], match["mount"], match["path"], match["package_name"], match["package_func"]
 
-		if !query.NodeContentEquals(router_name, f.Program(), routerName) ||
-			!query.NodeContentEquals(mount, f.Program(), "Mount") {
+		if !query.NodeContentEquals(router_name, routerName) ||
+			!query.NodeContentEquals(mount, "Mount") {
 			continue
 		}
 
 		mounts = append(mounts, routerMount{
-			Path:     stringLiteralContent(path, source),
-			PkgAlias: package_name.Content(source),
-			FuncName: package_func.Content(source),
+			Path:     stringLiteralContent(path),
+			PkgAlias: package_name.Content(),
+			FuncName: package_func.Content(),
 		})
 	}
 
@@ -419,7 +418,6 @@ func (h *restAPIHandler) findChiRouterMounts(f *core.SourceFile, routerName stri
 }
 
 func (h *restAPIHandler) findChiRouterMountPackage(f *core.SourceFile, mount *routerMount) error {
-	source := f.Program()
 	nextMatch := doQuery(f.Tree().RootNode(), findImports)
 	for {
 		match, found := nextMatch()
@@ -433,10 +431,10 @@ func (h *restAPIHandler) findChiRouterMountPackage(f *core.SourceFile, mount *ro
 			continue
 		}
 
-		p := strings.Split(stringLiteralContent(package_path, source), "/")
+		p := strings.Split(stringLiteralContent(package_path), "/")
 		package_name := p[len(p)-1]
 		if package_id != nil {
-			if !query.NodeContentEquals(package_id, source, mount.PkgAlias) {
+			if !query.NodeContentEquals(package_id, mount.PkgAlias) {
 				continue
 			}
 			mount.PkgName = package_name
@@ -468,7 +466,7 @@ func (h *restAPIHandler) findFilesForPackageName(pkgName string) []*core.SourceF
 				break
 			}
 			package_name := match["package_name"]
-			if query.NodeContentEquals(package_name, src.Program(), pkgName) {
+			if query.NodeContentEquals(package_name, pkgName) {
 				packageFiles = append(packageFiles, src)
 			}
 		}
@@ -487,7 +485,7 @@ func (h *restAPIHandler) findFileForFunctionName(files []*core.SourceFile, funcN
 			}
 			function_name, function := match["function_name"], match["function"]
 
-			if query.NodeContentEquals(function_name, f.Program(), funcName) {
+			if query.NodeContentEquals(function_name, funcName) {
 				return f, function
 			}
 		}
@@ -496,7 +494,6 @@ func (h *restAPIHandler) findFileForFunctionName(files []*core.SourceFile, funcN
 }
 
 func (h *restAPIHandler) findChiRoutesInFunction(f *core.SourceFile, funcNode *sitter.Node, m routerMount) []gatewayRouteDefinition {
-	source := f.Program()
 	var gatewayRoutes = make([]gatewayRouteDefinition, 0)
 	log := h.log.With(logging.FileField(f))
 
@@ -513,16 +510,16 @@ func (h *restAPIHandler) findChiRoutesInFunction(f *core.SourceFile, funcNode *s
 		verb := match["verb"]
 		routePath := match["path"]
 
-		funcName := verb.Content(source)
+		funcName := verb.Content()
 
 		if _, supported := core.Verbs[core.Verb(strings.ToUpper(funcName))]; !supported {
 			continue // unsupported verb
 		}
 
-		pathContent := stringLiteralContent(routePath, source)
+		pathContent := stringLiteralContent(routePath)
 
 		routes = append(routes, routeMethodPath{
-			Verb: verb.Content(source),
+			Verb: verb.Content(),
 			Path: pathContent,
 		})
 	}

--- a/pkg/lang/golang/plugin_expose_test.go
+++ b/pkg/lang/golang/plugin_expose_test.go
@@ -70,7 +70,7 @@ func Test_findHttpListenServe(t *testing.T) {
 				return
 			}
 
-			assert.Equal(tt.expectAppVar, listener.Identifier.Content(f.Program()))
+			assert.Equal(tt.expectAppVar, listener.Identifier.Content())
 		})
 	}
 }
@@ -111,7 +111,7 @@ func Test_findChiRouterDefinition(t *testing.T) {
 				return
 			}
 
-			assert.Equal(tt.expectAppVar, router.Identifier.Content(f.Program()))
+			assert.Equal(tt.expectAppVar, router.Identifier.Content())
 		})
 	}
 }

--- a/pkg/lang/golang/utils.go
+++ b/pkg/lang/golang/utils.go
@@ -8,12 +8,12 @@ import (
 )
 
 // stringLiteralContent returns the node content with outter quotes removed
-func stringLiteralContent(node *sitter.Node, program []byte) string {
+func stringLiteralContent(node *sitter.Node) string {
 	if node.Type() != "interpreted_string_literal" {
 		panic(fmt.Errorf("node of type %s cannot be parsed as interpreted string literal content", node.Type()))
 	}
 
-	nodeContent := node.Content(program)
+	nodeContent := node.Content()
 	if nodeContent == "" {
 		return ""
 	}

--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -121,7 +121,7 @@ func (r *AwsRuntime) TransformPersist(file *core.SourceFile, annot *core.Annotat
 	case core.PersistORMKind:
 		cfg := r.Config.GetPersisted(annot.Capability.ID, kind)
 		if cfg.Type == "cockroachdb_serverless" {
-			oldNodeContent := annot.Node.Content(file.Program())
+			oldNodeContent := annot.Node.Content()
 			newNodeContent := sequelizeReplaceRE.ReplaceAllString(oldNodeContent, "new cockroachdbSequelize.Sequelize(")
 
 			if err := file.ReplaceNodeContent(annot.Node, newNodeContent); err != nil {

--- a/pkg/lang/javascript/expose.go
+++ b/pkg/lang/javascript/expose.go
@@ -30,7 +30,7 @@ type exposeListenResult struct {
 	Identifier *sitter.Node // Identifier of the listen result (app)
 }
 
-func findListener(cap *core.Annotation, source []byte) exposeListenResult {
+func findListener(cap *core.Annotation) exposeListenResult {
 
 	nextMatch := DoQuery(cap.Node, exposeListener)
 	for {
@@ -41,7 +41,7 @@ func findListener(cap *core.Annotation, source []byte) exposeListenResult {
 
 		prop := match["prop"]
 
-		if prop.Content(source) == "listen" {
+		if prop.Content() == "listen" {
 			return exposeListenResult{
 				Expression: match["expression"],
 				Identifier: match["identifier"],
@@ -114,8 +114,8 @@ func handleGatewayRoutes(info *execUnitExposeInfo, result *core.CompilationResul
 }
 
 // findApp finds the variable containing the listen call for the purpose of adding the export statement
-func findApp(source []byte, listener exposeListenResult) (name string, err error) {
-	listenName := listener.Identifier.Content(source)
+func findApp(listener exposeListenResult) (name string, err error) {
+	listenName := listener.Identifier.Content()
 
 	if listener.Expression.Parent().Type() == "program" {
 		// app is use top-level, and is not a promise
@@ -131,11 +131,11 @@ func findApp(source []byte, listener exposeListenResult) (name string, err error
 				continue
 			}
 			prop := fn.ChildByFieldName("property")
-			if prop.Content(source) != "then" {
+			if prop.Content() != "then" {
 				continue
 			}
 			obj := fn.ChildByFieldName("object")
-			name = obj.Content(source)
+			name = obj.Content()
 
 			return
 		}
@@ -146,7 +146,7 @@ func findApp(source []byte, listener exposeListenResult) (name string, err error
 			program = program.Parent()
 		}
 
-		funcName := fdecl.ChildByFieldName("name").Content(source)
+		funcName := fdecl.ChildByFieldName("name").Content()
 
 		next := DoQuery(program, `(variable_declarator
 			name: (identifier) @name
@@ -160,10 +160,10 @@ func findApp(source []byte, listener exposeListenResult) (name string, err error
 				err = errors.Errorf("no variable declarators for listen in function %s", funcName)
 				return
 			}
-			if match["func"].Content(source) != funcName {
+			if match["func"].Content() != funcName {
 				continue
 			}
-			name = match["name"].Content(source)
+			name = match["name"].Content()
 
 			break
 		}

--- a/pkg/lang/javascript/expose_test.go
+++ b/pkg/lang/javascript/expose_test.go
@@ -130,12 +130,12 @@ async function setup() {
 				annot = v
 				break
 			}
-			listen := findListener(annot, f.Program())
+			listen := findListener(annot)
 			if !assert.NotNil(listen.Expression, "error in test source listen function") {
 				return
 			}
 
-			got, err := findApp(f.Program(), listen)
+			got, err := findApp(listen)
 			if tt.expectErr {
 				assert.Error(err)
 				return

--- a/pkg/lang/javascript/express.go
+++ b/pkg/lang/javascript/express.go
@@ -128,14 +128,14 @@ func (p *ExpressHandler) handleFile(f *core.SourceFile, unit *core.ExecutionUnit
 			return nil, core.NewCompilerError(f, annot, errors.New("expose capability must specify target = \"public\""))
 		}
 
-		listen := findListener(annot, f.Program())
+		listen := findListener(annot)
 
 		if listen.Expression == nil {
 			log.Debug("No listener found")
 			continue
 		}
 
-		appName, err := findApp(f.Program(), listen)
+		appName, err := findApp(listen)
 		if err != nil {
 			return nil, core.NewCompilerError(f, annot, errors.New("Couldnt find expose app creation"))
 		}
@@ -156,7 +156,7 @@ func (p *ExpressHandler) handleFile(f *core.SourceFile, unit *core.ExecutionUnit
 func (h *ExpressHandler) actOnAnnotation(f *core.SourceFile, listen *exposeListenResult, fileContent string, appName string, unitType string, id string) (actedOn bool, newfileContent string) {
 
 	varName := h.findExpress(f)
-	listenVarName := listen.Identifier.Content(f.Program())
+	listenVarName := listen.Identifier.Content()
 	actedOn = false
 	newfileContent = fileContent
 	if varName != listenVarName {
@@ -164,7 +164,7 @@ func (h *ExpressHandler) actOnAnnotation(f *core.SourceFile, listen *exposeListe
 	}
 	//TODO: look into moving this runtime-specific logic elsewhere
 	if unitType == "lambda" {
-		newfileContent = CommentNodes(fileContent, listen.Expression.Content(f.Program()))
+		newfileContent = CommentNodes(fileContent, listen.Expression.Content())
 	}
 	h.output.listeners = append(h.output.listeners, expressListner{varName: listenVarName, f: f, appName: appName, annotationId: id})
 	newfileContent += fmt.Sprintf(`
@@ -184,16 +184,16 @@ func (h *ExpressHandler) findExpress(f *core.SourceFile) string {
 
 		varName, expressName, exports := match["var"], match["express"], match["exports"]
 
-		if exports != nil && !query.NodeContentEquals(exports, f.Program(), "exports") {
+		if exports != nil && !query.NodeContentEquals(exports, "exports") {
 			continue
 		}
 
-		imp := FindImportForVar(f.Tree().RootNode(), f.Program(), expressName.Content(f.Program()))
+		imp := FindImportForVar(f.Tree().RootNode(), expressName.Content())
 		if imp.Source != `express` {
 			continue
 		}
 
-		return varName.Content(f.Program())
+		return varName.Content()
 	}
 	return ""
 }
@@ -226,9 +226,9 @@ func (h *ExpressHandler) assignRoutesToGateway(info *execUnitExposeInfo, result 
 			mwImportName := listenVarName
 			if mw.ObjectName != "" {
 				mwImportName = mw.ObjectName
-				h.log = h.log.With(logging.NodeField(mw.UseExpr, f.Program()))
+				h.log = h.log.With(logging.NodeField(mw.UseExpr))
 			}
-			imp := FindImportForVar(f.Tree().RootNode(), f.Program(), mwImportName)
+			imp := FindImportForVar(f.Tree().RootNode(), mwImportName)
 
 			var routes []gatewayRouteDefinition
 			if imp == (Import{}) {
@@ -246,24 +246,23 @@ func (h *ExpressHandler) assignRoutesToGateway(info *execUnitExposeInfo, result 
 				var exportName string
 				if mw.PropertyName == "" {
 					h.log.Debug("Looking for default export")
-					exportNode := FindDefaultExport(mwFile.Tree().RootNode(), mwFile.Program())
+					exportNode := FindDefaultExport(mwFile.Tree().RootNode())
 					if exportNode == nil {
 						h.log.Sugar().Warnf("Could not find default export in '%s'", mwFile.Path())
 						continue
 					}
-					exportName = exportNode.Content(mwFile.Program())
+					exportName = exportNode.Content()
 				} else {
 					h.log.Sugar().Debugf("Looking for export of %s", mw.PropertyName)
 					exportNode := FindExportForVar(
 						mwFile.Tree().RootNode(),
-						mwFile.Program(),
 						mw.PropertyName,
 					)
 					if exportNode == nil {
 						h.log.Sugar().Warnf("Could not find export for '%s' in '%s'", mw.PropertyName, mwFile.Path())
 						continue
 					}
-					exportName = exportNode.Content(mwFile.Program())
+					exportName = exportNode.Content()
 				}
 
 				if mwUnit := core.FileExecUnitName(mwFile); mwUnit != "" && info.Unit.Name != mwUnit {
@@ -275,7 +274,7 @@ func (h *ExpressHandler) assignRoutesToGateway(info *execUnitExposeInfo, result 
 						fileContent = string(mw.f.Program())
 					}
 
-					fileContent = CommentNodes(fileContent, importAssign.Content(mw.f.Program()), mwUse.Content(mw.f.Program()))
+					fileContent = CommentNodes(fileContent, importAssign.Content(), mwUse.Content())
 					fileContentUpdate[mw.f] = fileContent
 					continue // we have no routes to add, and make sure we don't log the "no routes" warning
 				} else {
@@ -391,17 +390,16 @@ func (h *ExpressHandler) findAllRouterMWs(listenerName string, listnerImportPath
 	for _, res := range h.output.middleware {
 		f := res.File
 		match := res.QueryResult
-		source := f.Program()
 
 		if f.Path() == listnerImportPath {
-			if !query.NodeContentEquals(match["obj"], f.Program(), listenerName) {
+			if !query.NodeContentEquals(match["obj"], listenerName) {
 				continue
 			}
 		} else {
-			obj := strings.Split(match["obj"].Content(f.Program()), ".")
+			obj := strings.Split(match["obj"].Content(), ".")
 			importVar := obj[0]
 
-			imp := FindImportForVar(f.Tree().RootNode(), f.Program(), importVar)
+			imp := FindImportForVar(f.Tree().RootNode(), importVar)
 
 			relPath, err := filepath.Rel(filepath.Dir(f.Path()), listnerImportPath)
 			if err != nil {
@@ -415,16 +413,16 @@ func (h *ExpressHandler) findAllRouterMWs(listenerName string, listnerImportPath
 
 		m := expressMiddleware{
 			UseExpr:    match["expr"],
-			ObjectName: match["mwObj"].Content(source),
+			ObjectName: match["mwObj"].Content(),
 			f:          f,
 		}
 
 		if mwProp := match["mwProp"]; mwProp != nil {
-			m.PropertyName = mwProp.Content(source)
+			m.PropertyName = mwProp.Content()
 		}
 
 		if path := match["path"]; path != nil {
-			m.Path = StringLiteralContent(path, source)
+			m.Path = StringLiteralContent(path)
 		}
 
 		mw = append(mw, m)
@@ -439,22 +437,21 @@ func (h *ExpressHandler) findVerbFuncs(varName string) []routeMethodPath {
 
 		file := res.File
 		match := res.QueryResult
-		source := file.Program()
 
 		obj, prop, path := match["obj"], match["prop"], match["path"]
 
-		if !query.NodeContentEquals(obj, source, varName) {
+		if !query.NodeContentEquals(obj, varName) {
 			continue
 		}
 
-		verb := prop.Content(source)
+		verb := prop.Content()
 		if verb == "all" {
 			verb = "any"
 		}
 
 		mw = append(mw, routeMethodPath{
 			Verb: verb,
-			Path: StringLiteralContent(path, source),
+			Path: StringLiteralContent(path),
 			f:    file,
 		})
 	}
@@ -465,7 +462,7 @@ func (h *ExpressHandler) findVerbFuncs(varName string) []routeMethodPath {
 
 func validateVerbs(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	prop := match["prop"]
-	funcName := prop.Content(f.Program())
+	funcName := prop.Content()
 	if funcName == "all" {
 		funcName = "any"
 	}
@@ -477,7 +474,7 @@ func validateMw(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	prop := match["prop"]
 
 	switch {
-	case !query.NodeContentEquals(prop, f.Program(), "use"):
+	case !query.NodeContentEquals(prop, "use"):
 		return false
 	}
 

--- a/pkg/lang/javascript/express_test.go
+++ b/pkg/lang/javascript/express_test.go
@@ -84,7 +84,7 @@ app.use(router);`,
 			for i, expected := range tt.expect {
 				got := got[i]
 				gotMw := mw{
-					UseExpr:      got.UseExpr.Content(f.Program()),
+					UseExpr:      got.UseExpr.Content(),
 					ObjectName:   got.ObjectName,
 					PropertyName: got.PropertyName,
 					Path:         got.Path,

--- a/pkg/lang/javascript/file_depedencies.go
+++ b/pkg/lang/javascript/file_depedencies.go
@@ -49,11 +49,11 @@ func localImports(input map[string]core.File, f *core.SourceFile) (execunit.Impo
 			continue
 		}
 
-		uses := ImportUsageQuery(f.Tree().RootNode(), f.Program(), imp.ImportedAs())
+		uses := ImportUsageQuery(f.Tree().RootNode(), imp.ImportedAs())
 
 		useNames := make(execunit.References)
 		for _, use := range uses {
-			name := use.Content(f.Program())
+			name := use.Content()
 			useNames.Add(name)
 		}
 		refs, ok := imports[importFile.Path()]

--- a/pkg/lang/javascript/imports_test.go
+++ b/pkg/lang/javascript/imports_test.go
@@ -728,7 +728,7 @@ func TestFindImportForVar(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			p := FindImportForVar(f.Tree().RootNode(), f.Program(), tt.varName)
+			p := FindImportForVar(f.Tree().RootNode(), tt.varName)
 			assert.Equal(tt.want, p.Source)
 		})
 	}

--- a/pkg/lang/javascript/js_modules.go
+++ b/pkg/lang/javascript/js_modules.go
@@ -53,7 +53,7 @@ func FindFileForImport(files map[string]core.File, importingFilePath string, mod
 	return nil, nil
 }
 
-func FindDefaultExport(n *sitter.Node, source []byte) *sitter.Node {
+func FindDefaultExport(n *sitter.Node) *sitter.Node {
 	nextMatch := DoQuery(n, modulesDefault)
 	var last *sitter.Node
 	for {
@@ -63,11 +63,11 @@ func FindDefaultExport(n *sitter.Node, source []byte) *sitter.Node {
 		}
 
 		obj, prop := match["obj"], match["prop"]
-		if obj != nil && !query.NodeContentEquals(obj, source, "module") {
+		if obj != nil && !query.NodeContentEquals(obj, "module") {
 			continue
 		}
 
-		if !query.NodeContentEquals(prop, source, "exports") {
+		if !query.NodeContentEquals(prop, "exports") {
 			continue
 		}
 		last = match["last"]
@@ -77,7 +77,7 @@ func FindDefaultExport(n *sitter.Node, source []byte) *sitter.Node {
 }
 
 // FindExportForVar returns the local variable that is exported as 'varName' (to handle cases where they don't match).
-func FindExportForVar(n *sitter.Node, source []byte, varName string) *sitter.Node {
+func FindExportForVar(n *sitter.Node, varName string) *sitter.Node {
 	nextMatch := DoQuery(n, modulesExport)
 	var last *sitter.Node
 	for {
@@ -88,10 +88,10 @@ func FindExportForVar(n *sitter.Node, source []byte, varName string) *sitter.Nod
 
 		obj, prop, right := match["obj"], match["prop"], match["right"]
 
-		if !query.NodeContentEquals(obj, source, "exports") {
+		if !query.NodeContentEquals(obj, "exports") {
 			continue
 		}
-		if !query.NodeContentEquals(prop, source, varName) {
+		if !query.NodeContentEquals(prop, varName) {
 			continue
 		}
 		if right.Type() == "identifier" {

--- a/pkg/lang/javascript/js_modules_test.go
+++ b/pkg/lang/javascript/js_modules_test.go
@@ -41,11 +41,11 @@ func TestFindDefaultExport(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			got := FindDefaultExport(f.Tree().RootNode(), f.Program())
+			got := FindDefaultExport(f.Tree().RootNode())
 			if tt.want == "" {
 				assert.Nil(got)
 			} else if assert.NotNil(got) {
-				assert.Equal(tt.want, got.Content(f.Program()))
+				assert.Equal(tt.want, got.Content())
 			}
 		})
 	}
@@ -85,11 +85,11 @@ func TestFindExportForVar(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			got := FindExportForVar(f.Tree().RootNode(), f.Program(), tt.varName)
+			got := FindExportForVar(f.Tree().RootNode(), tt.varName)
 			if tt.want == "" {
 				assert.Nil(got)
 			} else if assert.NotNil(got) {
-				assert.Equal(tt.want, got.Content(f.Program()))
+				assert.Equal(tt.want, got.Content())
 			}
 		})
 	}

--- a/pkg/lang/javascript/nestjs.go
+++ b/pkg/lang/javascript/nestjs.go
@@ -110,14 +110,14 @@ func (p *NestJsHandler) handleFile(f *core.SourceFile, unit *core.ExecutionUnit)
 
 		}
 
-		listen := findListener(annot, f.Program())
+		listen := findListener(annot)
 
 		if listen.Expression == nil {
 			log.Debug("No listener found")
 			continue
 		}
 
-		appName, err := findApp(f.Program(), listen)
+		appName, err := findApp(listen)
 		if err != nil {
 			return nil, core.NewCompilerError(f, annot, errors.New("Couldnt find expose app creation"))
 		}
@@ -176,7 +176,7 @@ func (h *NestJsHandler) actOnAnnotation(f *core.SourceFile, listen *exposeListen
 		return
 	}
 
-	if listen.Identifier.Content(f.Program()) != nestFactory.varName {
+	if listen.Identifier.Content() != nestFactory.varName {
 		return
 	}
 
@@ -184,9 +184,9 @@ func (h *NestJsHandler) actOnAnnotation(f *core.SourceFile, listen *exposeListen
 	if unitType == "lambda" {
 		// After CommentNode, `listen` is not a valid node
 		if listen.Expression.Parent().Parent().Type() == "await_expression" {
-			newfileContent = CommentNodes(fileContent, listen.Expression.Parent().Parent().Content(f.Program()))
+			newfileContent = CommentNodes(fileContent, listen.Expression.Parent().Parent().Content())
 		} else {
-			newfileContent = CommentNodes(fileContent, listen.Expression.Content(f.Program()))
+			newfileContent = CommentNodes(fileContent, listen.Expression.Content())
 		}
 	}
 
@@ -224,11 +224,11 @@ func (h *NestJsHandler) findNestFactory(f *core.SourceFile) nestFactoryResult {
 			continue
 		}
 
-		imp := FindImportForVar(f.Tree().RootNode(), f.Program(), moduleImportId.Content(f.Program()))
+		imp := FindImportForVar(f.Tree().RootNode(), moduleImportId.Content())
 		return nestFactoryResult{
 			f:                f,
-			varName:          varName.Content(f.Program()),
-			moduleImportName: moduleProp.Content(f.Program()),
+			varName:          varName.Content(),
+			moduleImportName: moduleProp.Content(),
 			moduleImportPath: imp.Source,
 		}
 	}
@@ -270,9 +270,9 @@ func (h *NestJsHandler) findControllers(unitName string) map[string]nestControll
 
 		varName, basePath := result["name"], result["basePath"]
 
-		controllerName := varName.Content(f.Program())
+		controllerName := varName.Content()
 
-		routes := h.findRoutesForController(controllerName, StringLiteralContent(basePath, f.Program()), unitName)
+		routes := h.findRoutesForController(controllerName, StringLiteralContent(basePath), unitName)
 
 		controllers[controllerName] = nestController{
 			f:      f,
@@ -292,17 +292,17 @@ func (h *NestJsHandler) findRoutesForController(controllerName string, basePath 
 
 		controller, method, routePath := result["controller"], result["method"], result["path"]
 
-		if controller.Content(f.Program()) != controllerName {
+		if controller.Content() != controllerName {
 			continue
 		}
 
 		methodPath := basePath
 
 		if routePath != nil {
-			methodPath = path.Join(basePath, StringLiteralContent(routePath, f.Program()))
+			methodPath = path.Join(basePath, StringLiteralContent(routePath))
 		}
 
-		verb := method.Content(f.Program())
+		verb := method.Content()
 		if verb == "All" {
 			verb = "Any"
 		}
@@ -332,12 +332,12 @@ func (h *NestJsHandler) findModules(controllers map[string]nestController) map[s
 		result := ref.QueryResult
 
 		varName, pairKey, controllerName, controllerImport := result["name"], result["pairKey"], result["controllerName"], result["controllerImport"]
-		moduleName := varName.Content(f.Program())
+		moduleName := varName.Content()
 
 		var moduleControllers []nestController
-		controllersImport := controllerImport.Content(f.Program())
-		controllersName := controllerName.Content(f.Program())
-		key := pairKey.Content(f.Program())
+		controllersImport := controllerImport.Content()
+		controllersName := controllerName.Content()
+		key := pairKey.Content()
 		if key == "controllers" {
 			controller, ok := controllers[controllersName]
 			if !ok {
@@ -375,25 +375,25 @@ func (h *NestJsHandler) findModules(controllers map[string]nestController) map[s
 
 func validateController(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	importName, method := match["import"], match["method"]
-	imp := FindImportForVar(f.Tree().RootNode(), f.Program(), importName.Content(f.Program()))
-	return imp.Source == "@nestjs/common" && method.Content(f.Program()) == "Controller"
+	imp := FindImportForVar(f.Tree().RootNode(), importName.Content())
+	return imp.Source == "@nestjs/common" && method.Content() == "Controller"
 }
 
 func ValidateModule(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	importName, method := match["import"], match["method"]
-	imp := FindImportForVar(f.Tree().RootNode(), f.Program(), importName.Content(f.Program()))
-	return imp.Source == "@nestjs/common" && method.Content(f.Program()) == "Module"
+	imp := FindImportForVar(f.Tree().RootNode(), importName.Content())
+	return imp.Source == "@nestjs/common" && method.Content() == "Module"
 }
 
 func validateRoute(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	importName := match["import"]
-	imp := FindImportForVar(f.Tree().RootNode(), f.Program(), importName.Content(f.Program()))
+	imp := FindImportForVar(f.Tree().RootNode(), importName.Content())
 	return imp.Source == "@nestjs/common"
 }
 
 func validateNestFactory(match map[string]*sitter.Node, f *core.SourceFile) bool {
 	importName, call := match["import"], match["call"]
-	importedName := importName.Content(f.Program())
-	imp := FindImportForVar(f.Tree().RootNode(), f.Program(), importName.Content(f.Program()))
-	return imp.Source == "@nestjs/core" && call.Content(f.Program()) == importedName+".NestFactory.create"
+	importedName := importName.Content()
+	imp := FindImportForVar(f.Tree().RootNode(), importName.Content())
+	return imp.Source == "@nestjs/core" && call.Content() == importedName+".NestFactory.create"
 }

--- a/pkg/lang/javascript/nestjs_test.go
+++ b/pkg/lang/javascript/nestjs_test.go
@@ -33,7 +33,7 @@ func Test_nestHandler_QueryResources(t *testing.T) {
 				})
 			], AppModule);`,
 			numResources: map[string]int{
-				"modules":     3, // We actually match 3 here because we look for each match of pairs that are member expressions. Then in the code we check the key of that pair to ensure its controllers
+				"modules":     2, // UsersController & OrgController
 				"controllers": 0,
 				"routes":      0,
 			},

--- a/pkg/lang/javascript/plugin_nodejs_executable.go
+++ b/pkg/lang/javascript/plugin_nodejs_executable.go
@@ -109,7 +109,7 @@ func warnIfContainsES6Import(file core.File) {
 
 	for _, p := range FindImportsInFile(jsF).Filter(filter.NewSimpleFilter(IsImportOfKind(ImportKindES))) {
 		if p.Kind == ImportKindES {
-			zap.L().Sugar().With(logging.FileField(jsF), logging.NodeField(p.ImportNode, jsF.Program())).Warn(
+			zap.L().Sugar().With(logging.FileField(jsF), logging.NodeField(p.ImportNode)).Warn(
 				"ES6 import statements are not yet supported: please use CommonJS 'require()' syntax instead")
 		}
 	}

--- a/pkg/lang/javascript/plugin_persist_test.go
+++ b/pkg/lang/javascript/plugin_persist_test.go
@@ -192,7 +192,7 @@ func Test_queryKV(t *testing.T) {
 
 			if tt.matchExpression != "" || tt.matchName != "" {
 				if assert.NotNil(kvResult) {
-					assert.Equal(tt.matchExpression, kvResult.expression.Content(f.Program()))
+					assert.Equal(tt.matchExpression, kvResult.expression.Content())
 					assert.Equal(tt.matchName, kvResult.name)
 				}
 			} else {
@@ -352,7 +352,7 @@ func Test_queryFS(t *testing.T) {
 				if !assert.NotNil(fsResult) {
 					return
 				}
-				assert.Equal(tt.matchExpression, fsResult.expression.Content(f.Program()))
+				assert.Equal(tt.matchExpression, fsResult.expression.Content())
 				assert.Equal(tt.matchName, fsResult.name)
 			} else {
 				assert.Nil(fsResult)
@@ -428,7 +428,7 @@ func Test_queryORM(t *testing.T) {
 			}, true)
 			if tt.matchExpression != "" {
 				assert.NotNil(fsResult)
-				assert.Equal(tt.matchExpression, fsResult.expression.Content(f.Program()))
+				assert.Equal(tt.matchExpression, fsResult.expression.Content())
 				assert.Equal(tt.matchName, fsResult.name)
 			} else {
 				assert.Nil(fsResult)
@@ -533,7 +533,7 @@ func Test_queryRedis(t *testing.T) {
 				Node:       f.Tree().RootNode(),
 			}, true)
 			if tt.matchExpression != "" {
-				assert.Equal(tt.matchExpression, fsResult.expression.Content(f.Program()))
+				assert.Equal(tt.matchExpression, fsResult.expression.Content())
 				assert.Equal(tt.matchName, fsResult.name)
 			} else {
 				assert.Nil(fsResult)

--- a/pkg/lang/javascript/plugin_pubsub.go
+++ b/pkg/lang/javascript/plugin_pubsub.go
@@ -149,7 +149,7 @@ func (p *Pubsub) rewriteFileEmitters(f *core.SourceFile, vars VarDeclarations) e
 	}
 
 	for spec, varReference := range vars {
-		expr := varReference.Annotation.Node.Content(f.Program())
+		expr := varReference.Annotation.Node.Content()
 		newExpr := emitterRE.ReplaceAllString(
 			expr,
 			fmt.Sprintf(`%sRuntime.Emitter("%s", "%s", "%s")`, emitterRTName, f.Path(), spec.VarName, varReference.Annotation.Capability.ID),
@@ -330,7 +330,7 @@ func (p *Pubsub) generateEmitterDefinitions() (err error) {
 			additional := "// klotho generated\n"
 			hasAdditional := false
 			for spec, emitter := range emitters {
-				emitterExport := FindExportForVar(js.Tree().RootNode(), js.Program(), spec.VarName)
+				emitterExport := FindExportForVar(js.Tree().RootNode(), spec.VarName)
 				if emitterExport == nil {
 					// If the file already existed as original, the export should already be there
 					// If the file already existed but was a proxy, we need to add the emitter creation & export
@@ -387,11 +387,11 @@ func findTopics(f *core.SourceFile, spec VarSpec, query string, methodName strin
 			break
 		}
 		switch {
-		case match["func"].Content(f.Program()) != methodName,
-			match["emitter"].Content(f.Program()) != varName:
+		case match["func"].Content() != methodName,
+			match["emitter"].Content() != varName:
 			continue
 		}
-		topic := StringLiteralContent(match["topic"], f.Program())
+		topic := StringLiteralContent(match["topic"])
 		topics = append(topics, topic)
 	}
 

--- a/pkg/lang/javascript/proxy_call.go
+++ b/pkg/lang/javascript/proxy_call.go
@@ -5,7 +5,7 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-func SpecificExportQuery(n *sitter.Node, source []byte, wantName string) *sitter.Node {
+func SpecificExportQuery(n *sitter.Node, wantName string) *sitter.Node {
 	nextMatch := DoQuery(n, proxyExport)
 
 	var last *sitter.Node
@@ -17,13 +17,13 @@ func SpecificExportQuery(n *sitter.Node, source []byte, wantName string) *sitter
 
 		result, obj, name := match["result"], match["obj"], match["name"]
 
-		if !query.NodeContentEquals(obj, source, "exports") {
+		if !query.NodeContentEquals(obj, "exports") {
 			continue
 		}
 
 		if wantName == "" {
 			last = result
-		} else if query.NodeContentEquals(name, source, wantName) {
+		} else if query.NodeContentEquals(name, wantName) {
 			last = result
 		}
 	}
@@ -34,7 +34,7 @@ func SpecificExportQuery(n *sitter.Node, source []byte, wantName string) *sitter
 	return last
 }
 
-func ImportUsageQuery(n *sitter.Node, source []byte, importName string) []*sitter.Node {
+func ImportUsageQuery(n *sitter.Node, importName string) []*sitter.Node {
 	nodes := make([]*sitter.Node, 0)
 	nextMatch := DoQuery(n, proxyUsage)
 	for {
@@ -45,7 +45,7 @@ func ImportUsageQuery(n *sitter.Node, source []byte, importName string) []*sitte
 
 		obj, prop := match["obj"], match["prop"]
 
-		if query.NodeContentEquals(obj, source, importName) {
+		if query.NodeContentEquals(obj, importName) {
 			nodes = append(nodes, prop)
 		}
 
@@ -53,7 +53,7 @@ func ImportUsageQuery(n *sitter.Node, source []byte, importName string) []*sitte
 	return nodes
 }
 
-func SpecificAsyncFuncDecl(n *sitter.Node, source []byte, funcName string) *sitter.Node {
+func SpecificAsyncFuncDecl(n *sitter.Node, funcName string) *sitter.Node {
 	nextMatch := DoQuery(n, proxyAsync)
 	for {
 		match, found := nextMatch()
@@ -65,11 +65,11 @@ func SpecificAsyncFuncDecl(n *sitter.Node, source []byte, funcName string) *sitt
 
 		// Because `async` is not a named child, we cannot get/select it from the query.
 		checkAsyncNode := function.Child(0)
-		if !query.NodeContentEquals(checkAsyncNode, source, "async") {
+		if !query.NodeContentEquals(checkAsyncNode, "async") {
 			continue
 		}
 
-		if query.NodeContentEquals(name, source, funcName) {
+		if query.NodeContentEquals(name, funcName) {
 			return function
 		}
 	}

--- a/pkg/lang/javascript/proxy_call_test.go
+++ b/pkg/lang/javascript/proxy_call_test.go
@@ -64,9 +64,9 @@ func TestSpecificExportQuery(t *testing.T) {
 				return
 			}
 
-			node := SpecificExportQuery(tree.RootNode(), []byte(tt.source), tt.queryName)
+			node := SpecificExportQuery(tree.RootNode(), tt.queryName)
 			if tt.matchString != "" && assert.NotNil(node) {
-				str := node.Content([]byte(tt.source))
+				str := node.Content()
 				assert.Equal(tt.matchString, str)
 			} else {
 				assert.Nil(node)

--- a/pkg/lang/javascript/queries/exported_var.scm
+++ b/pkg/lang/javascript/queries/exported_var.scm
@@ -6,7 +6,7 @@
     )
 		right: (_) @right
 	) @assign
-  (#match? @obj "^exports$") ;; not supported in go-tree-sitter
+  ;;(#match? @obj "^exports$") ;; not supported in go-tree-sitter
 )
 
 ;; TODO: not supported syntaxes:

--- a/pkg/lang/javascript/queries/exported_var.scm
+++ b/pkg/lang/javascript/queries/exported_var.scm
@@ -6,7 +6,7 @@
     )
 		right: (_) @right
 	) @assign
-  ;;(#match? @obj "^exports$") ;; not supported in go-tree-sitter
+  (#match? @obj "^exports$") ;; not supported in go-tree-sitter
 )
 
 ;; TODO: not supported syntaxes:

--- a/pkg/lang/javascript/queries/expose/nestJs/module.scm
+++ b/pkg/lang/javascript/queries/expose/nestJs/module.scm
@@ -1,40 +1,38 @@
-[
-    (assignment_expression 
-        left: (identifier) @name
-        right: (call_expression
-            function: (_) @func
-            arguments: (arguments
-                (array
-                    (call_expression
-                        (parenthesized_expression
-                            (sequence_expression
-                                right: (member_expression
-                                    object: (identifier) @import
-                                    property: (property_identifier) @method
-                                )
-                            )
-                        )
-                        (arguments
-                            (object
-                            	(pair
-                                	key: (property_identifier) @pairKey
-                                    value: (array
-                                    	(member_expression
-                                        	object: (identifier) @controllerImport
-                                            property: (property_identifier) @controllerName
-                                        )@controllers
-                                    )
-                                )
-                                ;;(#match? @pairKey "^controllers$")
+(assignment_expression 
+    left: (identifier) @name
+    right: (call_expression
+        function: (_) @func
+        arguments: (arguments
+            (array
+                (call_expression
+                    (parenthesized_expression
+                        (sequence_expression
+                            right: (member_expression
+                                object: (identifier) @import
+                                property: (property_identifier) @method
                             )
                         )
                     )
+                    (arguments
+                        (object
+                            (pair
+                                key: (property_identifier) @pairKey
+                                value: (array
+                                    (member_expression
+                                        object: (identifier) @controllerImport
+                                        property: (property_identifier) @controllerName
+                                    )@controllers
+                                )
+                            )
+                            (#match? @pairKey "^controllers$")
+                        )
+                    )
                 )
-                (identifier) @moduleName
             )
+            (identifier) @moduleName
         )
     )
-]
+)
 
 ;; AppModule = __decorate([
 ;;    (0, common_1.Module)({

--- a/pkg/lang/javascript/queries/expose/nestJs/module.scm
+++ b/pkg/lang/javascript/queries/expose/nestJs/module.scm
@@ -25,7 +25,7 @@
                                         )@controllers
                                     )
                                 )
-                                (#match? @pairKey "^controllers$")
+                                ;;(#match? @pairKey "^controllers$")
                             )
                         )
                     )

--- a/pkg/lang/javascript/queries/pubsub/publisher.scm
+++ b/pkg/lang/javascript/queries/pubsub/publisher.scm
@@ -12,5 +12,5 @@
       (string) @topic
     )
   )
-  ;;(#match? @func "^emit$") ;; not supported in go-tree-sitter
+  (#match? @func "^emit$") ;; not supported in go-tree-sitter
 )

--- a/pkg/lang/javascript/queries/pubsub/publisher.scm
+++ b/pkg/lang/javascript/queries/pubsub/publisher.scm
@@ -12,5 +12,5 @@
       (string) @topic
     )
   )
-  (#match? @func "^emit$") ;; not supported in go-tree-sitter
+  ;;(#match? @func "^emit$") ;; not supported in go-tree-sitter
 )

--- a/pkg/lang/javascript/queries/pubsub/subscriber.scm
+++ b/pkg/lang/javascript/queries/pubsub/subscriber.scm
@@ -12,5 +12,5 @@
       (string) @topic
     )
   )
-  ;;(#match? @func "^on$") ;; not supported in go-tree-sitter
+  (#match? @func "^on$") ;; not supported in go-tree-sitter
 )

--- a/pkg/lang/javascript/queries/pubsub/subscriber.scm
+++ b/pkg/lang/javascript/queries/pubsub/subscriber.scm
@@ -12,5 +12,5 @@
       (string) @topic
     )
   )
-  (#match? @func "^on$") ;; not supported in go-tree-sitter
+  ;;(#match? @func "^on$") ;; not supported in go-tree-sitter
 )

--- a/pkg/lang/javascript/utils.go
+++ b/pkg/lang/javascript/utils.go
@@ -6,6 +6,6 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-func StringLiteralContent(node *sitter.Node, program []byte) string {
-	return strings.Trim(node.Content(program), `'"`)
+func StringLiteralContent(node *sitter.Node) string {
+	return strings.Trim(node.Content(), `'"`)
 }

--- a/pkg/lang/javascript/var_finder.go
+++ b/pkg/lang/javascript/var_finder.go
@@ -143,24 +143,24 @@ func (vf *varFinder) parseNode(f *core.SourceFile, annot *core.Annotation) (inte
 		if !found {
 			break
 		}
-		if match["type"].Content(f.Program()) != vf.queryMatchType {
+		if match["type"].Content() != vf.queryMatchType {
 			continue
 		}
-		internalName = match["name"].Content(f.Program())
+		internalName = match["name"].Content()
 
 		if module := match["ctor.obj"]; module != nil {
-			moduleStr := module.Content(f.Program())
+			moduleStr := module.Content()
 			if moduleStr != vf.queryMatchTypeModule {
 				return "", "", errors.Errorf("ignoring export because its qualified module name is not \"%s\"", vf.queryMatchTypeModule)
 			}
 		}
 		if obj := match["var.obj"]; obj != nil {
-			objStr := obj.Content(f.Program())
+			objStr := obj.Content()
 			if objStr != "exports" {
 				return "", "", errors.Errorf(`unsupported: non-"exports" object property assignment (%s.%s)`, objStr, internalName)
 			}
 			exportName = internalName
-			internalName = match["var"].Content(f.Program()) // use fully-qualified object & property
+			internalName = match["var"].Content() // use fully-qualified object & property
 			return
 		}
 
@@ -171,17 +171,17 @@ func (vf *varFinder) parseNode(f *core.SourceFile, annot *core.Annotation) (inte
 				break
 			}
 
-			if exportMatch["obj"].Content(f.Program()) != "exports" {
+			if exportMatch["obj"].Content() != "exports" {
 				continue
 			}
 
-			if exportMatch["right"].Content(f.Program()) != internalName {
+			if exportMatch["right"].Content() != internalName {
 				continue
 			}
 
-			exportName = exportMatch["prop"].Content(f.Program())
+			exportName = exportMatch["prop"].Content()
 			if exportName != internalName {
-				zap.S().Debugf(`found export of '%s' as '%s': "%s"`, internalName, exportName, exportMatch["assign"].Content(f.Program()))
+				zap.S().Debugf(`found export of '%s' as '%s': "%s"`, internalName, exportName, exportMatch["assign"].Content())
 			}
 			return
 		}

--- a/pkg/lang/python/functions.go
+++ b/pkg/lang/python/functions.go
@@ -25,7 +25,7 @@ func (a FunctionArg) String() string {
 	return a.Value
 }
 
-func getNextCallDetails(node *sitter.Node, program []byte) (callDetails FunctionCallDetails, found bool) {
+func getNextCallDetails(node *sitter.Node) (callDetails FunctionCallDetails, found bool) {
 	fnName := ""
 	nextMatch := DoQuery(node, findFunctionCalls)
 	callDetails = FunctionCallDetails{Arguments: []FunctionArg{}}
@@ -39,20 +39,20 @@ func getNextCallDetails(node *sitter.Node, program []byte) (callDetails Function
 		argName := match["argName"]
 		arg := match["arg"]
 
-		if fnName != "" && !query.NodeContentEquals(fn, program, fnName) {
+		if fnName != "" && !query.NodeContentEquals(fn, fnName) {
 			break
 		}
 
-		fnName = fn.Content(program)
+		fnName = fn.Content()
 		argNameContent := ""
 		argContent := ""
 		callDetails.Name = fnName
 
 		if argName != nil {
-			argNameContent = argName.Content(program)
+			argNameContent = argName.Content()
 		}
 		if arg != nil {
-			argContent = arg.Content(program)
+			argContent = arg.Content()
 		}
 
 		// ignore overlapping pattern that captures keyword_argument nodes as standard aguments

--- a/pkg/lang/python/functions_test.go
+++ b/pkg/lang/python/functions_test.go
@@ -72,7 +72,7 @@ func Test_getNextCallDetails(t *testing.T) {
 				return
 			}
 
-			details, found := getNextCallDetails(f.Tree().RootNode(), f.Program())
+			details, found := getNextCallDetails(f.Tree().RootNode())
 
 			assert.Equal(tt.wantCallDetails, details)
 			assert.Equal(tt.wantFound, found)

--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -84,7 +84,7 @@ func FindImports(file *core.SourceFile) Imports {
 
 		prefixContent := ""
 		if importPrefix != nil {
-			prefixContent = importPrefix.Content(file.Program())
+			prefixContent = importPrefix.Content()
 		}
 
 		moduleContent := ""
@@ -93,7 +93,7 @@ func FindImports(file *core.SourceFile) Imports {
 		aliasName := ""
 
 		if module != nil {
-			moduleContent = module.Content(file.Program())
+			moduleContent = module.Content()
 			lastPeriod := strings.LastIndex(moduleContent, ".")
 
 			if lastPeriod != -1 {
@@ -103,7 +103,7 @@ func FindImports(file *core.SourceFile) Imports {
 				moduleName = moduleContent
 			}
 		} else if aliasedModule != nil {
-			moduleContent = aliasedModule.Content(file.Program())
+			moduleContent = aliasedModule.Content()
 			lastPeriod := strings.LastIndex(moduleContent, ".")
 
 			if lastPeriod != -1 {
@@ -112,7 +112,7 @@ func FindImports(file *core.SourceFile) Imports {
 			} else {
 				moduleName = moduleContent
 			}
-			aliasName = alias.Content(file.Program())
+			aliasName = alias.Content()
 		}
 
 		parent = prefixContent + parent
@@ -129,14 +129,14 @@ func FindImports(file *core.SourceFile) Imports {
 		i := fileImports[qualifiedModuleName]
 		// technically, this may be a submodule, but we can't tell without deeper analysis of the imported file
 		if attribute != nil {
-			attributeName := attribute.Content(file.Program())
+			attributeName := attribute.Content()
 			ia := i.ImportedAttributes
 			if ia == nil {
 				ia = map[string]Attribute{}
 			}
 			aliasFrom := ""
 			if alias != nil {
-				aliasFrom = alias.Content(file.Program())
+				aliasFrom = alias.Content()
 			}
 			ia[attributeName] = Attribute{
 				Name:  attributeName,
@@ -198,8 +198,8 @@ func ResolveFileDependencies(files map[string]core.File) (execunit.FileDependenc
 							break
 						}
 						objName, attrName := attrUsage["obj_name"], attrUsage["attr_name"]
-						if query.NodeContentEquals(objName, pyFile.Program(), importSpec.ImportedAs()) {
-							attrNameStr := attrName.Content(pyFile.Program())
+						if query.NodeContentEquals(objName, importSpec.ImportedAs()) {
+							attrNameStr := attrName.Content()
 							refs[attrNameStr] = struct{}{}
 						}
 					}

--- a/pkg/lang/python/plugin_expose_test.go
+++ b/pkg/lang/python/plugin_expose_test.go
@@ -61,7 +61,7 @@ func Test_findFastApiApp(t *testing.T) {
 				return
 			}
 
-			assert.Equal(tt.expectAppVar, app.Identifier.Content(f.Program()))
+			assert.Equal(tt.expectAppVar, app.Identifier.Content())
 			assert.Equal(tt.expectRootPath, app.RootPath)
 		})
 	}
@@ -218,7 +218,7 @@ func Test_fastapiHandler_findVerbFuncs(t *testing.T) {
 			if !assert.NoError(err) {
 				return
 			}
-			got, _ := testRestAPIHandler.findVerbFuncs(f.Tree().RootNode(), f.Program(), tt.varName)
+			got, _ := testRestAPIHandler.findVerbFuncs(f.Tree().RootNode(), tt.varName)
 			assert.Equal(tt.expect, got)
 			assert.Equal(len(tt.expect), len(got))
 		})

--- a/pkg/lang/python/plugin_persist_test.go
+++ b/pkg/lang/python/plugin_persist_test.go
@@ -352,7 +352,7 @@ async with secrets.open(s, mode='r') as f:
 			`,
 			secretsImportName: "secrets",
 			want:              []string{},
-			wantErr:           true,
+			wantErr:           false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/lang/python/queries/persist/aiofiles_open.scm
+++ b/pkg/lang/python/queries/persist/aiofiles_open.scm
@@ -1,21 +1,21 @@
 (with_statement
 	(with_clause
      	(with_item
-    		value: (call
+    		value: (as_pattern
+                (call
             		function: (attribute
                     	object: (identifier) @module
                         attribute: (identifier) @moduleMethod
                     )
                     arguments: (argument_list
-                    [
+                        .
                     	(string) @path
-                        (_)
-                    ]
                     )
+                )
+                (as_pattern_target (identifier) @varOut)
             )
-        	alias: (identifier) @varOut
-    	) 
-    )@withItem
+    	) @withItem
+    )
     body: (block
     	(expression_statement [
             (assignment

--- a/pkg/lang/python/utils.go
+++ b/pkg/lang/python/utils.go
@@ -2,20 +2,21 @@ package python
 
 import (
 	"fmt"
-	sitter "github.com/smacker/go-tree-sitter"
 	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // stringLiteralContent returns the string literal content of the supplied node
 // after stripping any enclosing quotes and un-escaping any quotes of the same type inside the string.
 //
 // Passing in a Node that references a b-string will result in an error.
-func stringLiteralContent(node *sitter.Node, program []byte) (string, error) {
+func stringLiteralContent(node *sitter.Node) (string, error) {
 	if node.Type() != "string" {
 		return "", fmt.Errorf("node of type %s cannot be parsed as string literal content", node.Type())
 	}
 
-	nodeContent := node.Content(program)
+	nodeContent := node.Content()
 	if nodeContent == "" {
 		return "", nil
 	}

--- a/pkg/lang/python/utils_test.go
+++ b/pkg/lang/python/utils_test.go
@@ -57,7 +57,7 @@ func Test_stringLiteralContent(t *testing.T) {
 			assert := assert.New(t)
 
 			f, _ := core.NewSourceFile("", strings.NewReader(tt.inputStr), Language)
-			got, err := stringLiteralContent(f.Tree().RootNode().Child(0).Child(0), f.Program())
+			got, err := stringLiteralContent(f.Tree().RootNode().Child(0).Child(0))
 
 			if tt.wantError {
 				assert.Error(err)

--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -218,9 +218,9 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 					fmt.Fprintf(indentWriter, "in %s", ast.Path())
 				}
 
-				nodeContent := nodeField.content
+				nodeContent := nodeField.n.Content()
 				if nodeContent == "" {
-					nodeContent = node.Content(ast.Program())
+					nodeContent = node.Content()
 				}
 				line.AppendString("\n")
 				fmt.Fprintf(indentWriter, "%+v", &core.NodeContent{

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -65,8 +65,7 @@ func AnnotationField(a *core.Annotation) zap.Field {
 }
 
 type astNodeField struct {
-	n       *sitter.Node
-	content string
+	n *sitter.Node
 }
 
 type entryMessage struct{}
@@ -115,7 +114,7 @@ func (field astNodeField) Sanitize(hasher func(any) string) SanitizedField {
 		Key: "AstNodeType",
 		Content: map[string]any{
 			"type":    field.n.Type(),
-			"content": hasher(field.content),
+			"content": hasher(field.n.Content()),
 		},
 	}
 }
@@ -132,11 +131,10 @@ func (field astNodeField) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func NodeField(n *sitter.Node, source []byte) zap.Field {
+func NodeField(n *sitter.Node) zap.Field {
 	return zap.Object("node", astNodeField{
-		n:       n,
-		content: n.Content(source)},
-	)
+		n: n,
+	})
 }
 
 type postLogMessage struct {

--- a/pkg/query/filters.go
+++ b/pkg/query/filters.go
@@ -5,18 +5,18 @@ import (
 )
 
 // Selector takes a MatchNodes and the program source, and optionally returns some value.
-type Selector[T any] func(MatchNodes, []byte) (T, bool)
+type Selector[T any] func(MatchNodes) (T, bool)
 
 // Predicate takes some value and the program source, and returns a bool.
 type Predicate[T any] interface {
-	Test(input T, source []byte) bool
+	Test(input T) bool
 }
 
-func Select[T any](source []byte, query NextFunc[MatchNodes], selector Selector[T]) NextFunc[T] {
-	return SelectIf(source, query, selector, Is[MatchNodes](true))
+func Select[T any](query NextFunc[MatchNodes], selector Selector[T]) NextFunc[T] {
+	return SelectIf(query, selector, Is[MatchNodes](true))
 }
 
-func SelectIf[T any](source []byte, query NextFunc[MatchNodes], selector Selector[T], predicate Predicate[MatchNodes]) NextFunc[T] {
+func SelectIf[T any](query NextFunc[MatchNodes], selector Selector[T], predicate Predicate[MatchNodes]) NextFunc[T] {
 	return func() (T, bool) {
 		var zero T
 		for {
@@ -24,10 +24,10 @@ func SelectIf[T any](source []byte, query NextFunc[MatchNodes], selector Selecto
 			if !found {
 				return zero, false
 			}
-			if !predicate.Test(match, source) {
+			if !predicate.Test(match) {
 				continue
 			}
-			if selected, found := selector(match, source); found {
+			if selected, found := selector(match); found {
 				return selected, true
 			}
 		}
@@ -35,19 +35,19 @@ func SelectIf[T any](source []byte, query NextFunc[MatchNodes], selector Selecto
 }
 
 func ContentOf(filter Selector[*sitter.Node]) Selector[string] {
-	return func(match MatchNodes, source []byte) (string, bool) {
-		elem, found := filter(match, source)
+	return func(match MatchNodes) (string, bool) {
+		elem, found := filter(match)
 		if !found {
 			return "", false
 		}
-		elemContent := elem.Content(source)
+		elemContent := elem.Content()
 		return elemContent, true
 	}
 }
 
 // ParamNamed is a Selector that returns a param from the MatchNodes by name, if such a param exists.
 func ParamNamed(paramName string) Selector[*sitter.Node] {
-	return func(match MatchNodes, source []byte) (*sitter.Node, bool) {
+	return func(match MatchNodes) (*sitter.Node, bool) {
 		if paramNode, found := match[paramName]; found {
 			return paramNode, true
 		} else {
@@ -58,7 +58,7 @@ func ParamNamed(paramName string) Selector[*sitter.Node] {
 
 type Is[T any] bool
 
-func (a Is[T]) Test(_ T, _ []byte) bool {
+func (a Is[T]) Test(_ T) bool {
 	return bool(a)
 }
 
@@ -67,18 +67,18 @@ type Param struct {
 	Matches Predicate[*sitter.Node]
 }
 
-func (wp Param) Test(nodes MatchNodes, source []byte) bool {
+func (wp Param) Test(nodes MatchNodes) bool {
 	if paramNode, found := nodes[wp.Named]; found {
-		return wp.Matches.Test(paramNode, source)
+		return wp.Matches.Test(paramNode)
 	}
 	return false
 }
 
 type AllOf[T any] []Predicate[T]
 
-func (a AllOf[T]) Test(input T, source []byte) bool {
+func (a AllOf[T]) Test(input T) bool {
 	for _, condition := range a {
-		if !condition.Test(input, source) {
+		if !condition.Test(input) {
 			return false
 		}
 	}
@@ -87,20 +87,20 @@ func (a AllOf[T]) Test(input T, source []byte) bool {
 
 type HasContent string
 
-func (hc HasContent) Test(node *sitter.Node, source []byte) bool {
-	return node.Content(source) == string(hc)
+func (hc HasContent) Test(node *sitter.Node) bool {
+	return node.Content() == string(hc)
 }
 
 type HasParent struct {
 	With Predicate[*sitter.Node]
 }
 
-func (hp HasParent) Test(node *sitter.Node, source []byte) bool {
+func (hp HasParent) Test(node *sitter.Node) bool {
 	parent := node.Parent()
 	if parent == nil {
 		return false
 	}
-	return hp.With.Test(parent, source)
+	return hp.With.Test(parent)
 }
 
 type Type string

--- a/pkg/query/node.go
+++ b/pkg/query/node.go
@@ -7,8 +7,8 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-func NodeContentStartWith(node *sitter.Node, src []byte, s string) bool {
-	content := node.Content(src)
+func NodeContentStartWith(node *sitter.Node, s string) bool {
+	content := node.Content()
 
 	if s != "" && strings.HasPrefix(content, s) {
 		return true
@@ -16,16 +16,16 @@ func NodeContentStartWith(node *sitter.Node, src []byte, s string) bool {
 	return false
 }
 
-func NodeContentEquals(node *sitter.Node, src []byte, s string) bool {
-	content := node.Content(src)
+func NodeContentEquals(node *sitter.Node, s string) bool {
+	content := node.Content()
 	if s != "" && content == s {
 		return true
 	}
 	return false
 }
 
-func NodeContentRegex(node *sitter.Node, src []byte, regex *regexp.Regexp) bool {
-	content := node.Content(src)
+func NodeContentRegex(node *sitter.Node, regex *regexp.Regexp) bool {
+	content := node.Content()
 	return regex.MatchString(content)
 }
 


### PR DESCRIPTION
Switch to our fork of go-tree-sitter. Required fixes:

- Removed the content/program bytes from `.Content()` (and upwards in function signatures/fields as needed)
- New Python grammar changed how the `with_item` alias is represented (`pkg/lang/python/queries/persist/aiofiles_open.scm`)
- Now that `#match?` works, NestJS test matches exactly the two controllers (`pkg/lang/javascript/queries/expose/nestJs/module.scm` + `pkg/lang/javascript/nestjs_test.go`).

### Standard checks

- [x] **Unit tests**: Unit tests updated (not many changes needed in expectations, just updating to new APIs) and passing
- [x] **Docs**: Purely internal
- [x] **Backwards compatibility**: Purely internal - might break klotho-pro, will check after this gets merged.
