### PR TITLE
use the log group for the lambda function

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -520,11 +520,8 @@ export class CloudCCLib {
             }
         }
 
-        const logGroupName = sanitized(
-            AwsSanitizer.CloudWatch.logGroup.nameValidation()
-        )`/aws/lambda/${lambdaName}-function-api-lg`
         let cloudwatchGroup = new aws.cloudwatch.LogGroup(`${execUnitName}-function-api-lg`, {
-            name: logGroupName,
+            name: pulumi.interpolate`/aws/lambda/${lambdaConfig.name}`,
             retentionInDays: 1,
         })
 


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

a user reported this as an orphaned log group and its due to the fact that lambda logs to a specific log group naming format. Due to sanitization that format changed. Here we should not sanitize the log group because if the lambda name is valid, so is the log group

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
