### PR TITLE
send properties separately from event name in logs

### DIFF
--- a/pkg/analytics/client.go
+++ b/pkg/analytics/client.go
@@ -26,7 +26,7 @@ type (
 	LogLevel string
 )
 
-var (
+const (
 	Panic LogLevel = "panic"
 	Error LogLevel = "error"
 	Warn  LogLevel = "warn"
@@ -34,8 +34,8 @@ var (
 	Debug LogLevel = "debug"
 )
 
-var datadogLogLevel = "_logLevel"
-var datadogStatus = "status"
+const datadogLogLevel = "_logLevel"
+const datadogStatus = "status"
 
 func NewClient(properties map[string]interface{}) *Client {
 	local := GetOrCreateAnalyticsFile()
@@ -95,6 +95,10 @@ func (t *Client) AppendProperties(properties map[string]interface{}) {
 	for k, v := range properties {
 		t.Properties[k] = v
 	}
+}
+
+func (t *Client) DeleteProperty(key string) {
+	delete(t.Properties, key)
 }
 
 func (t *Client) UploadSource(source *core.InputFiles) {

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -209,7 +209,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Set up analytics, and hook them up to the logs
-	analyticsClient := analytics.NewClient(map[string]interface{}{
+	analyticsClient := analytics.NewClient(map[string]any{
 		"version": km.Version,
 		"strict":  cfg.strict,
 		"edition": km.DefaultUpdateStream,
@@ -363,7 +363,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Update analytics with app configs
-	analyticsClient.AppendProperties(map[string]interface{}{
+	analyticsClient.AppendProperties(map[string]any{
 		"provider": appCfg.Provider,
 		"app":      appCfg.AppName,
 	})
@@ -423,9 +423,11 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	CloseTreeSitter(result)
-	analyticsClient.AppendProperties(map[string]interface{}{"resource_types": GetResourceTypeCount(result, &appCfg)})
-	analyticsClient.AppendProperties(map[string]interface{}{"languages": GetLanguagesUsed(result)})
-	analyticsClient.AppendProperties(map[string]interface{}{"resources": resourceCounts})
+	analyticsClient.AppendProperties(map[string]any{
+		"resource_types": GetResourceTypeCount(result, &appCfg),
+		"languages":      GetLanguagesUsed(result),
+		"resources":      resourceCounts,
+	})
 	analyticsClient.Info(klothoName + " compile complete")
 
 	return nil

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -22,8 +22,8 @@ func (field fileField) Sanitize(hasher func(any) string) SanitizedField {
 		extension = filepath.Ext(field.f.Path())
 	}
 	return SanitizedField{
-		Key: "FileExtension",
-		Content: map[string]any{
+		Key: "file",
+		Content: map[string]string{
 			"extension": extension,
 			"path":      hasher(field.f.Path()),
 		},
@@ -51,8 +51,8 @@ func (field annotationField) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 func (field annotationField) Sanitize(hasher func(any) string) SanitizedField {
 	return SanitizedField{
-		Key: "Capability",
-		Content: map[string]any{
+		Key: "annotation",
+		Content: map[string]string{
 			"name":       field.a.Capability.Name,
 			"id":         hasher(field.a.Capability.ID),
 			"directives": hasher(field.a.Capability.Directives),
@@ -96,11 +96,11 @@ func DescribeKlothoFields(fields []zapcore.Field, expected ...string) map[string
 
 	for _, field := range fields {
 		encoder.b.Reset()
-		marhaledField, ok := field.Interface.(zapcore.ObjectMarshaler)
+		marshaledField, ok := field.Interface.(zapcore.ObjectMarshaler)
 		if !ok {
 			continue
 		}
-		if err := encoder.AppendObject(marhaledField); err != nil {
+		if err := encoder.AppendObject(marshaledField); err != nil {
 			all[field.Key] = "!!(UNMARSHALING ERROR)"
 		} else {
 			all[field.Key] = encoder.b.String()
@@ -111,8 +111,8 @@ func DescribeKlothoFields(fields []zapcore.Field, expected ...string) map[string
 
 func (field astNodeField) Sanitize(hasher func(any) string) SanitizedField {
 	return SanitizedField{
-		Key: "AstNodeType",
-		Content: map[string]any{
+		Key: "ast_node",
+		Content: map[string]string{
 			"type":    field.n.Type(),
 			"content": hasher(field.n.Content()),
 		},


### PR DESCRIPTION
When we hook into the log entries, don't send the sanitized fields as json in the event name. Instead, just send the log level for the event name (e.g. "WARN"), and send each sanitized field as a property with a dot-delimited key. For example, a file field would send:

    log.file.extension: .json
    log.file.path: sha256:<snip>

This resolves #239.

### Standard checks

- **Unit tests**: not unit tested; see our analytics dashboard for how this looks
- **Docs**: not needed
- **Backwards compatibility**: Analytics property names and formats have changed, so if we're relying on any for reports, then those would break. I don't think we're doing that.