### PR TITLE
fix dockerfiles to build correctly

### DIFF
--- a/pkg/lang/golang/aws_runtime/Exec_Dockerfile
+++ b/pkg/lang/golang/aws_runtime/Exec_Dockerfile
@@ -3,9 +3,8 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 WORKDIR /usr/src/app
 ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-COPY go.mod ./
-RUN go mod tidy && go mod download && go mod verify
 COPY . .
+RUN go mod tidy && go mod download && go mod verify
 RUN go build -o /usr/local/bin/app
 
 FROM scratch

--- a/pkg/lang/golang/aws_runtime/Lambda_Dockerfile
+++ b/pkg/lang/golang/aws_runtime/Lambda_Dockerfile
@@ -2,9 +2,8 @@ FROM golang:1.20 as builder
 
 WORKDIR /usr/src/app
 ENV GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-COPY go.mod ./
-RUN go mod tidy && go mod download && go mod verify
 COPY . .
+RUN go mod tidy && go mod download && go mod verify
 RUN go build -o /usr/local/bin/app
 
 FROM public.ecr.aws/lambda/provided:al2 


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

COPY go.mod ./
RUN go mod tidy && go mod download && go mod verify
COPY . .
because the COPY . . goes after the go mod tidy this last command empties the go.mod file bc non of the dependencies are used. And it end up failing.
Changing the order of them works


this change was made due to comments on https://github.com/klothoplatform/klotho/pull/274
### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
