### PR TITLE
allow dockerfiles to be anywhere

### DIFF
--- a/pkg/core/exec_unit.go
+++ b/pkg/core/exec_unit.go
@@ -19,6 +19,7 @@ type (
 		files                ConcurrentMap[string, File]
 		Executable           Executable
 		EnvironmentVariables []EnvironmentVariable
+		DockerfilePath       string
 	}
 
 	// Executable represents the slice of a project that is deployed to and executed on an ExecutionUnit

--- a/pkg/exec_unit/plugin_exec_unit.go
+++ b/pkg/exec_unit/plugin_exec_unit.go
@@ -39,7 +39,7 @@ func (p ExecUnitPlugin) Transform(result *core.CompilationResult, deps *core.Dep
 			// Plugins are responsible for adding in non-source files
 			// as required by its features.
 			if sf.IsAnnotatedWith(annotation.ExecutionUnitCapability) {
-				unit.AddEntrypoint(f.Clone())
+				unit.AddSourceFile(f.Clone())
 			} else {
 				unit.Add(f.Clone())
 			}

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -348,12 +348,15 @@ export class CloudCCLib {
         }
     }
 
-    createDockerAppRunner(execUnitName, envVars: any) {
+    createImage(execUnitName: string, dockerfilePath: string) {
         const image = this.sharedRepo.buildAndPushImage({
-            context: `./${execUnitName}`,
+            context: `./${execUnitName}/${dockerfilePath}`,
             extraOptions: ['--platform', 'linux/amd64', '--quiet'],
         })
+        this.execUnitToImage.set(execUnitName, image)
+    }
 
+    createDockerAppRunner(execUnitName, envVars: any) {
         const instanceRole = this.createRoleForName(execUnitName)
 
         this.addPolicyStatementForName(execUnitName, {
@@ -458,7 +461,7 @@ export class CloudCCLib {
                         port: isProxied ? '3001' : '3000',
                         runtimeEnvironmentVariables: additionalEnvVars,
                     },
-                    imageIdentifier: image,
+                    imageIdentifier: this.execUnitToImage.get(execUnitName)!,
                     imageRepositoryType: 'ECR',
                 },
             },
@@ -484,10 +487,7 @@ export class CloudCCLib {
         network_placement: 'private' | 'public',
         env_vars?: any[]
     ) {
-        const image = this.sharedRepo.buildAndPushImage({
-            context: `./${execUnitName}`,
-            extraOptions: ['--platform', 'linux/amd64', '--quiet'],
-        })
+        const image = this.execUnitToImage.get(execUnitName)!
 
         const subnetIds =
             network_placement === 'public' ? this.publicSubnetIds : this.privateSubnetIds
@@ -1375,14 +1375,6 @@ export class CloudCCLib {
         )}-eks-cluster`
         const providedClustername = kloConfig.get<string>('eks-cluster')
         const existingCluster = undefined
-        for (const execUnit of execUnits) {
-            const image: pulumi.Output<String> = this.sharedRepo.buildAndPushImage({
-                context: `./${execUnit.name}`,
-                extraOptions: ['--platform', 'linux/amd64', '--quiet'],
-            })
-            execUnit['image'] = image
-            this.execUnitToImage.set(execUnit.name, image)
-        }
         if (this.eks == undefined) {
             if (providedClustername != undefined) {
                 const existingCluster: aws.eks.GetClusterResult = await aws.eks.getCluster({
@@ -1413,10 +1405,7 @@ export class CloudCCLib {
             this.createEcsCluster()
         }
 
-        const image = this.sharedRepo.buildAndPushImage({
-            context: `./${execUnitName}`,
-            extraOptions: ['--platform', 'linux/amd64', '--quiet'],
-        })
+        const image = this.execUnitToImage.get(execUnitName)!
 
         const role = this.createRoleForName(execUnitName)
 

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -70,7 +70,7 @@ export class CloudCCLib {
     execUnitToFunctions = new Map<string, aws.lambda.Function>()
     execUnitToRole = new Map<string, aws.iam.Role>()
     execUnitToPolicyStatements = new Map<string, aws.iam.PolicyStatement[]>()
-    execUnitToImage = new Map<string, pulumi.Output<String>>()
+    execUnitToImage = new Map<string, pulumi.Output<string>>()
 
     gatewayToUrl = new Map<string, pulumi.Output<string>>()
     siteBuckets = new Map<string, aws.s3.Bucket>()

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -351,7 +351,8 @@ export class CloudCCLib {
 
     createImage(execUnitName: string, dockerfilePath: string) {
         const image = this.sharedRepo.buildAndPushImage({
-            context: `./${execUnitName}/${dockerfilePath}`,
+            context: `./${execUnitName}`,
+            dockerfile: `./${execUnitName}/${dockerfilePath}`,
             extraOptions: ['--platform', 'linux/amd64', '--quiet'],
         })
         this.execUnitToImage.set(execUnitName, image)

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -115,6 +115,7 @@ export class CloudCCLib {
         }
         // Right now we sanitize this bucket name in the compiler go code so we do not need to here  (issue #188 & pro#51)
         const resolvedBucketName = pulumi.interpolate`${this.account.accountId}${physicalPayloadsBucketName}`
+
         this.createBuckets([resolvedBucketName], true)
         this.addSharedPolicyStatement({
             Effect: 'Allow',
@@ -1389,8 +1390,7 @@ export class CloudCCLib {
             this,
             execUnits,
             charts || [],
-            existingCluster,
-            lbPlugin
+            existingCluster
         )
     }
 

--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -50,7 +50,6 @@ export interface EksExecUnit {
     params: EksExecUnitArgs
     helmOptions?: HelmOptions
     envVars?: any
-    image?: pulumi.Output<String>
 }
 
 export interface HelmChart {
@@ -560,7 +559,7 @@ export class Eks {
 
     private setupExecUnit(lib: CloudCCLib, unit: EksExecUnit) {
         const execUnit = unit.name
-        const image = unit.image
+        const image = this.lib.execUnitToImage.get(unit.name)!
         const args = unit.params
         let dependencyParent
         let serviceName

--- a/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
@@ -55,6 +55,7 @@ export function sanitize(s: string, options: Partial<SanitizationOptions>): Sani
         if (debug) {
             failedRules?.forEach((f) => console.debug(f))
         }
+
         if (failedRules?.length === 0) {
             return { result, violations: [] }
         }

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -105,6 +105,10 @@ export = async () => {
 
     const lbPlugin = new LoadBalancerPlugin(cloudLib)
 
+    {{range $unit := .ExecUnits -}}
+    cloudLib.createImage("{{$unit.Name}}","{{$unit.DockerfilePath}}")
+    {{end -}}
+
 
     const eksUnits: EksExecUnit[] = []
     const arUrls: any[] = [];

--- a/pkg/lang/golang/aws_runtime/aws.go
+++ b/pkg/lang/golang/aws_runtime/aws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang/golang"
 	"github.com/klothoplatform/klotho/pkg/provider/aws"
+	"github.com/klothoplatform/klotho/pkg/runtime"
 	"github.com/pkg/errors"
 )
 
@@ -47,10 +48,12 @@ func (r *AwsRuntime) AddExecRuntimeFiles(unit *core.ExecutionUnit, result *core.
 		ExecUnitName:   unit.Name,
 	}
 
-	err := golang.AddRuntimeFile(unit, templateData, "Dockerfile", DockerFile)
-	if err != nil {
-		return err
+	if runtime.ShouldOverrideDockerfile(unit) {
+		err := golang.AddRuntimeFile(unit, templateData, "Dockerfile", DockerFile)
+		if err != nil {
+			return err
+		}
 	}
 
-	return err
+	return nil
 }

--- a/pkg/lang/javascript/parser.go
+++ b/pkg/lang/javascript/parser.go
@@ -12,8 +12,10 @@ import (
 
 var multilineCommentMarginRegexp = regexp.MustCompile(`(?m)^\s*[*]*[ \t]*`) // we need to use [ \t] instead of \s, because \s includes newlines in (?m) mode.
 
+const js = core.LanguageId("javascript")
+
 var Language = core.SourceLanguage{
-	ID:     core.LanguageId("javascript"),
+	ID:     js,
 	Sitter: javascript.GetLanguage(),
 	CapabilityFinder: lang.NewCapabilityFinder("comment", lang.CompositePreprocessor(
 		lang.RegexpRemovePreprocessor(`//\s*`),

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -32,6 +32,7 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 				Type:                 cfg.Type,
 				EnvironmentVariables: res.EnvironmentVariables,
 				NetworkPlacement:     cfg.NetworkPlacement,
+				DockerfilePath:       res.DockerfilePath,
 			}
 
 			buildImage := true

--- a/pkg/provider/infra_template.go
+++ b/pkg/provider/infra_template.go
@@ -60,6 +60,7 @@ type (
 		HelmOptions          config.HelmChartOptions
 		Params               config.InfraParams
 		EnvironmentVariables []core.EnvironmentVariable
+		DockerfilePath       string
 	}
 
 	HelmChart struct {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,8 +1,6 @@
 package runtime
 
 import (
-	"path/filepath"
-
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang/dockerfile"
@@ -23,10 +21,11 @@ func ShouldOverrideDockerfile(unit *core.ExecutionUnit) bool {
 		for _, annot := range caps {
 			cap := annot.Capability
 			if cap.ID == unit.Name && cap.Name == annotation.ExecutionUnitCapability {
-				unit.DockerfilePath = filepath.Dir(f.Path())
+				unit.DockerfilePath = f.Path()
 				return false
 			}
 		}
 	}
+	unit.DockerfilePath = "Dockerfile"
 	return true
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"path/filepath"
+
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang/dockerfile"
@@ -21,6 +23,7 @@ func ShouldOverrideDockerfile(unit *core.ExecutionUnit) bool {
 		for _, annot := range caps {
 			cap := annot.Capability
 			if cap.ID == unit.Name && cap.Name == annotation.ExecutionUnitCapability {
+				unit.DockerfilePath = filepath.Dir(f.Path())
 				return false
 			}
 		}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #74 

we currently require dockerfiles to be at the klotho root path. With this change if a custom dockerfile is provided we will obey the location it is provided at in regards to the root path of the klotho invocation.

In order to make this work we have to add any annotated file as a sourcefile to prevent it from getting pruned https://github.com/klothoplatform/klotho-pro/pull/50 is the pro request for the same.

to standardize this logic in pulumi, i created a createImage function. We then store the exec unit images in a map to be retrieved by the other functions so we dont have to recreate this in 4 places and muddy the params to those other functions

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public? will remove the note in docs when this goes in
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yes
