### PR TITLE
need to sanitize filename to match

### DIFF
--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -5,10 +5,11 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"github.com/klothoplatform/klotho/pkg/sanitization"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
 
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -161,7 +162,7 @@ func (r *AwsRuntime) AddFsRuntimeFiles(unit *core.ExecutionUnit, bucketNameEnvVa
 	if err != nil {
 		return err
 	}
-	err = javascript.AddRuntimeFile(unit, templateData, fmt.Sprintf("fs_%s.js.tmpl", id), content)
+	err = javascript.AddRuntimeFile(unit, templateData, fmt.Sprintf("fs_%s.js.tmpl", sanitization.IdentifierSanitizer.Apply(id)), content)
 	return err
 }
 


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? we sanitize the import name to make it a valid filename, but never sanitized the file being created. This makes it consistent so we dont get a moduleNotFound error

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
