### PR TITLE
make analytics.Client more thread-safe

### DIFF
--- a/pkg/analytics/fields_listener.go
+++ b/pkg/analytics/fields_listener.go
@@ -74,7 +74,7 @@ func (fl *fieldListener) Write(entry zapcore.Entry, fields []zapcore.Field) erro
 		}
 	}
 
-	fl.client.Send(p)
+	fl.client.send(p)
 
 	return nil
 }

--- a/pkg/analytics/tracking_utils.go
+++ b/pkg/analytics/tracking_utils.go
@@ -19,14 +19,14 @@ type AnalyticsFile struct {
 	Id string
 }
 
-func (t *Client) Send(payload *Payload) {
+func (t *Client) send(payload Payload) {
 	postBody, _ := json.Marshal(payload)
 	data := bytes.NewBuffer(postBody)
 	url := t.serverUrlOverride
 	if url == "" {
 		url = kloServerUrl
 	}
-	resp, err := http.Post(fmt.Sprintf("%v/analytics/track", url), "application/json", data)
+	resp, err := http.Post(fmt.Sprintf("%s/analytics/track", url), "application/json", data)
 
 	if err != nil {
 		zap.L().Debug(fmt.Sprintf("Failed to send metrics info. %v", err))

--- a/pkg/analytics/tracking_utils.go
+++ b/pkg/analytics/tracking_utils.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go.uber.org/zap"
 	"math"
 	"net/http"
 	"time"
@@ -12,23 +13,26 @@ import (
 	"github.com/klothoplatform/klotho/pkg/core"
 )
 
-var kloServerUrl = "http://srv.klo.dev"
+const kloServerUrl = "http://srv.klo.dev"
 
 type AnalyticsFile struct {
 	Id string
 }
 
-func SendTrackingToServer(bundle *Client) error {
-	postBody, _ := json.Marshal(bundle)
+func (t *Client) Send(payload *Payload) {
+	postBody, _ := json.Marshal(payload)
 	data := bytes.NewBuffer(postBody)
-	resp, err := http.Post(fmt.Sprintf("%v/analytics/track", kloServerUrl), "application/json", data)
-	if err != nil {
-		return err
+	url := t.serverUrlOverride
+	if url == "" {
+		url = kloServerUrl
 	}
+	resp, err := http.Post(fmt.Sprintf("%v/analytics/track", url), "application/json", data)
 
-	defer resp.Body.Close()
-
-	return nil
+	if err != nil {
+		zap.L().Debug(fmt.Sprintf("Failed to send metrics info. %v", err))
+		return
+	}
+	resp.Body.Close()
 }
 
 func CompressFiles(input *core.InputFiles) ([]byte, error) {

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -209,7 +209,8 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Set up analytics, and hook them up to the logs
-	analyticsClient := analytics.NewClient(map[string]any{
+	analyticsClient := analytics.NewClient()
+	analyticsClient.AppendProperties(map[string]any{
 		"version": km.Version,
 		"strict":  cfg.strict,
 		"edition": km.DefaultUpdateStream,
@@ -255,7 +256,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	defer analyticsClient.PanicHandler(&err, errHandler)
 
 	updateStream := options.Update.Stream.OrDefault(km.DefaultUpdateStream)
-	analyticsClient.Properties["updateStream"] = updateStream
+	analyticsClient.AppendProperties(map[string]any{"updateStream": updateStream})
 
 	if cfg.version {
 		var versionQualifier string
@@ -267,7 +268,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 	klothoName := "klotho"
 	if km.VersionQualifier != "" {
-		analyticsClient.Properties[km.VersionQualifier] = true
+		analyticsClient.AppendProperties(map[string]any{km.VersionQualifier: true})
 	}
 
 	// if update is specified do the update in place

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -256,7 +256,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	defer analyticsClient.PanicHandler(&err, errHandler)
 
 	updateStream := options.Update.Stream.OrDefault(km.DefaultUpdateStream)
-	analyticsClient.AppendProperties(map[string]any{"updateStream": updateStream})
+	analyticsClient.AppendProperty("updateStream", updateStream)
 
 	if cfg.version {
 		var versionQualifier string
@@ -268,7 +268,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 	}
 	klothoName := "klotho"
 	if km.VersionQualifier != "" {
-		analyticsClient.AppendProperties(map[string]any{km.VersionQualifier: true})
+		analyticsClient.AppendProperty(km.VersionQualifier, true)
 	}
 
 	// if update is specified do the update in place


### PR DESCRIPTION
It's still not fully thread-safe, since we depend on being able to
append properties to it in klothomain; but for individual sends, it is.

We do this by separating out the client from the payload. Each time we
send a new message, we create a new payload, populate it with default
stuff from the client, modify that paylod (which is thread-local) and
send it.

This PR has two commits (at least for rev1):

- ff5d15bc7937c837be9ba997e25dbad62d95bc30 adds some simple unit tests for the analytics client, but doesn't affect prod at all
- 9ef7fd0ce692546d7200d2c23b94a07ce76e1d64 is the main part of this PR
    - note in particular the change to [`client_test.go` line 91][1]: when we send analytics directly (not via the logger hook), we now send `"status": "info"` where we didn't before

[1]: https://github.com/klothoplatform/klotho/commit/9ef7fd0ce692546d7200d2c23b94a07ce76e1d64#diff-9131bc6b505c18925e929864b3ffc81ae9840d00419019f63daeb5c3410751b8R91

Followup to #281.

### Standard checks

- **Unit tests**: added
- **Docs**: n/a
- **Backwards compatibility**: adds a status field to analytics; see above
