### PR TITLE
install fluentbit on nodes for eks

### DIFF
--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -439,6 +439,10 @@ export class Eks {
         }
     }
 
+    public getClusterName(): pulumi.Output<string> {
+        return this.cluster.name
+    }
+
     private determineNodeGroupSpecs(execUnits: EksExecUnit[]): Map<string, NodeGroupSpecs> {
         let nodeGroupSpecs: Map<string, NodeGroupSpecs> = new Map<string, NodeGroupSpecs>()
         const defaultDiskSize = 20

--- a/pkg/infra/pulumi_aws/iac/eks.ts
+++ b/pkg/infra/pulumi_aws/iac/eks.ts
@@ -7,7 +7,13 @@ import * as pulumi_k8s from '@pulumi/kubernetes'
 import * as k8s from './kubernetes'
 import * as https from 'https'
 import { getIssuerCAThumbprint } from '@pulumi/eks/cert-thumprint'
-import { cloud_map_controller, alb_controller, external_dns } from './k8s/add_ons/'
+import {
+    cloud_map_controller,
+    alb_controller,
+    external_dns,
+    installFluentBitForCW,
+    enableFargateLogging,
+} from './k8s/add_ons/'
 import { local } from '@pulumi/command'
 import { CloudCCLib, Resource } from '../deploylib'
 import * as uuid from 'uuid'
@@ -117,13 +123,14 @@ interface EksClusterOptions {
     initializePluginsOnFargate?: boolean
     installPlugins?: plugins[]
     enableFargateLogging?: Boolean
+    enableFluentBitLogging?: Boolean
     adminRoleArn?: string
     autoApply?: boolean
     createNodeGroup?: boolean
 }
 
 export const DefaultEksClusterOptions: EksClusterOptions = {
-    initializePluginsOnFargate: true,
+    initializePluginsOnFargate: false,
     installPlugins: [
         plugins.VPC_CNI,
         plugins.METRICS_SERVER,
@@ -132,6 +139,7 @@ export const DefaultEksClusterOptions: EksClusterOptions = {
         plugins.CLOUD_MAP_CONTROLLER,
     ],
     enableFargateLogging: true,
+    enableFluentBitLogging: true,
     autoApply: true,
     createNodeGroup: true,
 }
@@ -272,7 +280,10 @@ export class Eks {
         this.createNodeGroups(execUnits)
 
         if (options.enableFargateLogging) {
-            this.enableFargateLogging()
+            enableFargateLogging(this, this.provider)
+        }
+        if (options.enableFluentBitLogging) {
+            installFluentBitForCW(this, this.provider)
         }
 
         const p = options.installPlugins ? options.installPlugins : []
@@ -313,22 +324,21 @@ export class Eks {
                     break
                 case plugins.AWS_LOAD_BALANCER_CONTROLLER:
                     const lbSaName = `${clusterName}-alb-controller`
-                    const lbServiceAccount = this.createServiceAccount(
-                        lbSaName,
-                        KUBE_SYSTEM_NAMESPACE
-                    )
+                    const namespace = options.initializePluginsOnFargate
+                        ? KUBE_SYSTEM_NAMESPACE
+                        : EXEC_UNIT_NAMESPACE
+                    const lbServiceAccount = this.createServiceAccount(lbSaName, namespace)
                     alb_controller.attachPermissionsToRole(
-                        this.serviceAccounts.get(`${lbSaName}_${KUBE_SYSTEM_NAMESPACE}`)!
+                        this.serviceAccounts.get(`${lbSaName}_${namespace}`)!
                     )
                     certManagerInstall ? dependsOn.push(certManagerInstall) : null
                     const albController = alb_controller.installLoadBalancerController(
                         clusterName,
-                        KUBE_SYSTEM_NAMESPACE,
+                        namespace,
                         lbServiceAccount,
                         vpc,
                         this.provider,
                         this.region,
-                        this.options.initializePluginsOnFargate || false,
                         dependsOn
                     )
                     this.installedPlugins.set(plugins.AWS_LOAD_BALANCER_CONTROLLER, albController)
@@ -970,7 +980,7 @@ export class Eks {
         return sa
     }
 
-    private createNamespace(
+    public createNamespace(
         name: string,
         labels?: { [key: string]: any }
     ): pulumi_k8s.core.v1.Namespace {
@@ -1010,46 +1020,6 @@ export class Eks {
             customTimeouts: { create: '30m', update: '30m', delete: '30m' },
         })
         return profile
-    }
-
-    private enableFargateLogging() {
-        const ns = 'aws-observability'
-        const labels = { 'aws-observability': 'enabled' }
-        this.createNamespace(ns, labels)
-
-        const configMap = new pulumi_k8s.core.v1.ConfigMap(
-            'aws-observability-configmap',
-            {
-                metadata: {
-                    name: 'aws-logging',
-                    namespace: ns,
-                },
-                data: {
-                    'output.conf': `[OUTPUT]
-                    Name cloudwatch_logs
-                    Match   *
-                    region ${this.region}
-                    log_group_name fluent-bit-cloudwatch
-                    log_stream_prefix from-fluent-bit-
-                    auto_create_group true
-                    log_key log`,
-
-                    'parsers.conf': `[PARSER]
-                    Name crio
-                    Format Regex
-                    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
-                    Time_Key    time
-                    Time_Format %Y-%m-%dT%H:%M:%S.%L%z`,
-
-                    'filters.conf': `[FILTER]
-                    Name parser
-                    Match *
-                    Key_name log
-                    Parser crio`,
-                },
-            },
-            { provider: this.provider }
-        )
     }
 
     // These are exec unit level methods
@@ -1262,6 +1232,7 @@ export class Eks {
                 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly',
                 'arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy',
                 'arn:aws:iam::aws:policy/AWSCloudMapFullAccess',
+                'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy',
             ],
         })
     }

--- a/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/add_ons/alb_controller/index.ts
@@ -255,7 +255,6 @@ export const installLoadBalancerController = (
     vpc: awsx.ec2.Vpc,
     provider: pulumi_k8s.Provider,
     region: string,
-    fargate: boolean,
     dependsOn?
 ): pulumi_k8s.helm.v3.Chart => {
     /**
@@ -287,7 +286,6 @@ export const installLoadBalancerController = (
                 podLabels: {
                     app: 'aws-lb-controller',
                 },
-                enableCertManager: !fargate,
             },
             version: '1.4.7',
             namespace: namespace,

--- a/pkg/infra/pulumi_aws/iac/k8s/add_ons/fluent_bit_for_eks/index.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/add_ons/fluent_bit_for_eks/index.ts
@@ -1,0 +1,77 @@
+import * as pulumi_k8s from '@pulumi/kubernetes'
+import { Eks } from '../../../eks'
+
+export const installFluentBitForCW = (eks: Eks, provider) => {
+    const namespaceName = 'amazon-cloudwatch'
+    const label = { name: namespaceName }
+    const cwNamespace = eks.createNamespace(namespaceName, label)
+
+    const configMap = new pulumi_k8s.core.v1.ConfigMap(
+        `${eks.clusterName}-fluent-bit-cluster-info`,
+        {
+            metadata: {
+                name: 'fluent-bit-cluster-info',
+                namespace: namespaceName,
+            },
+            data: {
+                'cluster.name': eks.clusterName,
+                'logs.region': eks.region,
+                'http.server': 'On',
+                'http.port': '2020',
+                'read.head': 'Off',
+                'read.tail': 'On',
+            },
+        },
+        { provider, dependsOn: [cwNamespace] }
+    )
+    new pulumi_k8s.yaml.ConfigFile(
+        `${eks.clusterName}-FluentBitDriver`,
+        {
+            file: 'https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml',
+        },
+        {
+            provider,
+            dependsOn: [cwNamespace, configMap],
+        }
+    )
+}
+
+export const enableFargateLogging = (eks: Eks, provider) => {
+    const ns = 'aws-observability'
+    const labels = { 'aws-observability': 'enabled' }
+    eks.createNamespace(ns, labels)
+
+    const configMap = new pulumi_k8s.core.v1.ConfigMap(
+        'aws-observability-configmap',
+        {
+            metadata: {
+                name: 'aws-logging',
+                namespace: ns,
+            },
+            data: {
+                'output.conf': `[OUTPUT]
+                Name cloudwatch_logs
+                Match   *
+                region ${eks.region}
+                log_group_name fluent-bit-cloudwatch
+                log_stream_prefix from-fluent-bit-
+                auto_create_group true
+                log_key log`,
+
+                'parsers.conf': `[PARSER]
+                Name crio
+                Format Regex
+                Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+                Time_Key    time
+                Time_Format %Y-%m-%dT%H:%M:%S.%L%z`,
+
+                'filters.conf': `[FILTER]
+                Name parser
+                Match *
+                Key_name log
+                Parser crio`,
+            },
+        },
+        { provider }
+    )
+}

--- a/pkg/infra/pulumi_aws/iac/k8s/add_ons/index.ts
+++ b/pkg/infra/pulumi_aws/iac/k8s/add_ons/index.ts
@@ -2,5 +2,13 @@ import * as alb_controller from './alb_controller'
 import * as cloud_map_controller from './cloud_map_controller'
 import * as external_dns from './external_dns'
 import * as metrics_server from './metrics_server'
+import { installFluentBitForCW, enableFargateLogging } from './fluent_bit_for_eks'
 
-export { alb_controller, cloud_map_controller, external_dns, metrics_server }
+export {
+    alb_controller,
+    cloud_map_controller,
+    external_dns,
+    metrics_server,
+    installFluentBitForCW,
+    enableFargateLogging,
+}

--- a/pkg/infra/pulumi_aws/plugin_iac.go
+++ b/pkg/infra/pulumi_aws/plugin_iac.go
@@ -160,6 +160,7 @@ func (p Plugin) Transform(result *core.CompilationResult, deps *core.Dependencie
 	addFile("iac/ec2/instance_specs.ts")
 	addFile("iac/k8s/horizontal-pod-autoscaling.ts")
 	addFile("iac/k8s/helm_chart.ts")
+	addFile("iac/k8s/add_ons/fluent_bit_for_eks/index.ts")
 	addFile("iac/k8s/add_ons/metrics_server/index.ts")
 	addFile("iac/k8s/add_ons/alb_controller/target_group_binding.yaml")
 	addFile("iac/k8s/add_ons/alb_controller/index.ts")


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #205 

installing fluent bit on our nodes and making everything run on nodes instead of fargate by default since we cant solely run on fargate due to some plugins. 

This will ship logs on the nodes back to cloudwatch so that we can pull them easily without having to do cluster work in our tests and useful for others. 

Enabled by default but we can expose it to be disabled

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
