### PR TITLE
allow for import of rds instances and proxies

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -62,11 +62,6 @@ export interface TopologyEdgeData {
     target: string
 }
 
-export interface RdsImport {
-    dbInstanceIdentifier: string
-    proxy: string
-}
-
 export const kloConfig: pulumi.Config = new pulumi.Config('klo')
 
 export class CloudCCLib {

--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -62,7 +62,12 @@ export interface TopologyEdgeData {
     target: string
 }
 
-export const kloConfig = new pulumi.Config('klo')
+export interface RdsImport {
+    dbInstanceIdentifier: string
+    proxy: string
+}
+
+export const kloConfig: pulumi.Config = new pulumi.Config('klo')
 
 export class CloudCCLib {
     secrets = new Map<string, aws.secretsmanager.Secret>()
@@ -1001,174 +1006,6 @@ export class CloudCCLib {
                 `cron(${cronExpression})`,
                 schedulerLambda
             )
-    }
-
-    public setupRDS(orm: string, args: Partial<aws.rds.InstanceArgs>) {
-        if (!this.subnetGroup) {
-            const subnetGroupName = sanitized(AwsSanitizer.RDS.dbSubnetGroup.nameValidation())`${h(
-                this.name
-            )}`
-            this.subnetGroup = new aws.rds.SubnetGroup(subnetGroupName, {
-                subnetIds: this.privateSubnetIds,
-                tags: {
-                    Name: 'Klotho DB subnet group',
-                },
-            })
-        }
-
-        const dbName = sanitized(
-            AwsSanitizer.RDS.engine.pg.database.nameValidation()
-        )`${orm.toLowerCase()}`
-        const config = new pulumi.Config()
-        const username = config.require(`${dbName}_username`)
-        const password = config.requireSecret(`${dbName}_password`)
-
-        // create the db resources
-        validate(dbName, AwsSanitizer.RDS.instance.nameValidation())
-        const rds = new aws.rds.Instance(
-            dbName,
-            {
-                instanceClass: 'db.t4g.micro',
-                ...args,
-                engine: 'postgres',
-                dbName: dbName,
-                username: username,
-                password: password,
-                iamDatabaseAuthenticationEnabled: true,
-                dbSubnetGroupName: this.subnetGroup.name,
-                vpcSecurityGroupIds: this.sgs,
-            },
-            { protect: this.protect }
-        )
-
-        // setup secrets for the proxy
-        const secretName = `${dbName}_secret`
-        const ssmSecretName = `${this.name}-${secretName}`
-        validate(ssmSecretName, AwsSanitizer.SecretsManager.secret.nameValidation())
-        let rdsSecret = new aws.secretsmanager.Secret(`${secretName}`, {
-            name: ssmSecretName,
-            recoveryWindowInDays: 0,
-        })
-
-        const rdsSecretValues = {
-            username: username,
-            password: password,
-            engine: 'postgres',
-            host: rds.address,
-            port: rds.port,
-            dbname: dbName,
-            dbInstanceIdentifier: rds.id,
-            iamDatabaseAuthenticationEnabled: false,
-        }
-
-        const secret = new aws.secretsmanager.SecretVersion(`${secretName}`, {
-            secretId: rdsSecret.id,
-            secretString: pulumi.output(rdsSecretValues).apply((v) => JSON.stringify(v)),
-        })
-
-        this.topology.topologyIconData.forEach((resource) => {
-            if (resource.kind == Resource.secret) {
-                this.topology.topologyEdgeData.forEach((edge) => {
-                    if (edge.target == resource.id) {
-                        this.addPolicyStatementForName(
-                            this.resourceIdToResource.get(edge.source).title,
-                            {
-                                Effect: 'Allow',
-                                Action: ['secretsmanager:GetSecretValue'],
-                                Resource: [secret.arn],
-                            }
-                        )
-                    }
-                })
-            }
-        })
-
-        // prettier-ignore
-        const ormRoleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(dbName)}-ormsecretrole`
-        //setup role for proxy
-        const role = new aws.iam.Role(ormRoleName, {
-            assumeRolePolicy: {
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Effect: 'Allow',
-                        Principal: {
-                            Service: 'rds.amazonaws.com',
-                        },
-                        Action: 'sts:AssumeRole',
-                    },
-                ],
-            },
-        })
-
-        // prettier-ignore
-        const ormPolicyName = sanitized(AwsSanitizer.IAM.policy.nameValidation())`${h(dbName)}-ormsecretpolicy`
-        const policy = new aws.iam.Policy(ormPolicyName, {
-            description: 'klotho orm secret policy',
-            policy: {
-                Version: '2012-10-17',
-                Statement: [
-                    {
-                        Effect: 'Allow',
-                        Action: 'secretsmanager:GetSecretValue',
-                        Resource: [secret.arn],
-                    },
-                ],
-            },
-        })
-
-        const attach = new aws.iam.RolePolicyAttachment(`${dbName}-ormattach`, {
-            role: role.name,
-            policyArn: policy.arn,
-        })
-
-        // setup the rds proxy
-        const proxyName = sanitized(AwsSanitizer.RDS.dbProxy.nameValidation())`${h(dbName)}`
-        const proxy = new aws.rds.Proxy(proxyName, {
-            debugLogging: false,
-            engineFamily: 'POSTGRESQL',
-            idleClientTimeout: 1800,
-            requireTls: false,
-            roleArn: role.arn,
-            vpcSecurityGroupIds: this.sgs,
-            vpcSubnetIds: this.privateSubnetIds,
-            auths: [
-                {
-                    authScheme: 'SECRETS',
-                    description: 'use the secrets generated by klotho',
-                    iamAuth: 'DISABLED',
-                    secretArn: secret.arn,
-                },
-            ],
-        })
-
-        const proxyDefaultTargetGroup = new aws.rds.ProxyDefaultTargetGroup(`${dbName}`, {
-            dbProxyName: proxy.name,
-            connectionPoolConfig: {
-                connectionBorrowTimeout: 120,
-                maxConnectionsPercent: 100,
-                maxIdleConnectionsPercent: 50,
-            },
-        })
-        const proxyTarget = new aws.rds.ProxyTarget(`${dbName}`, {
-            dbInstanceIdentifier: rds.id,
-            dbProxyName: proxy.name,
-            targetGroupName: proxyDefaultTargetGroup.name,
-        })
-
-        const clients = this.addConnectionString(
-            orm,
-            pulumi.interpolate`postgresql://${username}:${password}@${proxy.endpoint}:5432/${dbName}`
-        )
-
-        const resource = pulumi.interpolate`arn:aws:rds-db:${this.region}:${this.account.accountId}:dbuser:${rds.resourceId}/${username}`
-        for (const client of clients) {
-            this.addPolicyStatementForName(this.resourceIdToResource.get(client).title, {
-                Effect: 'Allow',
-                Action: ['rds-db:connect'],
-                Resource: resource,
-            })
-        }
     }
 
     public addConnectionString(orm: string, connectionString: pulumi.Output<string>) {

--- a/pkg/infra/pulumi_aws/iac/rds.ts
+++ b/pkg/infra/pulumi_aws/iac/rds.ts
@@ -2,11 +2,16 @@ import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import { hash as h, sanitized, validate } from './sanitization/sanitizer'
 import AwsSanitizer from './sanitization/aws'
-import { Resource, CloudCCLib, RdsImport, kloConfig } from '../deploylib'
+import { Resource, CloudCCLib, kloConfig } from '../deploylib'
 
 export interface CreateInstanceAndProxyResult {
     rds: aws.rds.Instance
     proxy: aws.rds.Proxy
+}
+
+export interface RdsImport {
+    dbInstanceIdentifier: string
+    proxy: string
 }
 
 export class RDS {

--- a/pkg/infra/pulumi_aws/iac/rds.ts
+++ b/pkg/infra/pulumi_aws/iac/rds.ts
@@ -1,0 +1,215 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import { hash as h, sanitized, validate } from './sanitization/sanitizer'
+import AwsSanitizer from './sanitization/aws'
+import { Resource, CloudCCLib, RdsImport, kloConfig } from '../deploylib'
+
+export interface CreateInstanceAndProxyResult {
+    rds: aws.rds.Instance
+    proxy: aws.rds.Proxy
+}
+
+export class RDS {
+    constructor() {}
+
+    static setupRDS(lib: CloudCCLib, orm: string, args: Partial<aws.rds.InstanceArgs>) {
+        const rdsImports: { [key: string]: RdsImport } | undefined = kloConfig.getObject('rds')
+        const config = new pulumi.Config()
+        const dbName = sanitized(
+            AwsSanitizer.RDS.engine.pg.database.nameValidation()
+        )`${orm.toLowerCase()}`
+        const username = config.require(`${dbName}_username`)
+        const password = config.requireSecret(`${dbName}_password`)
+
+        let rds
+        let proxy
+
+        if (rdsImports != undefined && rdsImports[orm] != undefined) {
+            rds = aws.rds.Instance.get(dbName, rdsImports[orm].dbInstanceIdentifier)
+            const proxyName = sanitized(AwsSanitizer.RDS.dbProxy.nameValidation())`${h(dbName)}`
+            proxy = aws.rds.Proxy.get(proxyName, rdsImports[orm].proxy)
+        } else {
+            const result: CreateInstanceAndProxyResult = RDS.createInstanceAndProxy(
+                lib,
+                dbName,
+                username,
+                password,
+                args
+            )
+            rds = result.rds
+            proxy = result.proxy
+        }
+
+        const clients = lib.addConnectionString(
+            orm,
+            pulumi.interpolate`postgresql://${username}:${password}@${proxy.endpoint}:5432/${dbName}`
+        )
+
+        const resource = pulumi.interpolate`arn:aws:rds-db:${lib.region}:${lib.account.accountId}:dbuser:${rds.resourceId}/${username}`
+        for (const client of clients) {
+            lib.addPolicyStatementForName(lib.resourceIdToResource.get(client).title, {
+                Effect: 'Allow',
+                Action: ['rds-db:connect'],
+                Resource: resource,
+            })
+        }
+    }
+
+    static createInstanceAndProxy(
+        lib: CloudCCLib,
+        dbName: string,
+        username: string,
+        password: pulumi.Output<string>,
+        args: Partial<aws.rds.InstanceArgs>
+    ): CreateInstanceAndProxyResult {
+        if (!lib.subnetGroup) {
+            const subnetGroupName = sanitized(AwsSanitizer.RDS.dbSubnetGroup.nameValidation())`${h(
+                lib.name
+            )}`
+            lib.subnetGroup = new aws.rds.SubnetGroup(subnetGroupName, {
+                subnetIds: lib.privateSubnetIds,
+                tags: {
+                    Name: 'Klotho DB subnet group',
+                },
+            })
+        }
+
+        // create the db resources
+        validate(dbName, AwsSanitizer.RDS.instance.nameValidation())
+        const rds = new aws.rds.Instance(
+            dbName,
+            {
+                instanceClass: 'db.t4g.micro',
+                ...args,
+                engine: 'postgres',
+                dbName: dbName,
+                username: username,
+                password: password,
+                iamDatabaseAuthenticationEnabled: true,
+                dbSubnetGroupName: lib.subnetGroup.name,
+                vpcSecurityGroupIds: lib.sgs,
+            },
+            { protect: lib.protect }
+        )
+
+        // setup secrets for the proxy
+        const secretName = `${dbName}_secret`
+        const ssmSecretName = `${lib.name}-${secretName}`
+        validate(ssmSecretName, AwsSanitizer.SecretsManager.secret.nameValidation())
+        let rdsSecret = new aws.secretsmanager.Secret(`${secretName}`, {
+            name: ssmSecretName,
+            recoveryWindowInDays: 0,
+        })
+
+        const rdsSecretValues = {
+            username: username,
+            password: password,
+            engine: 'postgres',
+            host: rds.address,
+            port: rds.port,
+            dbname: dbName,
+            dbInstanceIdentifier: rds.id,
+            iamDatabaseAuthenticationEnabled: false,
+        }
+
+        const secret = new aws.secretsmanager.SecretVersion(`${secretName}`, {
+            secretId: rdsSecret.id,
+            secretString: pulumi.output(rdsSecretValues).apply((v) => JSON.stringify(v)),
+        })
+
+        lib.topology.topologyIconData.forEach((resource) => {
+            if (resource.kind == Resource.secret) {
+                lib.topology.topologyEdgeData.forEach((edge) => {
+                    if (edge.target == resource.id) {
+                        lib.addPolicyStatementForName(
+                            lib.resourceIdToResource.get(edge.source).title,
+                            {
+                                Effect: 'Allow',
+                                Action: ['secretsmanager:GetSecretValue'],
+                                Resource: [secret.arn],
+                            }
+                        )
+                    }
+                })
+            }
+        })
+
+        // prettier-ignore
+        const ormRoleName = sanitized(AwsSanitizer.IAM.role.nameValidation())`${h(dbName)}-ormsecretrole`
+        //setup role for proxy
+        const role = new aws.iam.Role(ormRoleName, {
+            assumeRolePolicy: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Principal: {
+                            Service: 'rds.amazonaws.com',
+                        },
+                        Action: 'sts:AssumeRole',
+                    },
+                ],
+            },
+        })
+
+        // prettier-ignore
+        const ormPolicyName = sanitized(AwsSanitizer.IAM.policy.nameValidation())`${h(dbName)}-ormsecretpolicy`
+        const policy = new aws.iam.Policy(ormPolicyName, {
+            description: 'klotho orm secret policy',
+            policy: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: 'secretsmanager:GetSecretValue',
+                        Resource: [secret.arn],
+                    },
+                ],
+            },
+        })
+
+        const attach = new aws.iam.RolePolicyAttachment(`${dbName}-ormattach`, {
+            role: role.name,
+            policyArn: policy.arn,
+        })
+
+        // setup the rds proxy
+        const proxyName = sanitized(AwsSanitizer.RDS.dbProxy.nameValidation())`${h(dbName)}`
+        const proxy = new aws.rds.Proxy(proxyName, {
+            debugLogging: false,
+            engineFamily: 'POSTGRESQL',
+            idleClientTimeout: 1800,
+            requireTls: false,
+            roleArn: role.arn,
+            vpcSecurityGroupIds: lib.sgs,
+            vpcSubnetIds: lib.privateSubnetIds,
+            auths: [
+                {
+                    authScheme: 'SECRETS',
+                    description: 'use the secrets generated by klotho',
+                    iamAuth: 'DISABLED',
+                    secretArn: secret.arn,
+                },
+            ],
+        })
+
+        const proxyDefaultTargetGroup = new aws.rds.ProxyDefaultTargetGroup(`${dbName}`, {
+            dbProxyName: proxy.name,
+            connectionPoolConfig: {
+                connectionBorrowTimeout: 120,
+                maxConnectionsPercent: 100,
+                maxIdleConnectionsPercent: 50,
+            },
+        })
+        const proxyTarget = new aws.rds.ProxyTarget(`${dbName}`, {
+            dbInstanceIdentifier: rds.id,
+            dbProxyName: proxy.name,
+            targetGroupName: proxyDefaultTargetGroup.name,
+        })
+
+        return {
+            rds,
+            proxy,
+        }
+    }
+}

--- a/pkg/infra/pulumi_aws/index.ts.tmpl
+++ b/pkg/infra/pulumi_aws/index.ts.tmpl
@@ -32,6 +32,10 @@ import { Cloudfront } from './iac/cloudfront'
 import { SecretsManager } from './iac/secrets_manager'
 {{end}}
 
+{{- if .RdsInstances}}
+import { RDS } from './iac/rds'
+{{end}}
+
 export = async () => {
     const minimumNodeVersion = 16
     const nodeVersionMatch = process.version.match(/^v(\d+)/)
@@ -91,10 +95,12 @@ export = async () => {
     new SecretsManager(cloudLib, {{json .SecretManagerSecrets}});
     {{- end}}
 
+    {{range $rds := .RdsInstances -}}
+    RDS.setupRDS(cloudLib, "{{$rds.Name}}", {{json $rds.Params}} as Partial<aws.rds.InstanceArgs>);
+    {{- end}}
+
     {{range $orm := .ORMs -}}
-    {{if eq $orm.Type "rds_postgres" -}}
-    cloudLib.setupRDS("{{$orm.Name}}", {{json $orm.Params}} as Partial<aws.rds.InstanceArgs>);
-    {{- else if eq $orm.Type "cockroachdb_serverless" -}}
+    {{if eq $orm.Type "cockroachdb_serverless" -}}
     cloudLib.addConnectionString(
         "{{$orm.Name}}",
         new CockroachDB("{{$orm.Name}}-db", {app: appName, id: "{{$orm.Name}}", region, topology{{if $orm.Params}}, ...{{json $orm.Params}}{{end -}} }).connectionString,

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -137,6 +137,10 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 		addFile("iac/secrets_manager.ts")
 	}
 
+	if len(data.RdsInstances) > 0 {
+		addFile("iac/rds.ts")
+	}
+
 	addFile("deploylib.ts")
 	addFile("package.json")
 	addFile("tsconfig.json")

--- a/pkg/lang/javascript/aws_runtime/clients.js
+++ b/pkg/lang/javascript/aws_runtime/clients.js
@@ -1,8 +1,8 @@
-const {S3Client} = require('@aws-sdk/client-s3')
-const {LambdaClient}  = require('@aws-sdk/client-lambda')
-const {SecretsManagerClient}  = require('@aws-sdk/client-secrets-manager')
-const { SNSClient }  = require('@aws-sdk/client-sns')
-const {DynamoDBClient}  = require('@aws-sdk/client-dynamodb')
+const { S3Client } = require('@aws-sdk/client-s3')
+const { LambdaClient } = require('@aws-sdk/client-lambda')
+const { SecretsManagerClient } = require('@aws-sdk/client-secrets-manager')
+const { SNSClient } = require('@aws-sdk/client-sns')
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
 const AWSXRay = require('aws-xray-sdk-core')
 
 const endpoint = process.env['AWS_ENDPOINT']

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -22,6 +22,7 @@ type (
 		ALBs                    []provider.Gateway
 		Buckets                 []provider.FS
 		SecretManagerSecrets    []provider.Config
+		RdsInstances            []provider.ORM
 	}
 )
 
@@ -55,7 +56,7 @@ const (
 	eks                                = "eks"
 	ecs                                = "ecs"
 	lambda                             = "lambda"
-	rds_postgres                       = "rds_postgres"
+	Rds_postgres                       = "rds_postgres"
 	Secrets_manager                    = "secrets_manager"
 	s3                                 = "s3"
 	dynamodb                           = "dynamodb"
@@ -116,9 +117,9 @@ var defaultConfig = config.Defaults{
 			Type: s3,
 		},
 		ORM: config.KindDefaults{
-			Type: rds_postgres,
+			Type: Rds_postgres,
 			InfraParamsByType: map[string]config.InfraParams{
-				rds_postgres: {
+				Rds_postgres: {
 					"instanceClass":     "db.t4g.micro",
 					"allocatedStorage":  20,
 					"skipFinalSnapshot": true,
@@ -167,7 +168,7 @@ func (a *AWS) GetKindTypeMappings(kind string) ([]string, bool) {
 	case string(core.PersistKVKind):
 		return []string{dynamodb}, true
 	case string(core.PersistORMKind):
-		return []string{rds_postgres}, true
+		return []string{Rds_postgres}, true
 	case string(core.PersistRedisNodeKind):
 		return []string{elasticache}, true
 	case string(core.PersistRedisClusterKind):

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -124,13 +124,19 @@ func (a *AWS) Transform(result *core.CompilationResult, deps *core.Dependencies)
 				data.HasKV = true
 			}
 			if res.Kind == core.PersistORMKind {
-				data.ORMs = append(data.ORMs, provider.ORM{
-					Name:   res.Name,
-					Type:   cfg.Type,
-					Params: cfg.InfraParams,
-				})
 				if cfg.Type == "rds_postgres" {
+					data.RdsInstances = append(data.RdsInstances, provider.ORM{
+						Name:   res.Name,
+						Type:   cfg.Type,
+						Params: cfg.InfraParams,
+					})
 					data.UseVPC = true
+				} else {
+					data.ORMs = append(data.ORMs, provider.ORM{
+						Name:   res.Name,
+						Type:   cfg.Type,
+						Params: cfg.InfraParams,
+					})
 				}
 			}
 			if res.Kind == core.PersistRedisClusterKind || res.Kind == core.PersistRedisNodeKind {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

allows for the import of rds and proxy instances

import looks similar to below in pulumi config

```
  klo:rds:
    sequelizeDB:
      dbInstanceIdentifier: sequelizedbc90e5a2
      proxy: sequelizedb-8bfa7fc
```

modularizing our pulumi code a bit so that we only add our rds instances if necessary.

tested on ts-sequelize

### Standard checks

- **Unit tests**: Any special considerations? just imports so no
- **Docs**: Do we need to update any docs, internal or public? will add once gordons pr is in since he started the imports page
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? yes new feature
