### PR TITLE
replace local login with auth0

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -27,9 +27,9 @@ func (local *LocalAuth) SetUpCliFlags(flags *pflag.FlagSet) {
 	flags.BoolVar((*bool)(local), "local", bool(*local), "If provided, runs Klotho with a local login (that is, not requiring an authenticated login)")
 }
 
-func (local *LocalAuth) Authorize() error {
+func (local *LocalAuth) Authorize() (*auth.KlothoClaims, error) {
 	if !*local {
 		return auth.Authorize()
 	}
-	return nil
+	return nil, nil
 }

--- a/pkg/analytics/tracking_utils.go
+++ b/pkg/analytics/tracking_utils.go
@@ -5,10 +5,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/klothoplatform/klotho/pkg/cli_config"
 	"math"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -17,8 +15,7 @@ import (
 var kloServerUrl = "http://srv.klo.dev"
 
 type AnalyticsFile struct {
-	Email string
-	Id    string
+	Id string
 }
 
 func SendTrackingToServer(bundle *Client) error {
@@ -71,21 +68,4 @@ func CompressFiles(input *core.InputFiles) ([]byte, error) {
 	err := zipWriter.Close()
 
 	return buf.Bytes(), err
-}
-
-func getTrackingFileContents(file string) (AnalyticsFile, error) {
-	configPath, err := cli_config.KlothoConfigPath(file)
-	result := AnalyticsFile{}
-
-	if err != nil {
-		return result, err
-	}
-
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		return result, err
-	}
-	err = json.Unmarshal(content, &result)
-
-	return result, err
 }

--- a/pkg/analytics/user.go
+++ b/pkg/analytics/user.go
@@ -1,18 +1,11 @@
 package analytics
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"github.com/klothoplatform/klotho/pkg/cli_config"
-	"net/http"
-	"net/mail"
-	"os"
-
-	"github.com/fatih/color"
 	"github.com/google/uuid"
+	"github.com/klothoplatform/klotho/pkg/cli_config"
 	"go.uber.org/zap"
+	"os"
 )
 
 type User struct {
@@ -30,184 +23,49 @@ type Validated struct {
 // located in ~/.klotho/
 var analyticsFile = "analytics.json"
 
-func CreateUser(email string) error {
-
+func GetOrCreateAnalyticsFile() AnalyticsFile {
 	// Check if the analytics file exists. If it does, try retrieving the user.
 	// If it doesn't or we error because the data is invalid, it's fine.
 	// We will create the new user and override the invalid or non-existent file
-	result, err := getTrackingFileContents(analyticsFile)
-	var existUser *User
+
+	localLogin, err := getTrackingFileContents(analyticsFile)
 	if err == nil {
-		existUser = RetrieveUser(result)
+		return localLogin
+	}
+	login := AnalyticsFile{Id: uuid.New().String()}
+
+	// Try to write the file, but don't let any errors stop us
+	err = writeTrackingFileContents(analyticsFile, AnalyticsFile{Id: login.Id})
+	if err != nil {
+		zap.L().Debug("Couldn't write local analytics state", zap.Error(err))
+	}
+	return login
+}
+func getTrackingFileContents(file string) (AnalyticsFile, error) {
+	configPath, err := cli_config.KlothoConfigPath(file)
+	result := AnalyticsFile{}
+
+	if err != nil {
+		return result, err
 	}
 
-	user := User{}
-	if email == "local" {
-		// login local will wipe an existing set email, but we want to preserve any set uuid
-		if existUser != nil {
-			user.Id = existUser.Id
-		} else {
-			user.Id = uuid.New().String()
-		}
-		printLocalLoginMessage()
-	} else {
-		addr, err := mail.ParseAddress(email)
-		if err != nil {
-			return err
-		}
-
-		if existUser == nil {
-			user.Email = addr.Address
-			if err := user.SendUserEmailValidation(); err != nil {
-				return err
-			}
-			printEmailLoginMessage(user.Email)
-		} else {
-			// preserve the uuid if it was set before
-			user.Id = existUser.Id
-			user.Email = addr.Address
-			validated := false
-			// Determine if the address provided is new or the same and if we need to do any validation
-			if existUser.Email == addr.Address {
-				validated = existUser.Validated
-			} else {
-				if v, err := user.CheckUserEmailValidation(); err != nil {
-					zap.L().Warn("Failed to validate email with server")
-				} else {
-					user.Validated = v.Validated
-				}
-				validated = user.Validated
-			}
-
-			if validated {
-				printEmailLoginMessage(user.Email)
-			} else {
-				if err := user.SendUserEmailValidation(); err != nil {
-					return err
-				}
-				printEmailLoginMessage(user.Email)
-			}
-		}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return result, err
 	}
+	err = json.Unmarshal(content, &result)
 
-	configPath, err := cli_config.KlothoConfigPath(analyticsFile)
+	return result, err
+}
+
+func writeTrackingFileContents(file string, contents AnalyticsFile) error {
+	configPath, err := cli_config.KlothoConfigPath(file)
 	if err != nil {
 		return err
 	}
-	return user.writeConfig(configPath)
-}
-
-func RetrieveUser(result AnalyticsFile) *User {
-	user := User{}
-
-	if result.Email != "" {
-		user.Email = result.Email
-		if v, err := user.CheckUserEmailValidation(); err != nil {
-			zap.L().Warn("Failed to validate email with server")
-		} else {
-			user.Validated = v.Validated
-		}
-	}
-	if result.Id != "" {
-		user.Id = result.Id
-	}
-	if (User{} == user) {
-		return nil
-	}
-	return &user
-}
-
-func (u *User) CheckUserEmailValidation() (*Validated, error) {
-	postBody, err := json.Marshal(u)
-	if err != nil {
-		return nil, err
-	}
-
-	data := bytes.NewBuffer(postBody)
-	resp, err := http.Post(fmt.Sprintf("%v/user/check-validation", kloServerUrl), "application/json", data)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("failed to check user validation")
-	}
-
-	defer resp.Body.Close()
-
-	validated := Validated{}
-
-	err = json.NewDecoder(resp.Body).Decode(&validated)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &validated, nil
-}
-
-func (u *User) SendUserEmailValidation() error {
-	postBody, _ := json.Marshal(u)
-	data := bytes.NewBuffer(postBody)
-	resp, err := http.Post(fmt.Sprintf("%v/user/send-validation", kloServerUrl), "application/json", data)
-
+	loginJson, err := json.Marshal(contents)
 	if err != nil {
 		return err
 	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("failed to send user validation email")
-	}
-
-	return nil
-}
-
-func (user *User) writeConfig(configPath string) error {
-	content, err := json.Marshal(user)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(configPath, content, 0660)
-}
-
-func (u *User) RegisterUser() error {
-
-	postBody, err := json.Marshal(u)
-	if err != nil {
-		return err
-	}
-
-	data := bytes.NewBuffer(postBody)
-	resp, err := http.Post(fmt.Sprintf("%v/analytics/user", kloServerUrl), "application/json", data)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("non 200 status code: %v", resp.StatusCode)
-	}
-
-	return nil
-}
-
-func printLocalLoginMessage() {
-	color.New(color.FgHiGreen).Println("Success: Logged in as local user")
-	color.New(color.FgYellow).Println(
-		"If you would like to \n",
-		"  \u2022 Receive support with klotho issues\n",
-		"  \u2022 Help shape the future of the product\n",
-		"  \u2022 Access features like the developer console",
-	)
-	color.New(color.FgHiBlue).Println(
-		"run:\n",
-		"  $ klotho --login <email>",
-	)
-}
-
-func printEmailLoginMessage(email string) {
-	color.New(color.FgHiGreen).Printf("Success: Logged in as %s\n\n", email)
+	return os.WriteFile(configPath, loginJson, 0660)
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -165,7 +165,7 @@ type KlothoClaims struct {
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	Name          string `json:"name"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 func Authorize() (*KlothoClaims, error) {
@@ -192,7 +192,7 @@ func authorize(tokenRefreshed bool) (*KlothoClaims, error) {
 		}
 	} else if !claims.ProEnabled {
 		return nil, fmt.Errorf("user %s is not authorized to use KlothoPro", claims.Email)
-	} else if claims.ExpiresAt < time.Now().Unix() {
+	} else if claims.ExpiresAt.Before(time.Now()) {
 		if tokenRefreshed {
 			return nil, fmt.Errorf("user %s, does not have a valid token", claims.Email)
 		}
@@ -206,11 +206,6 @@ func authorize(tokenRefreshed bool) (*KlothoClaims, error) {
 		}
 	}
 	return claims, nil
-}
-
-func GetClaims() (*KlothoClaims, error) {
-	_, claims, err := getClaims()
-	return claims, err
 }
 
 func getClaims() (*Credentials, *KlothoClaims, error) {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -2,7 +2,10 @@ package auth
 
 import (
 	"bytes"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"github.com/klothoplatform/klotho/pkg/closenicely"
 	"github.com/pkg/errors"
@@ -18,6 +21,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const authServerPemCacheFile = "auth0-klotho.pem"
+
 var authUrlBase = getAuthUrlBase()
 
 type LoginResponse struct {
@@ -26,7 +31,7 @@ type LoginResponse struct {
 }
 
 type Authorizer interface {
-	Authorize() error
+	Authorize() (*KlothoClaims, error)
 }
 
 func DefaultIfNil(auth Authorizer) Authorizer {
@@ -38,7 +43,7 @@ func DefaultIfNil(auth Authorizer) Authorizer {
 
 type standardAuthorizer struct{}
 
-func (s standardAuthorizer) Authorize() error {
+func (s standardAuthorizer) Authorize() (*KlothoClaims, error) {
 	return Authorize()
 }
 
@@ -152,7 +157,7 @@ func CallRefreshToken(token string) error {
 	return nil
 }
 
-type MyCustomClaims struct {
+type KlothoClaims struct {
 	ProEnabled    bool
 	ProTier       int
 	Email         string `json:"email"`
@@ -161,72 +166,67 @@ type MyCustomClaims struct {
 	jwt.StandardClaims
 }
 
-func Authorize() error {
+func Authorize() (*KlothoClaims, error) {
 	return authorize(false)
 }
 
-func authorize(tokenRefreshed bool) error {
-	creds, err := GetIDToken()
+func authorize(tokenRefreshed bool) (*KlothoClaims, error) {
+	creds, claims, err := getClaims()
 	if err != nil {
-		return errors.New("failed to get credentials for user, please login")
+		return nil, err
 	}
 
-	token, err := jwt.ParseWithClaims(creds.IdToken, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return nil, nil
-	})
-	if err != nil {
-		zap.S().Debug(err)
-	}
-
-	if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		if !claims.EmailVerified {
-			if tokenRefreshed {
-				return fmt.Errorf("user %s, has not verified their email", claims.Email)
-			}
-			err := CallRefreshToken(creds.RefreshToken)
-			if err != nil {
-				return err
-			}
-			err = authorize(true)
-			if err != nil {
-				return err
-			}
-		} else if !claims.ProEnabled {
-			return fmt.Errorf("user %s is not authorized to use KlothoPro", claims.Email)
-		} else if claims.ExpiresAt < time.Now().Unix() {
-			if tokenRefreshed {
-				return fmt.Errorf("user %s, does not have a valid token", claims.Email)
-			}
-			err := CallRefreshToken(creds.RefreshToken)
-			if err != nil {
-				return err
-			}
-			err = authorize(true)
-			if err != nil {
-				return err
-			}
+	if !claims.EmailVerified {
+		if tokenRefreshed {
+			return nil, fmt.Errorf("user %s, has not verified their email", claims.Email)
 		}
-	} else {
-		return errors.New("failed to authorize user")
+		err := CallRefreshToken(creds.RefreshToken)
+		if err != nil {
+			return nil, err
+		}
+		claims, err = authorize(true)
+		if err != nil {
+			return nil, err
+		}
+	} else if !claims.ProEnabled {
+		return nil, fmt.Errorf("user %s is not authorized to use KlothoPro", claims.Email)
+	} else if claims.ExpiresAt < time.Now().Unix() {
+		if tokenRefreshed {
+			return nil, fmt.Errorf("user %s, does not have a valid token", claims.Email)
+		}
+		err := CallRefreshToken(creds.RefreshToken)
+		if err != nil {
+			return nil, err
+		}
+		claims, err = authorize(true)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return claims, nil
 }
 
-func GetUserEmail() (string, error) {
+func GetClaims() (*KlothoClaims, error) {
+	_, claims, err := getClaims()
+	return claims, err
+}
+
+func getClaims() (*Credentials, *KlothoClaims, error) {
+	errMsg := `Failed to get credentials for user. Please run "klotho --login"`
 	creds, err := GetIDToken()
 	if err != nil {
-		return "", errors.New("failed to get credentials for user, please login")
+		return nil, nil, errors.New(errMsg)
 	}
-	token, err := jwt.ParseWithClaims(creds.IdToken, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return nil, nil
+	token, err := jwt.ParseWithClaims(creds.IdToken, &KlothoClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return getPem()
 	})
 	if err != nil {
-		zap.S().Debug(err)
+		return nil, nil, errors.Wrap(err, errMsg)
 	}
-	if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		return claims.Email, nil
+	if claims, ok := token.Claims.(*KlothoClaims); ok {
+		return creds, claims, nil
 	} else {
-		return "", errors.New("failed to authorize user")
+		return nil, nil, errors.Wrap(err, errMsg)
 	}
 }
 
@@ -236,4 +236,54 @@ func getAuthUrlBase() string {
 		host = "http://klotho-auth-service-alb-e22c092-466389525.us-east-1.elb.amazonaws.com"
 	}
 	return host
+}
+
+func getPem() (*rsa.PublicKey, error) {
+	writePemCache := false
+	// Try to read the PEM from local cache
+	configPath, err := cli_config.KlothoConfigPath(authServerPemCacheFile)
+	if err != nil {
+		return nil, err
+	}
+	bs, err := os.ReadFile(configPath)
+	// Couldn't read it from cache, so (a) try to fetch it from URL and (b) mark down that we should write it on success
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			zap.L().Debug("Couldn't read PEM cache file. Will download it.", zap.Error(err))
+		}
+		pemResp, err := http.Get(`https://klotho.us.auth0.com/pem`)
+		if err != nil {
+			return nil, err
+		}
+		defer closenicely.OrDebug(pemResp.Body)
+		bs, err = io.ReadAll(pemResp.Body)
+		if err != nil {
+			return nil, err
+		}
+		writePemCache = true
+	}
+	// okay, we have the PEM bytes. Try to decode them into a PublicKey.
+	block, _ := pem.Decode(bs)
+	if block == nil {
+		return nil, errors.New("Couldn't parse PEM certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pub, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("Couldn't parse PEM certificate block")
+	}
+	// Finally, if we'd fetched the PEM bytes from URL, save them now.
+	if writePemCache {
+		configPath, err := cli_config.KlothoConfigPath(authServerPemCacheFile)
+		if err == nil {
+			err = os.WriteFile(configPath, bs, 0644)
+		}
+		if err != nil {
+			zap.L().Debug("Couldn't write PEM to local cache", zap.Error(err))
+		}
+	}
+	return pub, nil
 }

--- a/pkg/auth/credentials.go
+++ b/pkg/auth/credentials.go
@@ -30,7 +30,6 @@ func WriteIDToken(token string) error {
 }
 
 func GetIDToken() (*Credentials, error) {
-
 	idToken := os.Getenv("KLOTHO_ID_TOKEN")
 	if idToken != "" {
 		return &Credentials{

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/klothoplatform/klotho/pkg/closenicely"
 	"github.com/spf13/pflag"
 	"os"
 	"regexp"
@@ -179,30 +180,26 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Warnf("failed to create .klotho directory: %v", err)
 	}
 
-	analyticsClientProperties := map[string]interface{}{
+	// Set up analytics, and hook them up to the logs
+	analyticsClient := analytics.NewClient(map[string]interface{}{
 		"version": km.Version,
 		"strict":  cfg.strict,
 		"edition": km.DefaultUpdateStream,
+	})
+	z, err := setupLogger(analyticsClient)
+	if err != nil {
+		return err
 	}
+	defer closenicely.FuncOrDebug(z.Sync)
+	zap.ReplaceGlobals(z)
 
 	// Set up user if login is specified
 	if cfg.login {
 		err := auth.Login(func(err error) {
-			// We don't have the analytics client set up to the logger yet, so the warn message won't send any
-			//analytics. Manually create a client and send the tracking.
 			zap.L().Warn(`Couldn't log in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.'`)
-			client := &analytics.Client{Properties: analyticsClientProperties}
-			client.Warn("login failed")
 		})
 		if err != nil {
 			return err
-		}
-		email, err := auth.GetUserEmail()
-		if err != nil {
-			return err
-		}
-		if err := analytics.CreateUser(email); err != nil {
-			return errors.Wrapf(err, "could not configure user '%s'", email)
 		}
 		return nil
 	}
@@ -216,17 +213,9 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Set up analytics
-	analyticsClient, err := analytics.NewClient(analyticsClientProperties)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Issue retrieving user info: %s. \nYou may need to run: klotho --login <email>", err))
 	}
-
-	z, err := setupLogger(analyticsClient)
-	if err != nil {
-		return err
-	}
-	defer z.Sync() // nolint:errcheck
-	zap.ReplaceGlobals(z)
 
 	errHandler := ErrorHandler{
 		InternalDebug: cfg.internalDebug,
@@ -265,7 +254,10 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Needs to go after the --version and --update checks
-	err = km.Authorizer.Authorize()
+	claims, err := km.Authorizer.Authorize()
+	if claims != nil {
+		analyticsClient.AttachAuthorizations(claims)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/closenicely/closeutil.go
+++ b/pkg/closenicely/closeutil.go
@@ -6,7 +6,11 @@ import (
 )
 
 func OrDebug(closer io.Closer) {
-	if err := closer.Close(); err != nil {
+	FuncOrDebug(closer.Close)
+}
+
+func FuncOrDebug(closer func() error) {
+	if err := closer(); err != nil {
 		zap.L().Debug("Failed to close resource", zap.Error(err))
 	}
 }


### PR DESCRIPTION
There's a fair amount going on here, sorry.

- split analytics/client.go:NewClient up, such that its email stuff is in a new method, AttachAuthorizations().
- rm most of analytics/user.go, and replace it with a tiny method GetOrCreateAnalyticsFile(). This just upserts the ~/.klotho/analytics.json file. All of the logic around retrieving the user and validating emails and all that is just gone.
- auth/auth.go:
  - Authorize() now returns its claims. We pass these to AttachAuthorizations(), mentioned above.
  - We download our auth0 PEM (and cache it), and use it to verify the auth0 token. Without this, we can't actually get the claims.
- cli/klothomain.go:
  - construct analytics.Client just once, and then later attach the email from the claims (this resolves #180)
  - also move the log hooks up, to follow the client

### Standard checks

- **Unit tests**: um, some of this could definitely be unit tested. Right now it's a lot of manual testing.
- **Docs**: auth isn't documented yet
- **Backwards compatibility**: n/a