### PR TITLE
delete before replace will cause slight downtime, so remove

### DIFF
--- a/pkg/infra/pulumi_aws/iac/api_gateway.ts
+++ b/pkg/infra/pulumi_aws/iac/api_gateway.ts
@@ -390,12 +390,6 @@ export class ApiGateway {
                 }
             }
 
-            //create the methods
-            // We use the combination of the aws method property operationName alongside pulumi properties
-            // replaceOnChanges and deleteBeforeReplace in order to correctly trigger swapping integrations
-            // when infra is changed, for example from lambda to fargate. All three properties are required
-            // to trigger a replace action of the method, which is required to correctly swap integrations
-            // while preventing resource collisions on the method.
             const method = new aws.apigateway.Method(
                 `${r.verb.toUpperCase()}-${routeAndHash}`,
                 {
@@ -411,8 +405,6 @@ export class ApiGateway {
                 },
                 {
                     parent: parentResource ?? restAPI,
-                    replaceOnChanges: ['*'],
-                    deleteBeforeReplace: true,
                 }
             )
             methods.push(method)


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

avoid causing downtime on deployments

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
