### PR TITLE
updater needs a Client now

### DIFF
--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"encoding/json"
+	"github.com/gojek/heimdall/v7/httpclient"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -178,6 +179,7 @@ func TestCheckUpdate(t *testing.T) {
 				ServerURL:     server.URL,
 				Stream:        tt.cli.checkStream,
 				CurrentStream: tt.cli.buildStream,
+				Client:        httpclient.NewClient(),
 			}
 			needsUpdate, e := updater.CheckUpdate(tt.cli.currentVersion)
 


### PR DESCRIPTION
This broke due to bf2bf479b901726b8b6af908fa3cd976942de0d6, which hit main before this branch did.

### Standard checks

- **Unit tests**: fixed
- **Docs**: n/a
- **Backwards compatibility**: no issues
