### PR TITLE
fix analytics message

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -295,7 +295,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 			zap.S().Warnf("failed to check for updates: %v", err)
 		}
 		if needsUpdate {
-			analyticsClient.Info(klothoName + "update is available")
+			analyticsClient.Info(klothoName + " update is available")
 			zap.L().Info("new update is available, please run klotho --update to get the latest version")
 		}
 	} else {


### PR DESCRIPTION
"klothoupdate is available" -> "klotho update is available"

### Standard checks

- **Unit tests**: n/a
- **Docs**: not needed
- **Backwards compatibility**: will break analytics aggregation if searching for "klothoupdate", but @AlaShibanAtKlo requested it, so I think he's fine with that
