### PR TITLE
Fixes negative log suffix padding

### DIFF
--- a/pkg/logging/console.go
+++ b/pkg/logging/console.go
@@ -170,6 +170,9 @@ func (enc *ConsoleEncoder) EncodeEntry(ent zapcore.Entry, fieldList []zapcore.Fi
 		} else {
 			padding -= lineLength
 		}
+		if padding < 0 {
+			padding = 0
+		}
 		line.AppendString(strings.Repeat(" ", padding))
 		line.AppendString(fields.String())
 	}

--- a/pkg/logging/terminal.go
+++ b/pkg/logging/terminal.go
@@ -32,7 +32,7 @@ func init() {
 			Height: 60,
 		}
 
-	case err != nil:
+	case err != nil, termSize.Width == 0 && termSize.Height == 0:
 		fmt.Fprintf(os.Stderr, "Could not get terminal size: %v\n", err)
 		termSize = tsize.Size{
 			Width:  80,


### PR DESCRIPTION
Set padding width to 0 when calculated value is negative, which currently causes a panic. This happens when using a terminal that doesn't properly notify the OS of its width. 

This is only known to impact the debug terminal in Jetbrains products.


### Standard checks

- **Unit tests**: Any special considerations? No
- **Docs**: Do we need to update any docs, internal or public? No
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? No
