### PR TITLE
Fixes target group replacement and extra logging

### DIFF
--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/elb.ts
@@ -40,7 +40,7 @@ export const targetGroup = {
                 regexpMatch(
                     'The name can contain only alphanumeric characters and hyphens.',
                     /^[a-zA-Z\d-]+$/,
-                    (s) => s.replace(/[^a-zA-Z\d-]/g, '_')
+                    (s) => s.replace(/[^a-zA-Z\d-]/g, '-')
                 ),
                 {
                     description: 'The name must not begin with a hyphen',

--- a/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/sanitizer.ts
@@ -1,6 +1,9 @@
 import Multimap = require('multimap')
 import * as sha256 from 'simple-sha256'
 
+// Set debug = true to enable additional logging
+let debug = false
+
 // Resource name length offset required to account for IAC-added suffixes
 const reservedCharCount = 8
 
@@ -33,7 +36,9 @@ export function sanitize(s: string, options: Partial<SanitizationOptions>): Sani
     let failedRules = new Array<SanitizationRule>()
     for (let i = 0; i < (options.maxPasses || 5); i++) {
         let failedRules = options.rules?.filter((r) => !r.validate(result))
-        failedRules?.forEach((f) => console.debug(f))
+        if (debug) {
+            failedRules?.forEach((f) => console.debug(f))
+        }
         if (options.minLength != null && result.length < options.minLength) {
             throw new Error(
                 `The sanitized value, "${result}", is shorter than minLength: ${options.minLength}`
@@ -47,7 +52,9 @@ export function sanitize(s: string, options: Partial<SanitizationOptions>): Sani
         }
         failedRules?.forEach((r) => (result = r.fix?.apply(this, [result]) || result))
         failedRules = options.rules?.filter((r) => !r.validate(result))
-        failedRules?.forEach((f) => console.debug(f))
+        if (debug) {
+            failedRules?.forEach((f) => console.debug(f))
+        }
         if (failedRules?.length === 0) {
             return { result, violations: [] }
         }


### PR DESCRIPTION
Fixes #196

Fixes the `fix()` function for the broken rule by changing the replacement character from `_` to `-` and hides debug logging behind a flag.

### Standard checks

- **Unit tests**: Any special considerations? no
- **Docs**: Do we need to update any docs, internal or public? no
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? no
