### PR TITLE
for js files not tscd read them normally

### DIFF
--- a/pkg/input/readdir.go
+++ b/pkg/input/readdir.go
@@ -3,14 +3,15 @@ package input
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/klothoplatform/klotho/pkg/filter/predicate"
-	"github.com/klothoplatform/klotho/pkg/lang/csharp/csproj"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/klothoplatform/klotho/pkg/filter/predicate"
+	"github.com/klothoplatform/klotho/pkg/lang/csharp/csproj"
 
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -226,10 +227,10 @@ func ReadDir(fsys fs.FS, cfg config.Application, cfgFilePath string) (*core.Inpu
 				if tsConfig.CompilerOptions.OutDir != "" {
 					tsPrefix := tsConfig.CompilerOptions.OutDir + string(os.PathSeparator)
 					newPath := strings.TrimPrefix(path, tsPrefix) // tsPrefix is already joined to cfg.Path, so use `path` not `relPath`
-					if relPath != newPath {
+					if relPath != newPath && newPath != path {
 						zap.S().Debugf("Removing TS outdir from %s -> %s", relPath, newPath)
+						relPath = newPath
 					}
-					relPath = newPath
 				}
 				f, err = addFile(fsys, path, relPath, javascript.NewFile)
 				jsLang.foundSources = true


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? if you have a js file in a ts project, we will currently read it incorrectly because we assume that it should be in the location of the tsconfigs output dir. If we trim the prefix and find the relative path to the run is still the same, we should return the original relative path

closes #351

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
