### PR TITLE
s3 sse got lost in rebase

### DIFF
--- a/pkg/infra/pulumi_aws/deploylib.ts
+++ b/pkg/infra/pulumi_aws/deploylib.ts
@@ -772,6 +772,12 @@ export class CloudCCLib {
                     bucketName,
                     {
                         forceDestroy,
+                        serverSideEncryptionConfiguration: {
+                            applyServerSideEncryptionByDefault: {
+                                sseAlgorithm: 'aws:kms',
+                            },
+                            bucketKeyEnabled: true,
+                        },
                     },
                     { protect: this.protect }
                 )


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?


same as https://github.com/klothoplatform/klotho/pull/326 but got lost due to rebase, This is a ux issue caused by pulumi, but we can fix for now and always have default encryption.

pulumi issue https://github.com/pulumi/pulumi-aws/issues/2403.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
