### PR TITLE
add *-env-var-directive tests to slow sample apps

### DIFF
--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -332,14 +332,16 @@ jobs:
           sleep "$sleep_amount"
         env:
           SLOW_APPS: |
-            ts-nestjs-sequelize
-            ts-sequelize
-            ts-typeorm
-            ts-redis
-            ts-eks
-            ts-eks-helm
             py-orm
             py-redis
+            ts-eks
+            ts-eks-helm
+            ts-nestjs-sequelize
+            ts-orm-environment-variable-directive
+            ts-redis
+            ts-redis-env-var-directive
+            ts-sequelize
+            ts-typeorm
         working-directory: ${{ matrix.app_to_test }}
       - name: TypeScript - run integ tests
         if: steps.get_language.outputs.language == 'ts'


### PR DESCRIPTION
This resolves #206, which was just a race condition waiting for RDS to get healthy.

### Standard checks

- **Unit tests**: n/a
- **Docs**: none
- **Backwards compatibility**: no issues
