### PR TITLE
Fixes RDS instance and proxy name sanitization

### DIFF
--- a/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
+++ b/pkg/infra/pulumi_aws/iac/sanitization/aws/rds.ts
@@ -33,28 +33,6 @@ export const engine = {
     },
 }
 
-export const dbProxy = {
-    nameValidation() {
-        return {
-            minLength: 1,
-            rules: [
-                regexpMatch('', /^[\da-zA-Z-]+$/, (s) => s.replace(/[^\da-zA-Z-]/g, '-')),
-                regexpMatch('Identifier must start with a letter', /^[a-zA-Z]/, (s) =>
-                    s.replace(/^[^a-zA-Z]+/, '')
-                ),
-                {
-                    description: 'Identifier must not end with a hyphen',
-                    validate: (s) => !s.endsWith('-'),
-                    fix: (s) => s.replace(/-+$/, ''),
-                },
-                regexpNotMatch('Identifier must not contain consecutive hyphens', /--/, (s) =>
-                    s.replace(/--+/g, '-')
-                ),
-            ],
-        }
-    },
-}
-
 export const instance = {
     nameValidation() {
         return {


### PR DESCRIPTION
This change fixes RDS instance name sanitization and will enable users to use hyphenated resource IDs with Klotho annotations that map to RDS instances.

- Changes sanitization of RDS instance names to use both instance and engine-specific rules
- Removes DB proxy name sanitization since it follows the same rules as instance and mirrors the instance's name

<!-- Describe the PR. 
• Does any part of it require special attention?
• Does it relate to or fix any issue?
-->

### Standard checks

- **Unit tests**: Any special considerations? no
- **Docs**: Do we need to update any docs, internal or public? no
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? no
