### PR TITLE
Remove []byte from Type.Test to conform to Predicate

### DIFF
--- a/pkg/query/filters.go
+++ b/pkg/query/filters.go
@@ -105,6 +105,6 @@ func (hp HasParent) Test(node *sitter.Node) bool {
 
 type Type string
 
-func (ot Type) Test(node *sitter.Node, _ []byte) bool {
+func (ot Type) Test(node *sitter.Node) bool {
 	return node.Type() == string(ot)
 }


### PR DESCRIPTION
Missed in the previous update

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
