### PR TITLE
rm rm'ed worfklow_call arg

### DIFF
--- a/.github/workflows/nightly-integ-tests.yaml
+++ b/.github/workflows/nightly-integ-tests.yaml
@@ -10,5 +10,4 @@ jobs:
     uses: ./.github/workflows/run-integ-tests.yaml
     with:
       test-app-repo: klothoplatform/sample-apps
-      klotho-login: klotho-engineering@klo.dev
     secrets: inherit


### PR DESCRIPTION
Whoops!

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: n/a
