### PR TITLE
Improves project file detection

### DIFF
--- a/pkg/input/readdir.go
+++ b/pkg/input/readdir.go
@@ -326,7 +326,8 @@ func openFindUpward(lang *languageFiles, rootPath string, fsys fs.FS) (core.File
 				}
 
 				prjFilePath := path.Join(prjDir, entry.Name())
-				f, err := fsys.Open(prjFilePath)
+				var f fs.File
+				f, err = fsys.Open(prjFilePath)
 				if err != nil {
 					break
 				}
@@ -334,6 +335,9 @@ func openFindUpward(lang *languageFiles, rootPath string, fsys fs.FS) (core.File
 					defer f.Close()
 					return lang.projectFileOpener(prjFilePath, f)
 				}()
+				if err != nil {
+					break
+				}
 			}
 		}
 		if err != nil {

--- a/pkg/input/readdir.go
+++ b/pkg/input/readdir.go
@@ -187,7 +187,7 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 				if dir == "." {
 					dir = cfg.Path
 				}
-				projectsInDir := getProjectFilesInDir(allLangs, fsys, dir)
+				projectsInDir := getProjectFilesInDir(fsys, dir, csLang)
 				if _, ok := projectsInDir[CSharp]; ok {
 					zap.L().With(logging.FileField(f)).Debug("detected C# project output, skipping directory")
 					return fs.SkipDir
@@ -286,7 +286,7 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 	return input, nil
 }
 
-func getProjectFilesInDir(langs []*languageFiles, fsys fs.FS, dir string) map[languageName][]string {
+func getProjectFilesInDir(fsys fs.FS, dir string, langs ...*languageFiles) map[languageName][]string {
 	projectFiles := make(map[languageName][]string)
 	entries, _ := fs.ReadDir(fsys, dir)
 	for _, lang := range langs {

--- a/pkg/input/readdir.go
+++ b/pkg/input/readdir.go
@@ -54,9 +54,10 @@ func hasName(expected string) predicate.Predicate[string] {
 	}
 }
 
-func hasSuffix(expected string) predicate.Predicate[string] {
+func hasExtension(expected string) predicate.Predicate[string] {
+	extension := "." + expected
 	return func(name string) bool {
-		return strings.HasSuffix(name, expected)
+		return extension != name && strings.HasSuffix(name, extension)
 	}
 }
 
@@ -146,7 +147,7 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 		projectFileOpener:      Upcast(golang.NewGoMod)}
 	csLang := &languageFiles{
 		name:                   CSharp,
-		projectFilePredicate:   hasSuffix(".csproj"),
+		projectFilePredicate:   hasExtension("csproj"),
 		projectFileDescription: "MSBuild Project File (.csproj)",
 		// TODO: project files in C# are currently unused, so no need to open & parse them.
 		projectFileOpener: func(path string, content io.Reader) (f core.File, err error) { return &core.FileRef{FPath: path}, nil },
@@ -188,8 +189,8 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 				// we'll need to remove this skip and check those.
 				return fs.SkipDir
 			case "bin", "obj":
-				dir, _ := filepath.Split(info.Name())
-				if dir == "" {
+				dir := filepath.Dir(info.Name())
+				if dir == "." {
 					dir = cfg.Path
 				}
 				for _, projectDir := range projectDirs[CSharp] {

--- a/pkg/input/readdir_test.go
+++ b/pkg/input/readdir_test.go
@@ -157,15 +157,6 @@ func TestReadDir(t *testing.T) {
 			rootPath: "parent/src",
 		},
 		{
-			name: "csharp: multiple csproj returns error",
-			files: map[string]string{
-				"fizz/one.cs":            "",
-				"fizz/myproject.csproj":  "<Project></Project>",
-				"fizz/myproject2.csproj": "<Project></Project>",
-			},
-			rootPath: "fizz",
-		},
-		{
 			name: "multi-language",
 			files: map[string]string{
 				"fizz/js/one.js":        "",

--- a/pkg/input/readdir_test.go
+++ b/pkg/input/readdir_test.go
@@ -122,6 +122,20 @@ func TestReadDir(t *testing.T) {
 			},
 		},
 		{
+			name: "csharp: obj and bin directories excluded",
+			files: map[string]string{
+				"fizz/one.cs":           "",
+				"fizz/aproject.csproj":  "<Project></Project>",
+				"fizz/obj/two.cs":       "",
+				"fizz/bin/aproject.dll": "",
+			},
+			rootPath: "fizz",
+			want: []string{
+				"one.cs",
+				"aproject.csproj",
+			},
+		},
+		{
 			name: "csharp: simple csproj in parent",
 			files: map[string]string{
 				"parent/src/one.cs":       "",                    // will be within ./new_cwd/src
@@ -140,7 +154,7 @@ func TestReadDir(t *testing.T) {
 				"parent/myproject.csproj":  "<Project></Project>",
 				"parent/myproject2.csproj": "<Project></Project>",
 			},
-			rootPath: "parent",
+			rootPath: "parent/src",
 		},
 		{
 			name: "csharp: multiple csproj returns error",

--- a/pkg/input/readdir_test.go
+++ b/pkg/input/readdir_test.go
@@ -110,6 +110,48 @@ func TestReadDir(t *testing.T) {
 			},
 		},
 		{
+			name: "csharp: simple",
+			files: map[string]string{
+				"fizz/one.cs":           "",
+				"fizz/myproject.csproj": "<Project></Project>",
+			},
+			rootPath: "fizz",
+			want: []string{
+				"one.cs",
+				"myproject.csproj",
+			},
+		},
+		{
+			name: "csharp: simple csproj in parent",
+			files: map[string]string{
+				"parent/src/one.cs":       "",                    // will be within ./new_cwd/src
+				"parent/myproject.csproj": "<Project></Project>", // will be wi
+			},
+			rootPath: "parent",
+			want: []string{
+				"src/one.cs",
+				"myproject.csproj",
+			},
+		},
+		{
+			name: "csharp: multiple csproj in parent returns error",
+			files: map[string]string{
+				"parent/src/one.cs":        "",
+				"parent/myproject.csproj":  "<Project></Project>",
+				"parent/myproject2.csproj": "<Project></Project>",
+			},
+			rootPath: "parent",
+		},
+		{
+			name: "csharp: multiple csproj returns error",
+			files: map[string]string{
+				"fizz/one.cs":            "",
+				"fizz/myproject.csproj":  "<Project></Project>",
+				"fizz/myproject2.csproj": "<Project></Project>",
+			},
+			rootPath: "fizz",
+		},
+		{
 			name: "multi-language",
 			files: map[string]string{
 				"fizz/js/one.js":        "",


### PR DESCRIPTION
This PR supports #105 

- Renamed "package" to "project"  in `ReadDir()`to move away from NodeJS terminology
- Replaced fixed project file names with predicate matching + a description for logging
- Implemented .csproj file detection for C#
- Implemented error handling for handling in the event multiple project files of the same language are detected in the same directory

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
