### PR TITLE
py: don't assume SecretBinary exists in response

### DIFF
--- a/pkg/lang/python/aws_runtime/secret.py
+++ b/pkg/lang/python/aws_runtime/secret.py
@@ -23,8 +23,8 @@ class SecretItem():
 
     async def read(self):
         response = self.client.get_secret_value(SecretId=self.name)
-        if response["SecretBinary"]:
+        if response.get("SecretBinary"):
             return response["SecretBinary"].decode('utf8')
-        elif response["SecretString"]:
+        elif response.get("SecretString"):
             return response["SecretString"]
         raise Exception("Empty Secret")

--- a/pkg/lang/python/aws_runtime/secret.py.tmpl
+++ b/pkg/lang/python/aws_runtime/secret.py.tmpl
@@ -23,8 +23,8 @@ class SecretItem():
 
     async def read(self):
         response = self.client.get_secret_value(SecretId=self.name)
-        if response["SecretBinary"]:
+        if response.get("SecretBinary"):
             return response["SecretBinary"].decode('utf8')
-        elif response["SecretString"]:
+        elif response.get("SecretString"):
             return response["SecretString"]
         raise Exception("Empty Secret")


### PR DESCRIPTION
If it's a text-based secret, there's no SecretBinary -- just SecretString. Use `get` so that it doesn't cause a KeyError.

### Standard checks

- **Unit tests**: none; discovered while integration testing
- **Docs**: n/a
- **Backwards compatibility**: no issues
