### PR TITLE
remove client-side login retry

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -39,13 +39,16 @@ func (s standardAuthorizer) Authorize() error {
 	return Authorize()
 }
 
-func Login() error {
+func Login(onError func(error)) error {
 	state, err := CallLoginEndpoint()
 	if err != nil {
 		return err
 	}
-	err = retry(20, time.Duration(5)*time.Second, CallGetTokenEndpoint, state)
-	return err
+	err = CallGetTokenEndpoint(state)
+	if err != nil {
+		onError(err)
+	}
+	return nil
 }
 
 func CallLoginEndpoint() (string, error) {
@@ -209,21 +212,4 @@ func GetUserEmail() (string, error) {
 	} else {
 		return "", errors.New("failed to authorize user")
 	}
-}
-
-func retry(attempts int, sleep time.Duration, f func(state string) error, state string) (err error) {
-	for i := 0; ; i++ {
-		err = f(state)
-		if err == nil {
-			return
-		}
-
-		if i >= (attempts - 1) {
-			break
-		}
-
-		time.Sleep(sleep)
-		sleep *= 2
-	}
-	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -180,9 +180,21 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Warnf("failed to create .klotho directory: %v", err)
 	}
 
+	analyticsClientProperties := map[string]interface{}{
+		"version": km.Version,
+		"strict":  cfg.strict,
+		"edition": km.DefaultUpdateStream,
+	}
+
 	// Set up user if login is specified
 	if cfg.login {
-		err := auth.Login()
+		err := auth.Login(func(err error) {
+			// We don't have the analytics client set up to the logger yet, so the warn message won't send any
+			//analytics. Manually create a client and send the tracking.
+			zap.L().Warn(`Couldn't log in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.'`)
+			client := &analytics.Client{Properties: analyticsClientProperties}
+			client.Warn("login failed")
+		})
 		if err != nil {
 			return err
 		}
@@ -205,11 +217,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Set up analytics
-	analyticsClient, err := analytics.NewClient(map[string]interface{}{
-		"version": km.Version,
-		"strict":  cfg.strict,
-		"edition": km.DefaultUpdateStream,
-	})
+	analyticsClient, err := analytics.NewClient(analyticsClientProperties)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Issue retrieving user info: %s. \nYou may need to run: klotho --login <email>", err))
 	}


### PR DESCRIPTION
I'm also moving the Login error handler to a callback, just as an organizational tool. We want to send the analytics for any error manually (since the client hasn't been set up yet), but the Login method shouldn't have to know about that intricacy. klothomain.go does, so that's where we should put that logic

### Standard checks

- **Unit tests**: not tested
- **Docs**: auth isn't documented yet (this is targeting a feature branch)
- **Backwards compatibility**: no issues
