### PR TITLE
Fixes fs.js s3 read/write issues introduced by switching clients

### DIFF
--- a/pkg/lang/javascript/aws_runtime/_fs.ts
+++ b/pkg/lang/javascript/aws_runtime/_fs.ts
@@ -90,7 +90,7 @@ exports.saveParametersToS3 = saveParametersToS3
 async function s3_writeFile(...args) {
     const bucketParams = {
         Bucket: bucketName,
-        Key: stripLeadingSlashes(`${args[0]}`),
+        Key: `${args[0]}`,
         Body: args[1],
     }
     try {
@@ -127,7 +127,7 @@ async function s3_readFile(...args) {
 async function s3_readdir(path) {
     const bucketParams: ListObjectsCommandInput = {
         Bucket: bucketName,
-        Prefix: stripLeadingSlashes(`${path}`),
+        Prefix: `${path}`,
     }
 
     try {
@@ -144,10 +144,7 @@ async function s3_readdir(path) {
 }
 
 async function s3_exists(fpath) {
-    const bucketParams = {
-        Bucket: bucketName,
-        Key: stripLeadingSlashes(`${path}`),
-    }
+    const bucketParams = { Bucket: bucketName, Key: `${path}` }
     try {
         const data = await s3Client.send(new HeadObjectCommand(bucketParams))
         console.debug('Success. Object deleted.', data)
@@ -159,10 +156,7 @@ async function s3_exists(fpath) {
 }
 
 async function s3_deleteFile(fpath) {
-    const bucketParams = {
-        Bucket: bucketName,
-        Key: stripLeadingSlashes(`${path}`),
-    }
+    const bucketParams = { Bucket: bucketName, Key: `${path}` }
     try {
         const data = await s3Client.send(new DeleteObjectCommand(bucketParams))
         console.debug('Success. Object deleted.', data)
@@ -171,9 +165,6 @@ async function s3_deleteFile(fpath) {
         console.log('Error', err)
         throw err
     }
-}
-function stripLeadingSlashes(path: string): string {
-    return path.replace(/^\/+/, '')
 }
 
 exports.fs = {

--- a/pkg/lang/javascript/aws_runtime/fs.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/fs.js.tmpl
@@ -73,7 +73,7 @@ exports.saveParametersToS3 = saveParametersToS3;
 async function s3_writeFile(...args) {
     const bucketParams = {
         Bucket: bucketName,
-        Key: `${args[0]}`,
+        Key: stripLeadingSlashes(`${args[0]}`),
         Body: args[1],
     };
     try {
@@ -88,15 +88,24 @@ async function s3_writeFile(...args) {
 async function s3_readFile(...args) {
     const bucketParams = {
         Bucket: bucketName,
-        Key: `${args[0]}`,
+        Key: stripLeadingSlashes(`${args[0]}`),
     };
     try {
         // Get the object from the Amazon S3 bucket. It is returned as a ReadableStream.
         const data = await s3Client.send(new client_s3_1.GetObjectCommand(bucketParams));
         if (data.Body) {
-            return await streamToString(data.Body);
+            if (args[1]?.encoding) {
+                return await streamToString(data.Body);
+            }
+            return new Promise((resolve, reject) => {
+                const stream = data.Body;
+                const chunks = [];
+                stream.on('data', chunk => chunks.push(chunk))
+                stream.once('end', () => resolve(Buffer.concat(chunks)))
+                stream.once('error', reject)
+            });
         }
-        return '';
+        return Promise.resolve();
     }
     catch (err) {
         console.log('Error', err);
@@ -106,7 +115,7 @@ async function s3_readFile(...args) {
 async function s3_readdir(path) {
     const bucketParams = {
         Bucket: bucketName,
-        Prefix: `${path}`,
+        Prefix: stripLeadingSlashes(`${path}`),
     };
     try {
         const data = await s3Client.send(new client_s3_1.ListObjectsCommand(bucketParams));
@@ -122,7 +131,10 @@ async function s3_readdir(path) {
     }
 }
 async function s3_exists(fpath) {
-    const bucketParams = { Bucket: bucketName, Key: `${path}` };
+    const bucketParams = {
+        Bucket: bucketName,
+        Key: stripLeadingSlashes(`${path}`)
+    };
     try {
         const data = await s3Client.send(new client_s3_1.HeadObjectCommand(bucketParams));
         console.debug('Success. Object deleted.', data);
@@ -134,7 +146,10 @@ async function s3_exists(fpath) {
     }
 }
 async function s3_deleteFile(fpath) {
-    const bucketParams = { Bucket: bucketName, Key: `${path}` };
+    const bucketParams = {
+        Bucket: bucketName,
+        Key: stripLeadingSlashes(`${path}`)
+    };
     try {
         const data = await s3Client.send(new client_s3_1.DeleteObjectCommand(bucketParams));
         console.debug('Success. Object deleted.', data);
@@ -144,6 +159,9 @@ async function s3_deleteFile(fpath) {
         console.log('Error', err);
         throw err;
     }
+}
+function stripLeadingSlashes(path) {
+    return path.replace(/^\/+/, "");
 }
 exports.fs = {
     writeFile: s3_writeFile,

--- a/pkg/lang/javascript/aws_runtime/fs.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/fs.js.tmpl
@@ -24,7 +24,7 @@ async function getCallParameters(paramKey, dispatcherMode) {
         const result = await s3Client.send(new client_s3_1.GetObjectCommand(bucketParams));
         let parameters = '';
         if (result.Body) {
-            parameters = await streamToString(result.Body, "utf-8");
+            parameters = await streamToString(result.Body, 'utf-8');
             console.log(parameters);
         }
         if (parameters != '') {
@@ -74,7 +74,7 @@ exports.saveParametersToS3 = saveParametersToS3;
 async function s3_writeFile(...args) {
     const bucketParams = {
         Bucket: bucketName,
-        Key: stripLeadingSlashes(`${args[0]}`),
+        Key: `${args[0]}`,
         Body: args[1],
     };
     try {
@@ -89,7 +89,7 @@ async function s3_writeFile(...args) {
 async function s3_readFile(...args) {
     const bucketParams = {
         Bucket: bucketName,
-        Key: stripLeadingSlashes(`${args[0]}`),
+        Key: `${args[0]}`,
     };
     try {
         // Get the object from the Amazon S3 bucket. It is returned as a ReadableStream.
@@ -98,7 +98,7 @@ async function s3_readFile(...args) {
             if (args[1]?.encoding) {
                 return await streamToString(data.Body, args[1].encoding);
             }
-           return streamToBuffer(data.Body);
+            return streamToBuffer(data.Body);
         }
     }
     catch (err) {
@@ -109,7 +109,7 @@ async function s3_readFile(...args) {
 async function s3_readdir(path) {
     const bucketParams = {
         Bucket: bucketName,
-        Prefix: stripLeadingSlashes(`${path}`),
+        Prefix: `${path}`,
     };
     try {
         const data = await s3Client.send(new client_s3_1.ListObjectsCommand(bucketParams));
@@ -125,10 +125,7 @@ async function s3_readdir(path) {
     }
 }
 async function s3_exists(fpath) {
-    const bucketParams = {
-        Bucket: bucketName,
-        Key: stripLeadingSlashes(`${path}`)
-    };
+    const bucketParams = { Bucket: bucketName, Key: `${path}` };
     try {
         const data = await s3Client.send(new client_s3_1.HeadObjectCommand(bucketParams));
         console.debug('Success. Object deleted.', data);
@@ -140,10 +137,7 @@ async function s3_exists(fpath) {
     }
 }
 async function s3_deleteFile(fpath) {
-    const bucketParams = {
-        Bucket: bucketName,
-        Key: stripLeadingSlashes(`${path}`)
-    };
+    const bucketParams = { Bucket: bucketName, Key: `${path}` };
     try {
         const data = await s3Client.send(new client_s3_1.DeleteObjectCommand(bucketParams));
         console.debug('Success. Object deleted.', data);
@@ -153,9 +147,6 @@ async function s3_deleteFile(fpath) {
         console.log('Error', err);
         throw err;
     }
-}
-function stripLeadingSlashes(path) {
-    return path.replace(/^\/+/, "");
 }
 exports.fs = {
     writeFile: s3_writeFile,

--- a/pkg/lang/javascript/aws_runtime/fs.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/fs.js.tmpl
@@ -7,11 +7,11 @@ const bucketEnvVar = '{{.BucketNameEnvVar}}';
 const bucketName = process.env[bucketEnvVar];
 const targetRegion = process.env['AWS_TARGET_REGION'];
 const s3Client = new client_s3_1.S3Client({ region: targetRegion });
-const streamToString = (stream) => new Promise((resolve, reject) => {
+const streamToString = (stream, encoding) => new Promise((resolve, reject) => {
     const chunks = [];
     stream.on('data', (chunk) => chunks.push(chunk));
     stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString(encoding)));
 });
 async function getCallParameters(paramKey, dispatcherMode) {
     let isEmitter = dispatcherMode === 'emitter' ? true : false;
@@ -23,7 +23,7 @@ async function getCallParameters(paramKey, dispatcherMode) {
         const result = await s3Client.send(new client_s3_1.GetObjectCommand(bucketParams));
         let parameters = '';
         if (result.Body) {
-            parameters = await streamToString(result.Body);
+            parameters = await streamToString(result.Body, "utf-8");
             console.log(parameters);
         }
         if (parameters != '') {
@@ -95,7 +95,7 @@ async function s3_readFile(...args) {
         const data = await s3Client.send(new client_s3_1.GetObjectCommand(bucketParams));
         if (data.Body) {
             if (args[1]?.encoding) {
-                return await streamToString(data.Body);
+                return await streamToString(data.Body, args[1].encoding);
             }
             return new Promise((resolve, reject) => {
                 const stream = data.Body;

--- a/pkg/lang/javascript/aws_runtime/fs.js.tmpl
+++ b/pkg/lang/javascript/aws_runtime/fs.js.tmpl
@@ -7,11 +7,12 @@ const bucketEnvVar = '{{.BucketNameEnvVar}}';
 const bucketName = process.env[bucketEnvVar];
 const targetRegion = process.env['AWS_TARGET_REGION'];
 const s3Client = new client_s3_1.S3Client({ region: targetRegion });
-const streamToString = (stream, encoding) => new Promise((resolve, reject) => {
+const streamToString = async (stream, encoding) => (await streamToBuffer(stream)).toString(encoding);
+const streamToBuffer = (stream) => new Promise((resolve, reject) => {
     const chunks = [];
     stream.on('data', (chunk) => chunks.push(chunk));
     stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks).toString(encoding)));
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
 });
 async function getCallParameters(paramKey, dispatcherMode) {
     let isEmitter = dispatcherMode === 'emitter' ? true : false;
@@ -97,15 +98,8 @@ async function s3_readFile(...args) {
             if (args[1]?.encoding) {
                 return await streamToString(data.Body, args[1].encoding);
             }
-            return new Promise((resolve, reject) => {
-                const stream = data.Body;
-                const chunks = [];
-                stream.on('data', chunk => chunks.push(chunk))
-                stream.once('end', () => resolve(Buffer.concat(chunks)))
-                stream.once('error', reject)
-            });
+           return streamToBuffer(data.Body);
         }
-        return Promise.resolve();
     }
     catch (err) {
         console.log('Error', err);


### PR DESCRIPTION
Resolves #280

- Stripped leading slashes in object paths supplied to fs functions to be more consistent with expected fs behavior (as well as the older s3fs-based implementation).
- Changed s3_readFile() to return a Promise<Buffer> by default and only returns a string if the user specifies an encoding. Additionally, an empty body results in a Promise<Void> rather than an empty string.

### Standard checks

- **Unit tests**: Any special considerations? No
- **Docs**: Do we need to update any docs, internal or public? No
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? Slim chance. Potentially breaks apps built with `v0.6.1` that using Cloud FS for JavaScript that intend to use `/` as an actual s3 object prefix or that expect `fs.readFile()` to always return a string.
