### PR TITLE
Adds identifier sanitization for the JS fs runtime

### DIFF
--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"github.com/klothoplatform/klotho/pkg/sanitization"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -99,7 +100,7 @@ func (r *AwsRuntime) TransformPersist(file *core.SourceFile, annot *core.Annotat
 	importModule := ""
 	switch kind {
 	case core.PersistFileKind:
-		importModule = "fs_" + annot.Capability.ID
+		importModule = sanitization.IdentifierSanitizer.Apply("fs_" + annot.Capability.ID)
 	case core.PersistKVKind:
 		importModule = "keyvalue"
 	case core.PersistSecretKind:

--- a/pkg/lang/javascript/plugin_persist.go
+++ b/pkg/lang/javascript/plugin_persist.go
@@ -3,6 +3,7 @@ package javascript
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/klothoplatform/klotho/pkg/sanitization"
 	"strings"
 
 	"github.com/klothoplatform/klotho/pkg/filter/predicate"
@@ -240,7 +241,7 @@ func (p *persister) transformSecret(file *core.SourceFile, cap *core.Annotation,
 }
 
 func (p *persister) transformFS(unit *core.ExecutionUnit, file *core.SourceFile, cap *core.Annotation, fsR *persistResult) (core.CloudResource, string, error) {
-	if err := file.ReplaceNodeContent(fsR.expression, fmt.Sprintf("fs_%sRuntime.fs", cap.Capability.ID)); err != nil {
+	if err := file.ReplaceNodeContent(fsR.expression, sanitization.IdentifierSanitizer.Apply(fmt.Sprintf("fs_%sRuntime", cap.Capability.ID))+".fs"); err != nil {
 		return nil, "", errors.Wrap(err, "could not reparse FS transformation")
 	}
 

--- a/pkg/sanitization/identifier.go
+++ b/pkg/sanitization/identifier.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 )
 
-// EnvVarKeySanitizer returns a sanitized environment key when applied.
-var EnvVarKeySanitizer = NewSanitizer(
+// IdentifierSanitizer returns a sanitized identifier that can be injected into source code when applied.
+var IdentifierSanitizer = NewSanitizer(
 	// strip any leading non alpha characters
 	Rule{
 		Pattern:     regexp.MustCompile(`^[^a-zA-Z]+`),

--- a/pkg/sanitization/sanitizer.go
+++ b/pkg/sanitization/sanitizer.go
@@ -13,6 +13,7 @@ type (
 	}
 )
 
+// Apply sequentially applies a Sanitizer's rules to the supplied input and returns the sanitized result.
 func (s *Sanitizer) Apply(input string) string {
 	output := input
 	for _, rule := range s.rules {
@@ -21,6 +22,7 @@ func (s *Sanitizer) Apply(input string) string {
 	return output
 }
 
+// NewSanitizer returns a new Sanitizer that applies the supplied rules to inputs.
 func NewSanitizer(rules ...Rule) *Sanitizer {
 	return &Sanitizer{rules: rules}
 }


### PR DESCRIPTION
Adds basic sanitization to source code identifiers (e.g. variable names) generated from Klotho capability IDs for the JavaScript FS runtime.

This PR doesn't handle identifier conflicts as that will be discussed further in design for #329. 

### Standard checks

- **Unit tests**: Any special considerations? No
- **Docs**: Do we need to update any docs, internal or public? No
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? No
