### PR TITLE
use separate stacks for different regions

### DIFF
--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -131,7 +131,7 @@ jobs:
           set -x
           cd _test_resources
           npm i
-          pulumi -s integ-test-shared stack select --create
+          pulumi -s integ-test-shared-${{ env.AWS_REGION }} stack select --create
           pulumi stack tag set usage integ-test
           pulumi config refresh || true
           pulumi up -y --refresh


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

because oss and pro use the same actions, this was causing the stack to have to be deleted and recreated each time. We will need to clean up the account, it seems that theres multiple stack resources created which we need to delete

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
