### PR TITLE
Fixes incorrect self reference in SG ingress rules

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -210,7 +210,6 @@ export class CloudCCLib {
                             cidrBlocks: ['0.0.0.0/0'],
                             fromPort: 9443,
                             protocol: 'TCP',
-                            self: true,
                             toPort: 9443,
                         },
                         {
@@ -218,7 +217,6 @@ export class CloudCCLib {
                             cidrBlocks: [...privateCidrBlocks, ...publicCidrBlocks],
                             fromPort: 0,
                             protocol: '-1',
-                            self: true,
                             toPort: 0,
                         },
                     ],


### PR DESCRIPTION
This PR fixes recently introduced incorrect self references in SG ingress rules that lead to an invalid security group configuration.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
