### PR TITLE
print out error fields on log lines

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -73,8 +73,10 @@ const defaultDisableLogo = false
 var hadWarnings = atomic.NewBool(false)
 var hadErrors = atomic.NewBool(false)
 
+const consoleEncoderName = "klotho-cli"
+
 func init() {
-	err := zap.RegisterEncoder("klotho-cli", func(zcfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
+	err := zap.RegisterEncoder(consoleEncoderName, func(zcfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
 		return logging.NewConsoleEncoder(cfg.verbose, hadWarnings, hadErrors), nil
 	})
 
@@ -145,7 +147,7 @@ func setupLogger(analyticsClient *analytics.Client) (*zap.Logger, error) {
 	} else {
 		zapCfg = zap.NewProductionConfig()
 	}
-	zapCfg.Encoding = "klotho-cli"
+	zapCfg.Encoding = consoleEncoderName
 	return zapCfg.Build(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		trackingCore := analyticsClient.NewFieldListener(zapcore.WarnLevel)
 		return zapcore.NewTee(core, trackingCore)

--- a/pkg/logging/console_test.go
+++ b/pkg/logging/console_test.go
@@ -1,0 +1,125 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"testing"
+)
+
+func TestEncodings(t *testing.T) {
+	cases := []struct {
+		name    string
+		given   logInput
+		expect  result
+		logFunc func(logger *zap.Logger, message string, fields ...zap.Field)
+	}{
+		{
+			name:  "no fields",
+			given: log("hello world"),
+			expect: result{
+				message:        "hello world\n",
+				verboseMessage: "  info hello world\n",
+			},
+		},
+		{
+			name:  "plain error field",
+			given: log("hello world", zap.Error(fmt.Errorf("my cool error"))),
+			expect: result{
+				message:        "hello world\n",
+				verboseMessage: "  info hello world\n",
+			},
+		},
+		{
+			name:  "error field with stack",
+			given: log("hello world", zap.Error(errors.WithStack(errors.New("my cool error")))),
+			expect: result{
+				message:        "hello world\n",
+				verboseMessage: "  info hello world\n",
+			},
+		},
+		{
+			name:    "debug message",
+			given:   log("boom"),
+			logFunc: (*zap.Logger).Warn,
+			expect: result{
+				message:        "boom\n",
+				verboseMessage: "  warn boom\n",
+				warningsFound:  true,
+			},
+		},
+		{
+			name:    "error message",
+			given:   log("boom"),
+			logFunc: (*zap.Logger).Error,
+			expect: result{
+				message:        "boom\n",
+				verboseMessage: " error boom\n",
+				warningsFound:  true,
+				errorsFound:    true,
+			},
+		},
+		// note: don't test (*zap.Logger).Fatal, because it always calls os.Exit(1)
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, verbose := range []bool{false, true} {
+				t.Run(fmt.Sprintf("verbose=%v", verbose), func(t *testing.T) {
+					assert := assert.New(t)
+
+					var hadWarnings, hadErrors atomic.Bool
+					encoder := NewConsoleEncoder(verbose, &hadWarnings, &hadErrors)
+
+					buf := &bytes.Buffer{}
+					logger := zap.New(
+						zapcore.NewCore(encoder, zapcore.AddSync(buf), zap.DebugLevel),
+						zap.AddCaller(),
+						zap.AddCallerSkip(1),
+					)
+
+					if tt.logFunc == nil {
+						tt.logFunc = (*zap.Logger).Info
+					}
+					tt.logFunc(logger, tt.given.message, tt.given.fields...)
+
+					var expectMessage string
+					if verbose {
+						expectMessage = tt.expect.verboseMessage
+					} else {
+						expectMessage = tt.expect.message
+					}
+
+					assert.Equal(expectMessage, buf.String())
+					assert.Equal(tt.expect.warningsFound, hadWarnings.Load())
+					assert.Equal(tt.expect.errorsFound, hadErrors.Load())
+				})
+			}
+		})
+	}
+
+}
+
+type (
+	logInput struct {
+		message string
+		fields  []zap.Field
+	}
+
+	result struct {
+		message        string
+		warningsFound  bool
+		errorsFound    bool
+		verboseMessage string
+	}
+)
+
+func log(message string, fields ...zap.Field) logInput {
+	return logInput{
+		message: message,
+		fields:  fields,
+	}
+}


### PR DESCRIPTION
* always log the error message
* with `--verbose`, also log the stack trace (if available)

This resolves #195. This does not touch panics.

Here's an example with and without `--verbose`. I added three log lines, each with a stack trace: one at info, one at warn, one at error.

Without verbose:
> ![example with no verbose; prints only the message](https://user-images.githubusercontent.com/110620369/220468115-c04895c1-6c57-466d-8e60-7f04a4acc510.png)

With verbose:
> ![example with verbose; prints the full trace](https://user-images.githubusercontent.com/110620369/220468299-890aca7d-67c4-4aee-b39b-a1c5d52b2a60.png)




### Standard checks

- **Unit tests**: unit tests added
- **Docs**: no docs needed
- **Backwards compatibility**: no issues
