### PR TITLE
Slim release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,9 @@ jobs:
           npm install -g typescript
           mkdir dist
           go generate ./...
-          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux-musl" CXX="zig c++ -target x86_64-linux-musl" go build --tags extended -o dist/klotho_linux_amd64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'" ./cmd/klotho
-          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build --tags extended -o dist/klotho_darwin_amd64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'" ./cmd/klotho
-          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build --tags extended -o dist/klotho_darwin_arm64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'" ./cmd/klotho
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux-musl" CXX="zig c++ -target x86_64-linux-musl" go build --tags extended -o dist/klotho_linux_amd64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}' -s -w" ./cmd/klotho
+          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build --tags extended -o dist/klotho_darwin_amd64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}' -s -w" ./cmd/klotho
+          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build --tags extended -o dist/klotho_darwin_arm64 -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}' -s -w" ./cmd/klotho
           chmod +x dist
 
       - name: Upload build-artifacts


### PR DESCRIPTION
```
-rwxr-xr-x  1 gordon gordon  65M Feb 27 21:55 klotho_opt*
-rwxr-xr-x  1 gordon gordon  89M Feb 27 21:55 klotho_unopt*
```
More information about the flags are found here https://pkg.go.dev/cmd/link:
>-s
>	Omit the symbol table and debug information.
>
>-w
>	Omit the DWARF symbol table.

This does not impact go stack traces from `runtime` or `panic()`. With a panic inserted in main:
```
❯ ./klotho_opt
panic: test

goroutine 1 [running]:
main.main()
        /home/gordon/workspace/klotho/cmd/klotho/main.go:10 +0x27
```

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: Not breaking
