### PR TITLE
Fix panic when capture has no next sibling

### DIFF
--- a/pkg/lang/capabilities.go
+++ b/pkg/lang/capabilities.go
@@ -101,11 +101,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 		comment := capture.Content()
 		comment = c.preprocessor(comment)
 
-		combineWithNext := capture.NextSibling() != nil && capture.NextNamedSibling().Type() == capture.Type()
 		node := capture.NextNamedSibling()
-		if node == nil {
-			continue // this is the last node in the AST, so it's effectively a break :)
-		}
 		if combineWithPrevious {
 			prevBlock := blocks[len(blocks)-1]
 			prevBlock.comment = prevBlock.comment + "\n" + comment
@@ -113,7 +109,7 @@ func (c *capabilityFinder) findAllCommentsBlocks(f *core.SourceFile) []*commentB
 		} else {
 			blocks = append(blocks, &commentBlock{comment: comment, node: node})
 		}
-		combineWithPrevious = combineWithNext
+		combineWithPrevious = node != nil && node.Type() == capture.Type()
 	}
 	return blocks
 }

--- a/pkg/lang/capabilities_test.go
+++ b/pkg/lang/capabilities_test.go
@@ -51,7 +51,22 @@ const y = 456`,
 		},
 		{"comment is last node",
 			`// only line in source`,
-			[]FindAllCommentBlocksExpected{},
+			[]FindAllCommentBlocksExpected{
+				{
+					"only line in source",
+					"",
+				},
+			},
+		},
+		{"multi-line comment is last node",
+			`// first line
+// second line`,
+			[]FindAllCommentBlocksExpected{
+				{
+					"first line\nsecond line",
+					"",
+				},
+			},
 		},
 	}
 	for _, tt := range cases {

--- a/pkg/lang/capabilities_test_helper.go
+++ b/pkg/lang/capabilities_test_helper.go
@@ -36,9 +36,14 @@ func FindAllCommentBlocksForTest(language core.SourceLanguage, source string) ([
 	blocks := capFinder.findAllCommentsBlocks(f)
 	found := []FindAllCommentBlocksExpected{}
 	for _, block := range blocks {
+		content := ""
+		if block.node != nil {
+			content = block.node.Content()
+		}
 		found = append(found, FindAllCommentBlocksExpected{
 			Comment: block.comment,
-			Node:    block.node.Content()})
+			Node:    content,
+		})
 	}
 	return found, nil
 


### PR DESCRIPTION
Fixes panic:
```
github.com/klothoplatform/klotho/pkg/lang.(*capabilityFinder).findAllCommentsBlocks(0x1400021a0a8, 0x14000790d90)
	/Users/jordansinger/workspace/klotho/pkg/lang/capabilities.go:104 +0x244
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
