### PR TITLE
Remove code coverage since we don't add to PRs anymore

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,19 +27,4 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run test
-        run: go test -race -v -coverprofile=coverage.out ./...
-
-      - name: Convert to Cobertura
-        run: |
-          go get github.com/t-yuki/gocover-cobertura
-          go install github.com/t-yuki/gocover-cobertura
-          gocover-cobertura < coverage.out > coverage.xml
-
-      - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.2.0
-        with:
-          filename: coverage.xml
-          format: markdown
-          output: both
-          hide_complexity: true
-          hide_branch_rate: true
+        run: go test -race -v ./...


### PR DESCRIPTION
Since we no longer add the coverage to the PR as a comment, no need to generate the report.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
