### PR TITLE
change metadata name to force replacement

### DIFF
--- a/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
@@ -24,7 +24,7 @@ export const createTargetBinding = (
             transformations: [
                 // Make every service private to the cluster, i.e., turn all services into ClusterIP instead of LoadBalancer.
                 (obj: any, opts: pulumi.CustomResourceOptions) => {
-                    obj.metadata = { name: `${execUnit}-tgb` }
+                    obj.metadata = { name: `${execUnit}` }
                     obj.spec.serviceRef.name = serviceName
                     obj.spec.serviceRef.port = port
                     obj.spec.targetGroupARN = targetGroupArn


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? fixes upgrade path for eks tests

since sanitiztion modiied target group names and thus arns, we need to trigger a new TGB to be created since you cant replace arns in an existing TGB.

error from integ tests
```
    kubernetes:elbv2.k8s.aws/v1beta1:TargetGroupBinding (main-tgb):
      error: 1 error occurred:
      	* the Kubernetes API server reported that "default/main-tgb" failed to fully initialize or become live: admission webhook "vtargetgroupbinding.elbv2.k8s.aws" denied the request: TargetGroupBinding update may not change these fields: spec.targetGroupARN
  ```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
