### PR TITLE
simplify loops to find exec units

### DIFF
--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -170,11 +170,8 @@ func OutputResources(result *core.CompilationResult, outDir string) (resourceCou
 
 func GetLanguagesUsed(result *core.CompilationResult) []core.ExecutableType {
 	executableLangs := []core.ExecutableType{}
-	for _, res := range result.Resources() {
-		switch r := res.(type) {
-		case *core.ExecutionUnit:
-			executableLangs = append(executableLangs, r.Executable.Type)
-		}
+	for _, u := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
+		executableLangs = append(executableLangs, u.Executable.Type)
 	}
 	return executableLangs
 }
@@ -190,12 +187,10 @@ func GetResourceTypeCount(result *core.CompilationResult, cfg *config.Applicatio
 }
 
 func CloseTreeSitter(result *core.CompilationResult) {
-	for _, res := range result.Resources() {
-		if eu, ok := res.(*core.ExecutionUnit); ok {
-			for _, f := range eu.Files() {
-				if astFile, ok := f.(*core.SourceFile); ok {
-					astFile.Tree().Close()
-				}
+	for _, eu := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
+		for _, f := range eu.Files() {
+			if astFile, ok := f.(*core.SourceFile); ok {
+				astFile.Tree().Close()
 			}
 		}
 	}

--- a/pkg/core/compiler.go
+++ b/pkg/core/compiler.go
@@ -131,11 +131,7 @@ func (result *CompilationResult) Len() int {
 func (result *CompilationResult) GetExecUnitForPath(fp string) (*ExecutionUnit, File) {
 	var best *ExecutionUnit
 	var bestFile File
-	for _, res := range result.Resources() {
-		eu, ok := res.(*ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, eu := range GetResourcesOfType[*ExecutionUnit](result) {
 		f := eu.Get(fp)
 		if f != nil {
 			astF, ok := f.(*SourceFile)

--- a/pkg/exec_unit/plugin_assets.go
+++ b/pkg/exec_unit/plugin_assets.go
@@ -21,11 +21,7 @@ func (p Assets) Transform(result *core.CompilationResult, deps *core.Dependencie
 	input := result.GetFirstResource(core.InputFilesKind).(*core.InputFiles)
 
 	units := make(map[string]*core.ExecutionUnit)
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		units[unit.Name] = unit
 	}
 

--- a/pkg/lang/golang/plugin_add_exec_runtime_files.go
+++ b/pkg/lang/golang/plugin_add_exec_runtime_files.go
@@ -17,9 +17,8 @@ func (p *AddExecRuntimeFiles) Name() string { return "AddExecRuntimeFiles:Go" }
 
 func (p *AddExecRuntimeFiles) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !(ok && unit.HasSourceFilesFor(goLang)) {
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
+		if !unit.HasSourceFilesFor(goLang) {
 			continue
 		}
 

--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -70,11 +70,7 @@ func (p *Expose) Name() string { return "Expose" }
 
 func (p Expose) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := p.transformSingle(result, deps, unit)
 		errs.Append(err)
 	}

--- a/pkg/lang/javascript/express.go
+++ b/pkg/lang/javascript/express.go
@@ -55,11 +55,7 @@ func (p ExpressHandler) Name() string { return "Express" }
 
 func (p ExpressHandler) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := p.transformSingle(result, deps, unit)
 		errs.Append(err)
 	}

--- a/pkg/lang/javascript/nestjs.go
+++ b/pkg/lang/javascript/nestjs.go
@@ -37,11 +37,7 @@ func (p NestJsHandler) Name() string { return "NestJs" }
 
 func (p NestJsHandler) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := p.transformSingle(result, deps, unit)
 		errs.Append(err)
 	}

--- a/pkg/lang/javascript/plugin_add_exec_runtime_files.go
+++ b/pkg/lang/javascript/plugin_add_exec_runtime_files.go
@@ -16,11 +16,7 @@ func (p AddExecRuntimeFiles) Name() string { return "AddExecRuntimeFiles:JavaScr
 func (p AddExecRuntimeFiles) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		if !unit.HasSourceFilesFor(Language.ID) {
 			continue
 		}

--- a/pkg/lang/javascript/plugin_persist.go
+++ b/pkg/lang/javascript/plugin_persist.go
@@ -51,12 +51,7 @@ func (p Persist) Transform(result *core.CompilationResult, deps *core.Dependenci
 	}
 
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
-
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := persister.handleFiles(unit)
 		if err != nil {
 			errs.Append(err)

--- a/pkg/lang/javascript/plugin_pubsub.go
+++ b/pkg/lang/javascript/plugin_pubsub.go
@@ -58,11 +58,7 @@ func (p Pubsub) Transform(result *core.CompilationResult, deps *core.Dependencie
 	p.emitters = make(map[VarSpec]*emitterValue)
 
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		vars := DiscoverDeclarations(unit.Files(), pubsubVarType, pubsubVarTypeModule, true, FilterByCapability(annotation.PubSubCapability))
 		for spec, value := range vars {
 			if value.Annotation.Capability.ID == "" {
@@ -253,12 +249,7 @@ func (p *Pubsub) generateProxies(filepath string, emitters []EmitterSubscriberPr
 	log := zap.L().With(logging.FileField(f)).Sugar()
 	var merr multierr.Error
 	appendBuf := new(bytes.Buffer)
-	for _, res := range p.result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
-
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](p.result) {
 		if existing := unit.Get(filepath); existing != nil {
 			existing := existing.(*core.SourceFile)
 			if bytes.Contains(existing.Program(), []byte(emitters[0].VarName)) {
@@ -284,11 +275,7 @@ func (p *Pubsub) generateProxies(filepath string, emitters []EmitterSubscriberPr
 // generateEmitterDefinitions handles making sure the emitters are defined in all the execution units its used in at the path they are originally defined in,
 // even if the original definition is in a file marked only for a single execution unit. It also make sure that the subscribers are imported to register their handlers.
 func (p *Pubsub) generateEmitterDefinitions() (err error) {
-	for _, res := range p.result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](p.result) {
 		emittersByFile := make(map[string]map[VarSpec]*emitterValue)
 		for spec, emitter := range p.emitters {
 			f, ok := emittersByFile[spec.DefinedIn]

--- a/pkg/lang/python/plugin_add_exec_runtime_files.go
+++ b/pkg/lang/python/plugin_add_exec_runtime_files.go
@@ -17,15 +17,10 @@ func (p *AddExecRuntimeFiles) Name() string { return "AddExecRuntimeFiles:Python
 
 func (p *AddExecRuntimeFiles) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		if !unit.HasSourceFilesFor(Language.ID) {
 			continue
 		}
-
 		errs.Append(p.runtime.AddExecRuntimeFiles(unit, result, deps))
 	}
 

--- a/pkg/lang/python/plugin_expose.go
+++ b/pkg/lang/python/plugin_expose.go
@@ -50,11 +50,7 @@ func (p *Expose) Name() string { return "Expose" }
 
 func (p Expose) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := p.transformSingle(result, deps, unit)
 		errs.Append(err)
 	}

--- a/pkg/lang/python/plugin_persist.go
+++ b/pkg/lang/python/plugin_persist.go
@@ -24,12 +24,7 @@ func (p Persist) Transform(result *core.CompilationResult, deps *core.Dependenci
 	persister := &persister{result: result, deps: deps, runtime: p.runtime}
 
 	var errs multierr.Error
-	for _, res := range result.Resources() {
-		unit, ok := res.(*core.ExecutionUnit)
-		if !ok {
-			continue
-		}
-
+	for _, unit := range core.GetResourcesOfType[*core.ExecutionUnit](result) {
 		err := persister.handleFiles(unit)
 		if err != nil {
 			errs.Append(err)


### PR DESCRIPTION
Rather than looping over `result.Resources()`, use `GetResourcesOfType[ExecutionUnit]`. This is a newer form of the original loop, so this is just some cleanup.

I found these while going through our plugins to catalogue what uses what.

### Standard checks

- **Unit tests**: none changed
- **Docs**: n/a
- **Backwards compatibility**: should be fine
