### PR TITLE
print stack traces for panics

### DIFF
--- a/pkg/analytics/client.go
+++ b/pkg/analytics/client.go
@@ -142,6 +142,9 @@ func (t *Client) PanicHandler(err *error, errHandler ErrorHandler) {
 		} else {
 			*err = rerr
 		}
+		if _, hasStack := (*err).(interface{ StackTrace() errors.StackTrace }); !hasStack {
+			*err = errors.WithStack(*err)
+		}
 		t.Panic(rerr.Error())
 		errHandler.PrintErr(*err)
 	}

--- a/pkg/cli/err_handler.go
+++ b/pkg/cli/err_handler.go
@@ -76,7 +76,7 @@ func (h ErrorHandler) printErr(err error, num int) (nextNum int) {
 				log.
 					With(logging.FileField(suberr.File), logging.AnnotationField(suberr.Annotation)).
 					Error(
-						fmt.Sprintf("[err %d] %s", num+1, msg),
+						fmt.Sprintf("[err %d] "+errFmt, num+1, msg),
 						logging.PostLogMessageField(fmt.Sprintf("-> Caused by: "+errFmt, suberr.Cause)),
 					)
 			}
@@ -84,7 +84,7 @@ func (h ErrorHandler) printErr(err error, num int) (nextNum int) {
 		}
 	}
 
-	log.Sugar().Errorf("[err %d] %v", num, err)
+	log.Sugar().Errorf("[err %d] "+errFmt, num, err)
 
 	return num
 }


### PR DESCRIPTION
As with other errors, only print the stack trace if `--internalDebug`.

This resolves #270. Note that it only affects console output, not analytics tracking.

To test, I added a nil deref in `js/express.go`:
```golang
func (p ExpressHandler) Transform(result *core.CompilationResult, deps *core.Dependencies) error {
	var err error
	_ = err.Error()
	...
```

Default:
```
$ klotho . -paws --app ys
Adding resource exec_unit:main
[err 0] runtime error: invalid memory address or nil pointer dereference
Klotho compilation failed
```

With `--internalDebug`:
```
$ klotho . -paws --app ys --internalDebug
Adding resource exec_unit:main
[err 0] runtime error: invalid memory address or nil pointer dereference
github.com/klothoplatform/klotho/pkg/analytics.(*Client).PanicHandler
	/Users/yuval/.klotho/klotho-env/versions/src%2Foss/pkg/analytics/client.go:146
runtime.gopanic
	/opt/homebrew/Cellar/go/1.19.6/libexec/src/runtime/panic.go:890
runtime.panicmem
	/opt/homebrew/Cellar/go/1.19.6/libexec/src/runtime/panic.go:260
runtime.sigpanic
	/opt/homebrew/Cellar/go/1.19.6/libexec/src/runtime/signal_unix.go:835
github.com/klothoplatform/klotho/pkg/lang/javascript.ExpressHandler.Transform
	/Users/yuval/.klotho/klotho-env/versions/src%2Foss/pkg/lang/javascript/express.go:58
github.com/klothoplatform/klotho/pkg/lang/javascript.JavascriptPlugins.Transform
	/Users/yuval/.klotho/klotho-env/versions/src%2Foss/pkg/lang/javascript/plugins.go:34
github.com/klothoplatform/klotho/pkg/core.(*Compiler).Compile
	/Users/yuval/.klotho/klotho-env/versions/src%2Foss/pkg/core/compiler.go:168
github.com/klothoplatform/klotho/pkg/cli.KlothoMain.run
	/Users/yuval/.klotho/klotho-env/versions/src%2Foss/pkg/cli/klothomain.go:404
github.com/spf13/cobra.(*Command).execute
	/Users/yuval/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/yuval/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044
<snip>
```

### Standard checks

- **Unit tests**: not unit tested
- **Docs**: n/a
- **Backwards compatibility**: no issues
