### PR TITLE
allow appname to be 50 char length

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -272,9 +272,9 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 
 	if appCfg.AppName == "" {
 		return errors.New("'app' required")
-	} else if len(appCfg.AppName) > 35 {
-		analyticsClient.Error("Klotho parameter check failed. 'app' must be less than 35 characters in length")
-		return fmt.Errorf("'app' must be less than 35 characters in length. 'app' was %s", appCfg.AppName)
+	} else if len(appCfg.AppName) > 50 {
+		analyticsClient.Error("Klotho parameter check failed. 'app' must be less than 50 characters in length")
+		return fmt.Errorf("'app' must be less than 50 characters in length. 'app' was %s", appCfg.AppName)
 	}
 	match, err := regexp.MatchString(`^[\w-.:/]+$`, appCfg.AppName)
 	if err != nil {

--- a/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
@@ -18,7 +18,7 @@ export const createTargetBinding = (
     dependsOn
 ) => {
     return new pulumi_k8s.yaml.ConfigFile(
-        `${execUnit}-tgb`,
+        `${execUnit}-${port}-tgb`,
         {
             file: './iac/k8s/add_ons/alb_controller/target_group_binding.yaml',
             transformations: [


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

we have some integ tests that dont pass because of this and now that we have sanitization coming in place, we can move this up

because the arn of our TargetGroups changed, our TargetGroupBindings fail for the upgrade path (cant edit the TGB). So for that we are going to change the resource ID of the TGB so it creates a new one and deletes the old one

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
