### PR TITLE
use nicer, custom DNS hostname for auth server

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	authUrlBase          = cli_config.EnvVar("KLOTHO_AUTH_BASE").GetOr(`http://klotho-auth-service-alb-e22c092-466389525.us-east-1.elb.amazonaws.com`)
+	authUrlBase          = cli_config.EnvVar("KLOTHO_AUTH_BASE").GetOr(`http://auth.klo.dev`)
 	pemUrl               = cli_config.EnvVar("KLOTHO_AUTH_PEM").GetOr(`https://klotho.us.auth0.com/pem`)
 	ErrNoCredentialsFile = errors.New("no local credentials file")
 	ErrEmailUnverified   = errors.New("login email hasn't been verified")


### PR DESCRIPTION
this resolves #183

### Standard checks

- **Unit tests**: manually tested (smoke test, not full auth manual tests)
- **Docs**: n/a
- **Backwards compatibility**: no issues
