### PR TITLE
add `--local` auth to oss

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -1,17 +1,35 @@
 package main
 
 import (
+	"github.com/klothoplatform/klotho/pkg/auth"
 	"github.com/klothoplatform/klotho/pkg/cli"
+	"github.com/spf13/pflag"
 )
 
 func main() {
+	authRequirement := LocalAuth(false)
 	km := cli.KlothoMain{
 		DefaultUpdateStream: "open:latest",
 		Version:             Version,
 		PluginSetup: func(psb *cli.PluginSetBuilder) error {
 			return psb.AddAll()
 		},
+		Authorizer: &authRequirement,
 	}
 
 	km.Main()
+}
+
+// LocalAuth is an auth.Authorizer that requires login unless its value is true.
+type LocalAuth bool
+
+func (local *LocalAuth) SetUpCliFlags(flags *pflag.FlagSet) {
+	flags.BoolVar((*bool)(local), "local", bool(*local), "If provided, runs Klotho with a local login (that is, not requiring an authenticated login)")
+}
+
+func (local *LocalAuth) Authorize() error {
+	if !*local {
+		return auth.Authorize()
+	}
+	return nil
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/pflag"
 	"io"
 	"log"
 	"net/http"
@@ -24,7 +23,6 @@ type LoginResponse struct {
 }
 
 type Authorizer interface {
-	SetUpCliFlags(flags *pflag.FlagSet)
 	Authorize() error
 }
 
@@ -36,10 +34,6 @@ func DefaultIfNil(auth Authorizer) Authorizer {
 }
 
 type standardAuthorizer struct{}
-
-func (s standardAuthorizer) SetUpCliFlags(_ *pflag.FlagSet) {
-	// nothing
-}
 
 func (s standardAuthorizer) Authorize() error {
 	return Authorize()

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -173,14 +173,6 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Set up user if login is specified
-	if cfg.logout {
-		err := auth.CallLogoutEndpoint()
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	// Set up user if login is specified
 	if cfg.login {
 		err := auth.Login()
 		if err != nil {
@@ -192,6 +184,14 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		}
 		if err := analytics.CreateUser(email); err != nil {
 			return errors.Wrapf(err, "could not configure user '%s'", email)
+		}
+		return nil
+	}
+	// Set up user if login is specified
+	if cfg.logout {
+		err := auth.CallLogoutEndpoint()
+		if err != nil {
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
This introduces a new Authorizer, which is hookable per KlothoMain. The default one just calls `auth.Authorize()`, but KlothoMains can provide an alternative, including one that adds flags.

This will take care of #164 once the `auth` branch hits main.

### Standard checks

- **Unit tests**: not anything really worth testing
- **Docs**: auth stuff isn't documented yet (this is going into a feature branch)
- **Backwards compatibility**: no issues
