### PR TITLE
Remove step for commenting on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,19 +43,3 @@ jobs:
           output: both
           hide_complexity: true
           hide_branch_rate: true
-
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          recreate: true
-          path: code-coverage-results.md
-  # codetour-watch:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-
-  #     - name: 'Watch CodeTour changes'
-  #       uses: pozil/codetour-watch@v1.6.0
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PRs from forks don't have the permissions for automated commenting.
For example: https://github.com/klothoplatform/klotho/actions/runs/4270734762/jobs/7461021371
> Error: Resource not accessible by integration

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
