### PR TITLE
Don't use NewClient and add universalProperties to expectation

### DIFF
--- a/pkg/analytics/client.go
+++ b/pkg/analytics/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	"github.com/klothoplatform/klotho/pkg/auth"
 
 	"github.com/google/uuid"
@@ -64,8 +65,6 @@ func NewClient() *Client {
 }
 
 func (t *Client) AttachAuthorizations(loginInfo auth.LoginInfo) {
-	t.universalProperties["localId"] = t.userId
-
 	if loginInfo.Email != "" {
 		t.userId = loginInfo.Email
 		t.universalProperties["validated"] = loginInfo.EmailVerified


### PR DESCRIPTION
This fixes the tests relying on the runner being logged in.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
