### PR TITLE
improve auth analytics

### DIFF
--- a/cmd/klotho/main.go
+++ b/cmd/klotho/main.go
@@ -27,9 +27,9 @@ func (local *LocalAuth) SetUpCliFlags(flags *pflag.FlagSet) {
 	flags.BoolVar((*bool)(local), "local", bool(*local), "If provided, runs Klotho with a local login (that is, not requiring an authenticated login)")
 }
 
-func (local *LocalAuth) Authorize() (*auth.KlothoClaims, error) {
+func (local *LocalAuth) Authorize() (auth.LoginInfo, error) {
 	if !*local {
 		return auth.Authorize()
 	}
-	return nil, nil
+	return auth.LoginInfo{Authorizer: "local"}, nil
 }

--- a/pkg/analytics/client.go
+++ b/pkg/analytics/client.go
@@ -63,10 +63,14 @@ func NewClient() *Client {
 	return client
 }
 
-func (t *Client) AttachAuthorizations(claims *auth.KlothoClaims) {
+func (t *Client) AttachAuthorizations(loginInfo auth.LoginInfo) {
 	t.universalProperties["localId"] = t.userId
-	t.userId = claims.Email
-	t.universalProperties["validated"] = claims.EmailVerified
+
+	if loginInfo.Email != "" {
+		t.userId = loginInfo.Email
+		t.universalProperties["validated"] = loginInfo.EmailVerified
+	}
+	t.universalProperties["loginMethod"] = loginInfo.Authorizer
 }
 
 func (t *Client) Info(event string) {

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -37,10 +37,10 @@ type KlothoMain struct {
 }
 type Authorizer interface {
 
-	// Authorize tries to authorize the user. The klothoClaims it returns may be nil, even if the authentication
-	// succeeds. Conversely, if the klothoClaims is non-nil, it is valid even if the error is also non-nil; you can use
-	// those claims provisionally (and specifically, in analytics) even if the error is non-nil, indicating failed
-	// authentication.
+	// Authorize tries to authorize the user. The LoginInfo may have content even if the error is non-nil. That means
+	// that we got information from the user, but were not able to verify it. succeeds. You can use
+	// that information provisionally (and specifically, in analytics) even if the error is non-nil, as long as you
+	// don't rely on it for anything related to things like security or privacy.
 	Authorize() (auth.LoginInfo, error)
 }
 

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -37,11 +37,11 @@ type KlothoMain struct {
 }
 type Authorizer interface {
 
-	// Authorize tries to authorize the user. The KlothoClaims it returns may be nil, even if the authentication
-	// succeeds. Conversely, if the KlothoClaims is non-nil, it is valid even if the error is also non-nil; you can use
+	// Authorize tries to authorize the user. The klothoClaims it returns may be nil, even if the authentication
+	// succeeds. Conversely, if the klothoClaims is non-nil, it is valid even if the error is also non-nil; you can use
 	// those claims provisionally (and specifically, in analytics) even if the error is non-nil, indicating failed
 	// authentication.
-	Authorize() (*auth.KlothoClaims, error)
+	Authorize() (auth.LoginInfo, error)
 }
 
 type FlagsProvider interface {
@@ -314,9 +314,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 
 	// Needs to go after the --version and --update checks
 	claims, err := km.Authorizer.Authorize()
-	if claims != nil {
-		analyticsClient.AttachAuthorizations(claims)
-	}
+	analyticsClient.AttachAuthorizations(claims)
 	if err != nil {
 		if errors.Is(err, auth.ErrNoCredentialsFile) {
 			return errors.New(`Failed to get credentials for user. Please run "klotho --login"`)


### PR DESCRIPTION
Always get a LoginInfo from the authorizer; this is never nil, and always contains an "Authorizer" field which should be a non-empty string describing the authorizer (for now, just "auth0" or "local"). Then, always attach that info to the analytics. This will let us know e.g. how many compiles are using local vs auth0.

This resolves #218

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: no issues
