### PR TITLE
fail-open on auth

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -33,6 +33,10 @@ type LoginResponse struct {
 }
 
 type Authorizer interface {
+	// Authorize tries to authorize the user. The KlothoClaims it returns may be nil, even if the authentication
+	// succeeds. Conversely, if the KlothoClaims is non-nil, it is valid even if the error is also non-nil; you can use
+	// those claims provisionally (and specifically, in analytics) even if the error is non-nil, indicating failed
+	// authentication.
 	Authorize() (*KlothoClaims, error)
 }
 

--- a/pkg/auth/credentials.go
+++ b/pkg/auth/credentials.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"github.com/pkg/errors"
 	"os"
 
 	"github.com/klothoplatform/klotho/pkg/cli_config"
@@ -13,7 +14,6 @@ type Credentials struct {
 }
 
 func WriteIDToken(token string) error {
-
 	configPath, err := cli_config.KlothoConfigPath("credentials.json")
 	if err != nil {
 		return err
@@ -46,9 +46,14 @@ func GetIDToken() (*Credentials, error) {
 
 	content, err := os.ReadFile(configPath)
 	if err != nil {
-		return &result, err
+		if errors.Is(err, os.ErrNotExist) {
+			err = ErrNoCredentialsFile
+		}
+		return nil, err
 	}
-	err = json.Unmarshal(content, &result)
+	if len(content) > 0 {
+		err = json.Unmarshal(content, &result)
+	}
 
 	return &result, err
 }

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -195,8 +195,12 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 
 	// Set up user if login is specified
 	if cfg.login {
-		err := auth.Login(func(err error) {
-			zap.L().Warn(`Couldn't log in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.'`)
+		err := auth.Login(func(err error) error {
+			zap.L().Warn(`Couldn't log in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.`)
+			// Set an empty token. This will mean that the user doesn't get prompted to log in. The login token is still
+			// invalid, but it'll fail-open (at least for now).
+			_ = auth.WriteIDToken("")
+			return nil
 		})
 		if err != nil {
 			return err
@@ -253,15 +257,6 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		analyticsClient.Properties[km.VersionQualifier] = true
 	}
 
-	// Needs to go after the --version and --update checks
-	claims, err := km.Authorizer.Authorize()
-	if claims != nil {
-		analyticsClient.AttachAuthorizations(claims)
-	}
-	if err != nil {
-		return err
-	}
-
 	// if update is specified do the update in place
 	var klothoUpdater = updater.Updater{
 		ServerURL:     updater.DefaultServer,
@@ -296,6 +291,20 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		// Options were set above, and used to perform or check for update. Nothing else to do.
 		// We want to exit early, so that the user doesn't get an error about path not being provided.
 		return nil
+	}
+
+	// Needs to go after the --version and --update checks
+	claims, err := km.Authorizer.Authorize()
+	if claims != nil {
+		analyticsClient.AttachAuthorizations(claims)
+	}
+	if err != nil {
+		if errors.Is(err, auth.ErrNoCredentialsFile) {
+			return errors.New(`Failed to get credentials for user. Please run "klotho --login"`)
+		}
+		// Fail-open. See also the error handler at auth.Login(...) above (you should change that to not write the
+		// empty token, if this fail-open ever changes).
+		zap.L().Warn(`Not logged in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.`, zap.Error(err))
 	}
 
 	appCfg, err := readConfig(args)

--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -146,6 +146,9 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 		case postLogMessage:
 			postMessage = v.Message
 			continue
+		case error:
+			// hacky workaround to #195: just don't print errors, since they can be long strings of multi-line trace
+			continue
 		}
 		if fieldCount > 0 {
 			fields.AppendString(", ")


### PR DESCRIPTION
If the `credentials.json` file isn't there at all, then require a login.
But if it's there but the login doesn't work for whatever reason, just
issue a warning and move on. Meanwhile, in the login path, handle errors
by writing an empty `credentials.json` and then ignoring the error.

This resolves (once the auth branch is in main) #194.

Relatedly, add a workaround for https://github.com/klothoplatform/klotho/issues/195. It's very easy to hit it with this
new path, so I felt like a quick workaround is in order.

### Standard checks

- **Unit tests**: manually tested
- **Docs**: auth isn't documented yet
- **Backwards compatibility**: n/a
