### PR TITLE
check for annotated file as entrypoint

### DIFF
--- a/pkg/lang/javascript/plugin_nodejs_executable.go
+++ b/pkg/lang/javascript/plugin_nodejs_executable.go
@@ -56,9 +56,6 @@ func (l NodeJSExecutable) Transform(result *core.CompilationResult, dependencies
 			for _, annot := range file.Annotations() {
 				cap := annot.Capability
 				if cap.Name == annotation.ExecutionUnitCapability && cap.ID == unit.Name {
-					if len(unit.Executable.Entrypoints) == 1 {
-						return core.WrapErrf(err, "entrypoint resolution failed for execution unit: %s. Too many annotated files with the same execution unit ID", unit.Name)
-					}
 					unit.AddEntrypoint(file)
 				}
 			}

--- a/pkg/lang/python/parser.go
+++ b/pkg/lang/python/parser.go
@@ -8,8 +8,10 @@ import (
 	"github.com/smacker/go-tree-sitter/python"
 )
 
+const py = core.LanguageId("python")
+
 var Language = core.SourceLanguage{
-	ID:               core.LanguageId("python"),
+	ID:               py,
 	Sitter:           python.GetLanguage(),
 	CapabilityFinder: lang.NewCapabilityFinder("comment", lang.RegexpRemovePreprocessor(`^#\s*`)),
 	TurnIntoComment:  lang.MakeLineCommenter("# "),

--- a/pkg/lang/python/plugin_python_executable.go
+++ b/pkg/lang/python/plugin_python_executable.go
@@ -1,8 +1,6 @@
 package python
 
 import (
-	"fmt"
-
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/core"
 	execunit "github.com/klothoplatform/klotho/pkg/exec_unit"
@@ -52,9 +50,6 @@ func (l PythonExecutable) Transform(result *core.CompilationResult, dependencies
 			for _, annot := range file.Annotations() {
 				cap := annot.Capability
 				if cap.Name == annotation.ExecutionUnitCapability && cap.ID == unit.Name {
-					if len(unit.Executable.Entrypoints) == 1 {
-						return fmt.Errorf("entrypoint resolution failed for execution unit: %s. Too many annotated files with the same execution unit ID", unit.Name)
-					}
 					unit.AddEntrypoint(file)
 				}
 			}

--- a/pkg/lang/python/plugin_python_executable.go
+++ b/pkg/lang/python/plugin_python_executable.go
@@ -1,6 +1,8 @@
 package python
 
 import (
+	"fmt"
+
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/core"
 	execunit "github.com/klothoplatform/klotho/pkg/exec_unit"
@@ -46,23 +48,27 @@ func (l PythonExecutable) Transform(result *core.CompilationResult, dependencies
 		unit.AddResource(requirementsTxt.Clone())
 		unit.Executable.Type = core.ExecutableTypePython
 
-		if len(unit.Executable.Entrypoints) > 0 {
-			err := refreshSourceFiles(unit)
-			if err != nil {
-				return err
+		for _, file := range unit.FilesOfLang(py) {
+			for _, annot := range file.Annotations() {
+				cap := annot.Capability
+				if cap.Name == annotation.ExecutionUnitCapability && cap.ID == unit.Name {
+					if len(unit.Executable.Entrypoints) == 1 {
+						return fmt.Errorf("entrypoint resolution failed for execution unit: %s. Too many annotated files with the same execution unit ID", unit.Name)
+					}
+					unit.AddEntrypoint(file)
+				}
 			}
-			refreshUpstreamEntrypoints(unit)
 		}
 
 		if len(unit.Executable.Entrypoints) == 0 {
 			resolveDefaultEntrypoint(unit)
-
-			err := refreshSourceFiles(unit)
-			if err != nil {
-				return err
-			}
-			refreshUpstreamEntrypoints(unit)
 		}
+
+		err := refreshSourceFiles(unit)
+		if err != nil {
+			return err
+		}
+		refreshUpstreamEntrypoints(unit)
 	}
 	return nil
 }


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

We have a slight bug with proxy + pruning combo due to the addition of source files instead of entrypoints. This is because when we dont have the annotated files added as entry points we then prune everything since thats how the dependecy resolver is based.


### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
