### PR TITLE
break up config code for new foundations and unit tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,9 +12,8 @@ import (
 )
 
 type (
-	/** Application is used to define the configuration for the application being compiled by Klotho.
-	* The application configuration contains the necessary information to depict the architecture as well as klotho compilation configuration.
-	 */
+	// Application is used to define the configuration for the application being compiled by Klotho.
+	//The application configuration contains the necessary information to depict the architecture as well as klotho compilation configuration.
 	Application struct {
 		AppName  string `json:"app" yaml:"app" toml:"app"`
 		Provider string `json:"provider" yaml:"provider" toml:"provider"`
@@ -44,16 +43,10 @@ type (
 		Id string `json:"id,omitempty" yaml:"id,omitempty" toml:"id,omitempty"`
 	}
 
-	/** InfraParams are passed as-is to the generated IaC
-	*   It follows a generic map and is later converted to the Kind specific object
-	 */
-
 	InfraParams map[string]interface{}
 
-	KindParams interface {
-		Merge(cfg interface{}) InfraParams
-	}
-
+	// Defaults represent the default characteristics the application will be configured with on Klotho compilation
+	// If a new field is added to defaults, that field will need to be added to the MergeDefaults method
 	Defaults struct {
 		ExecutionUnit       KindDefaults `json:"execution_unit" yaml:"execution_unit" toml:"execution_unit"`
 		StaticUnit          KindDefaults `json:"static_unit" yaml:"static_unit" toml:"static_unit"`
@@ -147,7 +140,7 @@ func (a Application) GetResourceType(resource core.CloudResource) string {
 		return cfg.Type
 
 	case core.GatewayKind:
-		cfg := a.GetExposed(key.Name)
+		cfg := a.GetExpose(key.Name)
 		return cfg.Type
 
 	case string(core.PersistFileKind):
@@ -199,7 +192,7 @@ func (a *Application) UpdateForResources(res []core.CloudResource) {
 			a.StaticUnit[key.Name] = &cfg
 
 		case core.GatewayKind:
-			cfg := a.GetExposed(key.Name)
+			cfg := a.GetExpose(key.Name)
 			a.Exposed[key.Name] = &cfg
 
 		case string(core.PersistFileKind):
@@ -309,5 +302,5 @@ func mapify(i interface{}) (map[string]interface{}, bool) {
 		}
 		return m, true
 	}
-	return map[string]interface{}{}, false
+	return nil, false
 }

--- a/pkg/config/config_construct.go
+++ b/pkg/config/config_construct.go
@@ -1,0 +1,33 @@
+package config
+
+type (
+	// Config is how config Klotho constructs are represented in the klotho configuration
+	Config struct {
+		Type        string      `json:"type" yaml:"type" toml:"type"`
+		InfraParams InfraParams `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+	}
+)
+
+// GetConfig returns the `Config` config for the resource specified by `id`
+// merged with the defaults.
+func (a Application) GetConfig(id string) Config {
+	cfg := Config{}
+	if ecfg, ok := a.Config[id]; ok {
+		defaultParams, ok := a.Defaults.Config.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.Config.Type
+	defaultParams, ok := a.Defaults.Config.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = defaultParams
+	}
+	return cfg
+}

--- a/pkg/config/config_construct.go
+++ b/pkg/config/config_construct.go
@@ -1,7 +1,7 @@
 package config
 
 type (
-	// Config is how config Klotho constructs are represented in the klotho configuration
+	// Config is how config Klotho constructs and other related resources (or meta-resources) are represented in the klotho configuration
 	Config struct {
 		Type        string      `json:"type" yaml:"type" toml:"type"`
 		InfraParams InfraParams `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`

--- a/pkg/config/config_construct_test.go
+++ b/pkg/config/config_construct_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Config
+	}{
+		{
+			name: "get base config",
+			cfg: Application{
+				Defaults: Defaults{
+					Config: KindDefaults{
+						Type: "s3",
+						InfraParamsByType: map[string]InfraParams{
+							"s3": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Config{
+				Type: "s3",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params",
+			cfg: Application{
+				Defaults: Defaults{
+					Config: KindDefaults{
+						Type: "s3",
+						InfraParamsByType: map[string]InfraParams{
+							"s3": {"key1": "value1"},
+						},
+					},
+				},
+				Config: map[string]*Config{
+					"test": {Type: "s3"},
+				},
+			},
+			id: "test",
+			want: Config{
+				Type: "s3",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					Config: KindDefaults{
+						Type: "s3",
+						InfraParamsByType: map[string]InfraParams{
+							"s3": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				Config: map[string]*Config{
+					"test": {
+						Type:        "s3",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Config{
+				Type: "s3",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					Config: KindDefaults{
+						Type: "s3",
+						InfraParamsByType: map[string]InfraParams{
+							"s3": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				Config: map[string]*Config{
+					"test": {
+						Type:        "secrets_manager",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Config{
+				Type: "secrets_manager",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetConfig(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -154,6 +154,36 @@ func Test_MergeKindDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "basic defaults merge",
+			cfg: KindDefaults{
+				Type: "apigateway",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": "value100",
+						"key2": "value2",
+					},
+				},
+			},
+			defaults: KindDefaults{
+				Type: "somethingelse",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": 1234,
+						"key2": []int{1234},
+					},
+				},
+			},
+			want: KindDefaults{
+				Type: "apigateway",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": "value100",
+						"key2": "value2",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetResourceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Application
+		resource core.CloudResource
+		want     string
+	}{
+		{
+			name: "expose",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+					},
+				},
+			},
+			resource: &core.Gateway{Name: "test"},
+			want:     "apigateway",
+		},
+		{
+			name: "exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+					},
+				},
+			},
+			resource: &core.ExecutionUnit{Name: "test"},
+			want:     "lambda",
+		},
+		{
+			name: "persist kv",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+					},
+				},
+			},
+			resource: &core.Persist{Name: "test", Kind: core.PersistKVKind},
+			want:     "dynamodb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testType := tt.cfg.GetResourceType(tt.resource)
+			assert.Equal(tt.want, testType)
+
+		})
+	}
+}
+
+func Test_UpdateForResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Application
+		resources []core.CloudResource
+		want      Application
+	}{
+		{
+			name: "expose",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+					},
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+					},
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+					},
+				},
+			},
+			resources: []core.CloudResource{&core.Gateway{Name: "test"}, &core.ExecutionUnit{Name: "test"}, &core.Persist{Name: "test", Kind: core.PersistKVKind}},
+			want: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+					},
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+					},
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+					},
+				},
+				Exposed:        map[string]*Expose{"test": {Type: "apigateway"}},
+				ExecutionUnits: map[string]*ExecutionUnit{"test": {Type: "lambda"}},
+				PersistKv:      map[string]*Persist{"test": {Type: "dynamodb"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			tt.cfg.EnsureMapsExist()
+			tt.want.EnsureMapsExist()
+			tt.cfg.UpdateForResources(tt.resources)
+			assert.Equal(tt.want, tt.cfg)
+
+		})
+	}
+}
+
+func Test_MergeKindDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      KindDefaults
+		defaults KindDefaults
+		want     KindDefaults
+	}{
+		{
+			name: "basic defaults merge",
+			cfg: KindDefaults{
+				Type: "apigateway",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": "value100",
+					},
+				},
+			},
+			defaults: KindDefaults{
+				Type: "somethingelse",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": "value1",
+						"key2": "value2",
+					},
+					"somethingelse": {"1": "2"},
+				},
+			},
+			want: KindDefaults{
+				Type: "apigateway",
+				InfraParamsByType: map[string]InfraParams{
+					"apigateway": {
+						"key1": "value100",
+						"key2": "value2",
+					},
+					"somethingelse": {"1": "2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tt.cfg.Merge(tt.defaults)
+			assert.Equal(tt.want, tt.cfg)
+
+		})
+	}
+}
+
+func Test_MergeInfraParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      InfraParams
+		defaults InfraParams
+		want     map[string]interface{}
+	}{
+		{
+			name: "basic infra params merge",
+			cfg: InfraParams{
+				"key1": "value100",
+			},
+			defaults: InfraParams{
+				"key1": "value1",
+				"key2": "value2",
+				"1":    "2",
+			},
+			want: map[string]interface{}{
+				"key1": "value100",
+				"key2": "value2",
+				"1":    "2",
+			},
+		},
+		{
+			name: "nested infra params merge",
+			cfg: InfraParams{
+				"apigateway": map[string]interface{}{
+					"key1": "value100",
+				},
+			},
+			defaults: InfraParams{
+				"apigateway": map[string]interface{}{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				"somethingelse": map[string]interface{}{"1": "2"},
+			},
+			want: map[string]interface{}{
+				"apigateway": map[string]interface{}{
+					"key1": "value100",
+					"key2": "value2",
+				},
+				"somethingelse": map[string]interface{}{"1": "2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			result := tt.cfg.Merge(tt.defaults)
+			assert.Equal(tt.want, result)
+
+		})
+	}
+}

--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -1,0 +1,82 @@
+package config
+
+type (
+	// ExecutionUnit is how execution unit Klotho constructs are represented in the klotho configuration
+	ExecutionUnit struct {
+		Type                 string            `json:"type" yaml:"type" toml:"type"`
+		NetworkPlacement     string            `json:"network_placement,omitempty" yaml:"network_placement,omitempty" toml:"network_placement,omitempty"`
+		EnvironmentVariables map[string]string `json:"environment_variables,omitempty" yaml:"environment_variables,omitempty" toml:"environment_variables,omitempty"`
+		HelmChartOptions     *HelmChartOptions `json:"helm_chart_options,omitempty" yaml:"helm_chart_options,omitempty" toml:"helm_chart_options,omitempty"`
+		InfraParams          InfraParams       `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+	}
+
+	// HelmChartOptions represents configuration for execution units attempting to generate helm charts
+	HelmChartOptions struct {
+		Directory   string   `json:"directory,omitempty" yaml:"directory,omitempty" toml:"directory,omitempty"` // Directory signals the directory which will contain the helm chart outputs
+		Install     bool     `json:"install,omitempty" yaml:"install,omitempty" toml:"install,omitempty"`
+		ValuesFiles []string `json:"values_files,omitempty" yaml:"values_files,omitempty" toml:"values_files,omitempty"`
+	}
+
+	// ServerlessKindParams represents the KindParams, configurability, of execution units which match the serverless compatibility
+	ServerlessTypeParams struct {
+		Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty" toml:"timeout,omitempty"`
+		Memory  int `json:"memory,omitempty" yaml:"memory,omitempty" toml:"memory,omitempty"`
+	}
+
+	ContainerTypeParams struct {
+		// Cpu specifies the limit per pod in millicores
+		Cpu int `json:"cpu,omitempty" yaml:"cpu,omitempty" toml:"cpu,omitempty"`
+		// Memory specifies the limit per pod in MB
+		Memory int `json:"memory,omitempty" yaml:"memory,omitempty" toml:"memory,omitempty"`
+	}
+
+	// KubernetesKindParams represents the KindParams, configurability, of execution units which match the kubernetes compatibility
+	KubernetesTypeParams struct {
+		ClusterId                      string                                   `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty" toml:"cluster_id,omitempty"`
+		NodeType                       string                                   `json:"node_type,omitempty" yaml:"node_type,omitempty" toml:"node_type,omitempty"`
+		Replicas                       int                                      `json:"replicas,omitempty" yaml:"replicas,omitempty" toml:"replicas,omitempty"`
+		Limits                         KubernetesLimits                         `json:"limits,omitempty" yaml:"limits,omitempty" toml:"limits,omitempty"`
+		HorizontalPodAutoScalingConfig KubernetesHorizontalPodAutoScalingConfig `json:"horizontal_pod_autoscaling,omitempty" yaml:"horizontal_pod_autoscaling,omitempty" toml:"horizontal_pod_autoscaling,omitempty"`
+	}
+
+	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility
+	KubernetesLimits struct {
+		// Cpu specifies the limit per pod in millicores
+		Cpu int `json:"cpu,omitempty" yaml:"cpu,omitempty" toml:"cpu,omitempty"`
+		// Memory specifies the limit per pod in MB
+		Memory int `json:"memory,omitempty" yaml:"memory,omitempty" toml:"memory,omitempty"`
+	}
+
+	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility
+	KubernetesHorizontalPodAutoScalingConfig struct {
+		// MemoryUtilization specifies he percentage of cpu a pod can utilize before the cluster will attempt to scale the pod
+		CpuUtilization int `json:"cpu_utilization,omitempty" yaml:"cpu_utilization,omitempty" toml:"cpu_utilization,omitempty"`
+		// MemoryUtilization specifies the percentage of memory a pod can utilize before the cluster will attempt to scale the pod
+		MemoryUtilization int `json:"memory_utilization,omitempty" yaml:"memory_utilization,omitempty" toml:"memory_utilization,omitempty"`
+		// MaxReplicas specifies the maximum number of pods the cluster will scale the pod spec to
+		MaxReplicas int `json:"max_replicas,omitempty" yaml:"max_replicas,omitempty" toml:"max_replicas,omitempty"`
+	}
+)
+
+// GetExecutionUnit returns the `ExecutionUnit` config for the resource specified by `id`
+// merged with the defaults.
+func (a Application) GetExecutionUnit(id string) ExecutionUnit {
+	cfg := ExecutionUnit{}
+	if ecfg, ok := a.ExecutionUnits[id]; ok {
+		defaultParams, ok := a.Defaults.ExecutionUnit.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.ExecutionUnit.Type
+	defaultParams, ok := a.Defaults.ExecutionUnit.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = defaultParams
+	}
+	return cfg
+}

--- a/pkg/config/execution_unit_test.go
+++ b/pkg/config/execution_unit_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetExecutionUnit(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want ExecutionUnit
+	}{
+		{
+			name: "get base exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+						InfraParamsByType: map[string]InfraParams{
+							"lambda": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: ExecutionUnit{
+				Type: "lambda",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+						InfraParamsByType: map[string]InfraParams{
+							"lambda": {"key1": "value1"},
+						},
+					},
+				},
+				ExecutionUnits: map[string]*ExecutionUnit{
+					"test": {Type: "lambda"},
+				},
+			},
+			id: "test",
+			want: ExecutionUnit{
+				Type: "lambda",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+						InfraParamsByType: map[string]InfraParams{
+							"lambda": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				ExecutionUnits: map[string]*ExecutionUnit{
+					"test": {
+						Type:             "lambda",
+						InfraParams:      map[string]interface{}{"key2": "value200"},
+						HelmChartOptions: &HelmChartOptions{Install: true},
+					},
+				},
+			},
+			id: "test",
+			want: ExecutionUnit{
+				Type: "lambda",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+				HelmChartOptions: &HelmChartOptions{Install: true},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					ExecutionUnit: KindDefaults{
+						Type: "lambda",
+						InfraParamsByType: map[string]InfraParams{
+							"lambda": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				ExecutionUnits: map[string]*ExecutionUnit{
+					"test": {
+						Type:             "ecs",
+						InfraParams:      map[string]interface{}{"key2": "value200"},
+						HelmChartOptions: &HelmChartOptions{Install: true},
+					},
+				},
+			},
+			id: "test",
+			want: ExecutionUnit{
+				Type: "ecs",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+				HelmChartOptions: &HelmChartOptions{Install: true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetExecutionUnit(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}

--- a/pkg/config/expose.go
+++ b/pkg/config/expose.go
@@ -1,0 +1,41 @@
+package config
+
+type (
+	// Expose is how expose Klotho constructs are represented in the klotho configuration
+	Expose struct {
+		Type                   string                 `json:"type" yaml:"type" toml:"type"`
+		ContentDeliveryNetwork ContentDeliveryNetwork `json:"content_delivery_network,omitempty" yaml:"content_delivery_network,omitempty" toml:"content_delivery_network,omitempty"`
+		InfraParams            InfraParams            `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+	}
+
+	GatewayKindParams struct {
+		ApiType string
+	}
+
+	LoadBalancerKindParams struct {
+	}
+)
+
+// GetExpose returns the `Expose` config for the resource specified by `id`
+// merged with the defaults.
+func (a Application) GetExposed(id string) Expose {
+	cfg := Expose{}
+	if ecfg, ok := a.Exposed[id]; ok {
+		defaultParams, ok := a.Defaults.Expose.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.Expose.Type
+	defaultParams, ok := a.Defaults.Expose.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}

--- a/pkg/config/expose.go
+++ b/pkg/config/expose.go
@@ -8,17 +8,17 @@ type (
 		InfraParams            InfraParams            `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
 	}
 
-	GatewayKindParams struct {
+	GatewayTypeParams struct {
 		ApiType string
 	}
 
-	LoadBalancerKindParams struct {
+	LoadBalancerTypeParams struct {
 	}
 )
 
 // GetExpose returns the `Expose` config for the resource specified by `id`
 // merged with the defaults.
-func (a Application) GetExposed(id string) Expose {
+func (a Application) GetExpose(id string) Expose {
 	cfg := Expose{}
 	if ecfg, ok := a.Exposed[id]; ok {
 		defaultParams, ok := a.Defaults.Expose.InfraParamsByType[ecfg.Type]

--- a/pkg/config/expose_test.go
+++ b/pkg/config/expose_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetExpose(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Expose
+	}{
+		{
+			name: "get base exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+						InfraParamsByType: map[string]InfraParams{
+							"apigateway": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Expose{
+				Type: "apigateway",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+						InfraParamsByType: map[string]InfraParams{
+							"apigateway": {"key1": "value1"},
+						},
+					},
+				},
+				Exposed: map[string]*Expose{
+					"test": {Type: "apigateway"},
+				},
+			},
+			id: "test",
+			want: Expose{
+				Type: "apigateway",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+						InfraParamsByType: map[string]InfraParams{
+							"apigateway": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				Exposed: map[string]*Expose{
+					"test": {
+						Type:        "apigateway",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Expose{
+				Type: "apigateway",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					Expose: KindDefaults{
+						Type: "apigateway",
+						InfraParamsByType: map[string]InfraParams{
+							"apigateway": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				Exposed: map[string]*Expose{
+					"test": {
+						Type:        "alb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Expose{
+				Type: "alb",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetExposed(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}

--- a/pkg/config/expose_test.go
+++ b/pkg/config/expose_test.go
@@ -114,7 +114,7 @@ func Test_GetExpose(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			testcfg := tt.cfg.GetExposed(tt.id)
+			testcfg := tt.cfg.GetExpose(tt.id)
 			assert.Equal(tt.want, testcfg)
 
 		})

--- a/pkg/config/persist.go
+++ b/pkg/config/persist.go
@@ -1,0 +1,155 @@
+package config
+
+type (
+	// Persist is how persist Klotho constructs are represented in the klotho configuration
+	Persist struct {
+		// Type represents the service used for the persist construct
+		Type string `json:"type" yaml:"type" toml:"type"`
+		// KindParams represents the set of configuration to customize the kind of persist construct represented
+		InfraParams InfraParams `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+	}
+)
+
+// GetPersistKv returns the `Persist` config for the persist_kv resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistKv(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistKv[id]; ok {
+		defaultParams, ok := a.Defaults.PersistKv.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistKv.Type
+	defaultParams, ok := a.Defaults.PersistKv.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}
+
+// GetPersistFs returns the `Persist` config for the persist_fs resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistFs(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistFs[id]; ok {
+		defaultParams, ok := a.Defaults.PersistFs.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistFs.Type
+	defaultParams, ok := a.Defaults.PersistFs.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}
+
+// GetPersistSecrets returns the `Persist` config for the persist_secrets resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistSecrets(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistSecrets[id]; ok {
+		defaultParams, ok := a.Defaults.PersistSecrets.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistSecrets.Type
+	defaultParams, ok := a.Defaults.PersistSecrets.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}
+
+// GetPersistOrm returns the `Persist` config for the persist_orm resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistOrm(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistOrm[id]; ok {
+		defaultParams, ok := a.Defaults.PersistOrm.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistOrm.Type
+	defaultParams, ok := a.Defaults.PersistOrm.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}
+
+// GetPersistRedisNode returns the `Persist` config for the persist_redis_node resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistRedisNode(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistRedisNode[id]; ok {
+		defaultParams, ok := a.Defaults.PersistRedisNode.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistRedisNode.Type
+	defaultParams, ok := a.Defaults.PersistRedisNode.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}
+
+// GetPersistRedisCluster returns the `Persist` config for the persist_redis_cluster resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPersistRedisCluster(id string) Persist {
+	cfg := Persist{}
+	if ecfg, ok := a.PersistRedisCluster[id]; ok {
+		defaultParams, ok := a.Defaults.PersistRedisCluster.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PersistRedisCluster.Type
+	defaultParams, ok := a.Defaults.PersistRedisCluster.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}

--- a/pkg/config/persist_test.go
+++ b/pkg/config/persist_test.go
@@ -1,0 +1,697 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetPersistKv(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base kv",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistKv: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistKv: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistKv: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistKv: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistKv(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}
+
+func Test_GetPersistFs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base fs",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistFs: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistFs: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistFs: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistFs: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistFs: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistFs: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistFs: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistFs(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}
+
+func Test_GetPersistSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base secrets",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistSecrets: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistSecrets: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistSecrets: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistSecrets: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistSecrets: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistSecrets: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistSecrets: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistSecrets(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}
+
+func Test_GetPersistOrm(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base secrets",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistOrm: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistOrm: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistOrm: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistOrm: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistOrm: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistOrm: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistOrm: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistOrm(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}
+
+func Test_GetPersistRedisNode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base secrets",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisNode: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisNode: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistRedisNode: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisNode: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistRedisNode: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisNode: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistRedisNode: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistRedisNode(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}
+
+func Test_GetPersistRedisCluster(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want Persist
+	}{
+		{
+			name: "get base secrets",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisCluster: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisCluster: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				PersistRedisCluster: map[string]*Persist{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisCluster: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistRedisCluster: map[string]*Persist{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PersistRedisCluster: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PersistRedisCluster: map[string]*Persist{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: Persist{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPersistRedisCluster(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}

--- a/pkg/config/pubsub.go
+++ b/pkg/config/pubsub.go
@@ -1,0 +1,33 @@
+package config
+
+type (
+	// Pubsub is how pubsub Klotho constructs are represented in the klotho configuration
+	PubSub struct {
+		Type        string      `json:"type" yaml:"type" toml:"type"`
+		InfraParams InfraParams `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+	}
+)
+
+// GetConfig returns the `Config` config for the resource specified by `id`
+// merged with the defaults.
+func (a Application) GetPubSub(id string) PubSub {
+	cfg := PubSub{}
+	if ecfg, ok := a.PubSub[id]; ok {
+		defaultParams, ok := a.Defaults.PubSub.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.PubSub.Type
+	defaultParams, ok := a.Defaults.PubSub.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}

--- a/pkg/config/pubsub_test.go
+++ b/pkg/config/pubsub_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetPubsub(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want PubSub
+	}{
+		{
+			name: "get base exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					PubSub: KindDefaults{
+						Type: "sns",
+						InfraParamsByType: map[string]InfraParams{
+							"sns": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: PubSub{
+				Type: "sns",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					PubSub: KindDefaults{
+						Type: "sns",
+						InfraParamsByType: map[string]InfraParams{
+							"sns": {"key1": "value1"},
+						},
+					},
+				},
+				PubSub: map[string]*PubSub{
+					"test": {Type: "sns"},
+				},
+			},
+			id: "test",
+			want: PubSub{
+				Type: "sns",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PubSub: KindDefaults{
+						Type: "sns",
+						InfraParamsByType: map[string]InfraParams{
+							"sns": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PubSub: map[string]*PubSub{
+					"test": {
+						Type:        "sns",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: PubSub{
+				Type: "sns",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					PubSub: KindDefaults{
+						Type: "sns",
+						InfraParamsByType: map[string]InfraParams{
+							"sns": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				PubSub: map[string]*PubSub{
+					"test": {
+						Type:        "sqs",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: PubSub{
+				Type: "sqs",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetPubSub(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}

--- a/pkg/config/static_unit.go
+++ b/pkg/config/static_unit.go
@@ -1,0 +1,34 @@
+package config
+
+type (
+	// StaticUnit is how static unit Klotho constructs are represented in the klotho configuration
+	StaticUnit struct {
+		Type                   string                 `json:"type" yaml:"type" toml:"type"`
+		InfraParams            InfraParams            `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
+		ContentDeliveryNetwork ContentDeliveryNetwork `json:"content_delivery_network,omitempty" yaml:"content_delivery_network,omitempty" toml:"content_delivery_network,omitempty"`
+	}
+)
+
+// GetConfig returns the `Config` config for the resource specified by `id`
+// merged with the defaults.
+func (a Application) GetStaticUnit(id string) StaticUnit {
+	cfg := StaticUnit{}
+	if ecfg, ok := a.StaticUnit[id]; ok {
+		defaultParams, ok := a.Defaults.StaticUnit.InfraParamsByType[ecfg.Type]
+		if ok {
+			if ecfg.InfraParams == nil {
+				ecfg.InfraParams = defaultParams
+			} else {
+				ecfg.InfraParams = ecfg.InfraParams.Merge(defaultParams)
+			}
+		}
+		return *ecfg
+	}
+	cfg.Type = a.Defaults.StaticUnit.Type
+	defaultParams, ok := a.Defaults.StaticUnit.InfraParamsByType[cfg.Type]
+	if ok {
+		cfg.InfraParams = cfg.InfraParams.Merge(defaultParams)
+
+	}
+	return cfg
+}

--- a/pkg/config/static_unit_test.go
+++ b/pkg/config/static_unit_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetStaticUnit(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Application
+		id   string
+		want StaticUnit
+	}{
+		{
+			name: "get base fs",
+			cfg: Application{
+				Defaults: Defaults{
+					StaticUnit: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+			},
+			id: "test",
+			want: StaticUnit{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get base type params exec unit",
+			cfg: Application{
+				Defaults: Defaults{
+					StaticUnit: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1"},
+						},
+					},
+				},
+				StaticUnit: map[string]*StaticUnit{
+					"test": {Type: "dynamodb"},
+				},
+			},
+			id: "test",
+			want: StaticUnit{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+				},
+			},
+		},
+		{
+			name: "get config and add other default params",
+			cfg: Application{
+				Defaults: Defaults{
+					StaticUnit: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				StaticUnit: map[string]*StaticUnit{
+					"test": {
+						Type:        "dynamodb",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: StaticUnit{
+				Type: "dynamodb",
+				InfraParams: InfraParams{
+					"key1": "value1",
+					"key2": "value200",
+				},
+			},
+		},
+		{
+			name: "get config and with no default params",
+			cfg: Application{
+				Defaults: Defaults{
+					StaticUnit: KindDefaults{
+						Type: "dynamodb",
+						InfraParamsByType: map[string]InfraParams{
+							"dynamodb": {"key1": "value1", "key2": "value2"},
+						},
+					},
+				},
+				StaticUnit: map[string]*StaticUnit{
+					"test": {
+						Type:        "other",
+						InfraParams: map[string]interface{}{"key2": "value200"},
+					},
+				},
+			},
+			id: "test",
+			want: StaticUnit{
+				Type: "other",
+				InfraParams: InfraParams{
+					"key2": "value200",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			testcfg := tt.cfg.GetStaticUnit(tt.id)
+			assert.Equal(tt.want, testcfg)
+
+		})
+	}
+}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

This is the first half of the configuration work.

Split up the config to make it kind based (this leads to a split in persist)

Add some models for exec units and other places where necessary

Add unit tests since the config originally had no unit tests. Expect some tests (not the new config ones) to fail since im splitting up the pr to do the refactors of what this breaks next

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
