### PR TITLE
support for al2 gpu with nvidia driver

### DIFF
--- a/pkg/infra/pulumi_aws/files.go
+++ b/pkg/infra/pulumi_aws/files.go
@@ -6,7 +6,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/templateutils"
 )
 
-//go:embed *.tmpl *.ts *.json iac/*.ts iac/k8s/* iac/sanitization/*
+//go:embed *.tmpl *.ts *.json iac/*.ts iac/k8s/* iac/ec2/* iac/sanitization/*
 var files embed.FS
 
 var index = templateutils.MustTemplate(files, "index.ts.tmpl")

--- a/pkg/infra/pulumi_aws/iac/ec2/instance_specs.ts
+++ b/pkg/infra/pulumi_aws/iac/ec2/instance_specs.ts
@@ -1,0 +1,60 @@
+export const AL2_x86_64 = 'AL2_x86_64'
+export const AL2_x86_64_GPU = 'AL2_x86_64_GPU'
+export const AL2_ARM_64 = 'AL2_ARM_64'
+
+export const EKS_AMI_INSTANCE_PREFIX_MAP = new Map([
+    [
+        AL2_x86_64,
+        [
+            'c1',
+            'c3',
+            'c4',
+            'c5a',
+            'c5d',
+            'c5n',
+            'c6i',
+            'd2',
+            'i2',
+            'i3',
+            'i3en',
+            'i4i',
+            'inf1',
+            'm1',
+            'm2',
+            'm3',
+            'm4',
+            'm5',
+            'm5a',
+            'm5ad',
+            'm5d',
+            'm5zn',
+            'm6i',
+            'r3',
+            'r4',
+            'r5',
+            'r5a',
+            'r5ad',
+            'r5d',
+            'r5n',
+            'r6i',
+            't1',
+            't2',
+            't3',
+            't3a',
+            'z1d',
+        ],
+    ],
+    [AL2_x86_64_GPU, ['g2', 'g3', 'g4dn']],
+    [AL2_ARM_64, ['c6g', 'c6gd', 'c6gn', 'm6g', 'm6gd', 'r6g', 'r6gd', 't4g']],
+])
+
+export const getAmiFromInstanceType = (instanceType: string): string => {
+    const instancePrefix = instanceType.split('.')[0]
+    for (const key of EKS_AMI_INSTANCE_PREFIX_MAP.keys()) {
+        const validPrefixes = EKS_AMI_INSTANCE_PREFIX_MAP.get(key)
+        if (validPrefixes?.includes(instancePrefix)) {
+            return key
+        }
+    }
+    return ''
+}

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -151,6 +151,7 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 	addFile("iac/cockroachdb.ts")
 	addFile("iac/analytics.ts")
 	addFile("iac/load_balancing.ts")
+	addFile("iac/ec2/instance_specs.ts")
 	addFile("iac/k8s/horizontal-pod-autoscaling.ts")
 	addFile("iac/k8s/helm_chart.ts")
 	addFile("iac/k8s/add_ons/metrics_server/index.ts")


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #310  and https://github.com/klothoplatform/klotho-pro/issues/67

adds ami support and GPU support for eks. Some small fixes to multi exec eks as well

unfortunately cant fully test due to aws limits
```
    error: 1 error occurred:
    	* creating urn:pulumi:py-redis-cluster::py-redis-cluster::aws:eks/nodeGroup:NodeGroup::private-g3-4xlarge-NodeGroup: 1 error occurred:
    	* error waiting for EKS Node Group (py-redis-cluster-eks-cluster-6ad63af:private-g3-4xlarge-NodeGroup-1bff92a) to create: unexpected state 'CREATE_FAILED', wanted target 'ACTIVE'. last error: 1 error occurred:
    	* eks-private-g3-4xlarge-NodeGroup-1bff92a-3ec35205-3b66-2cff-aa7a-e60d5b0f7ad1: AsgInstanceLaunchFailures: Could not launch On-Demand Instances. VcpuLimitExceeded - You have requested more vCPU capacity than your current vCPU limit of 0 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit. Launching EC2 instance failed.
    error: post-step event returned an error: failed to save snapshot: renewing lease: [403] The provided update token has expired.
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
