### PR TITLE
fixes to email validation and analytics

### DIFF
--- a/pkg/analytics/fields_listener.go
+++ b/pkg/analytics/fields_listener.go
@@ -47,8 +47,8 @@ func (fl *fieldListener) Write(entry zapcore.Entry, fields []zapcore.Field) erro
 	safeLogsStr := logging.SanitizeFields(allFields, fl.client.Hash)
 
 	for _, f := range allFields {
-		if f.Key == logging.EntryMessageField {
-			safeLogsStr = entry.Message
+		if msgProducer, ok := f.Interface.(logging.LogMessageProducer); ok {
+			safeLogsStr = msgProducer.GetMessage(entry)
 		}
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -27,6 +27,7 @@ var (
 	authUrlBase          = EnvVar("KLOTHO_AUTH_BASE").GetOr(`http://klotho-auth-service-alb-e22c092-466389525.us-east-1.elb.amazonaws.com`)
 	pemUrl               = EnvVar("KLOTHO_AUTH_PEM").GetOr(`https://klotho.us.auth0.com/pem`)
 	ErrNoCredentialsFile = errors.New("no local credentials file")
+	ErrEmailUnverified   = errors.New("login email hasn't been verified")
 )
 
 type LoginResponse struct {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -190,7 +190,7 @@ func authorize(tokenRefreshed bool) (*KlothoClaims, error) {
 
 	if !claims.EmailVerified {
 		if tokenRefreshed {
-			return nil, fmt.Errorf("user %s, has not verified their email", claims.Email)
+			return claims, fmt.Errorf("user %s, has not verified their email", claims.Email)
 		}
 		err := CallRefreshToken(creds.RefreshToken)
 		if err != nil {

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -304,7 +304,10 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		}
 		// Fail-open. See also the error handler at auth.Login(...) above (you should change that to not write the
 		// empty token, if this fail-open ever changes).
-		zap.L().Warn(`Not logged in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.`, zap.Error(err))
+		zap.L().Warn(
+			`Not logged in. You may be able to continue using klotho without logging in for now, but this may break in the future. Please contact us if this continues.`,
+			zap.Error(err),
+			logging.SendDirectlyToAnalytics(`login failure`))
 	}
 
 	appCfg, err := readConfig(args)


### PR DESCRIPTION
1. If the problem with the claims is that they're unverified, then:
  1.  still return them
  2. also return an error, but a special one that we can check for in klothomain
  3. check for that error in klothomain, and warn on it (but then proceed with the rest of main)
2. add `logging.SendDirectlyToAnalytics`, and use it to send a message to analytics
3. generalize `SendDirectlyToAnalytics`  and the existing `SendEntryMessage` into a single interface


### Standard checks

- **Unit tests**: nothing special
- **Docs**: n/a
- **Backwards compatibility**: n/a
