### PR TITLE
Input output files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/coreos/go-semver v0.3.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dominikbraun/graph v0.16.1
 	github.com/fatih/color v1.13.0
 	github.com/gojek/heimdall/v7 v7.0.2
 	github.com/golang-jwt/jwt/v4 v4.4.3
@@ -17,6 +18,7 @@ require (
 	github.com/pborman/ansi v1.0.0
 	github.com/pelletier/go-toml/v2 v2.0.6
 	github.com/pkg/errors v0.9.1
+	github.com/schollz/progressbar/v3 v3.13.0
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
@@ -37,7 +39,6 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/schollz/progressbar/v3 v3.13.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect
 )
 
@@ -125,7 +126,7 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dominikbraun/graph v0.16.1 h1:ZtzDQFo32vxwSUsK4ioX8bfE45xoh8hQfavFMlKpaC8=
+github.com/dominikbraun/graph v0.16.1/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
@@ -481,13 +483,10 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -394,13 +394,17 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	document := core.CompilationDocument{
+		InputFiles: input,
+	}
 	compiler := core.Compiler{
-		Plugins: plugins.Plugins(),
+		Plugins:  plugins.Plugins(),
+		Document: document,
 	}
 
 	analyticsClient.Info(klothoName + " compiling")
 
-	result, err := compiler.Compile(input)
+	result, err := compiler.Compile()
 	if err != nil || hadErrors.Load() {
 		if err != nil {
 			errHandler.PrintErr(err)

--- a/pkg/core/compilation_document.go
+++ b/pkg/core/compilation_document.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/klothoplatform/klotho/pkg/graph"
+)
+
+type (
+	CompilationDocument struct {
+		InputFiles     *InputFiles
+		Constructs     graph.Directed[Construct]
+		CloudResources graph.Directed[ProviderResource]
+		OutputFiles    []File
+	}
+)
+
+func (doc *CompilationDocument) OutputTo(dest string) error {
+	errs := make(chan error)
+	files := doc.OutputFiles
+	for idx := range files {
+		go func(f File) {
+			path := filepath.Join(dest, f.Path())
+			dir := filepath.Dir(path)
+			err := os.MkdirAll(dir, 0777)
+			if err != nil {
+				errs <- err
+				return
+			}
+			file, err := os.OpenFile(path, os.O_RDWR, 0777)
+			if os.IsNotExist(err) {
+				file, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0777)
+			} else if err == nil {
+				ovr, ok := f.(NonOverwritable)
+				if ok && !ovr.Overwrite(file) {
+					errs <- nil
+					return
+				}
+				err = file.Truncate(0)
+			}
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, err = f.WriteTo(file)
+			file.Close()
+			errs <- err
+		}(files[idx])
+	}
+
+	for i := 0; i < len(files); i++ {
+		err := <-errs
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,128 @@
+package graph
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmptyGraph(t *testing.T) {
+	assert := assert.New(t)
+	d := NewDirected[DummyVertex]()
+	assert.Empty(d.Roots())
+}
+
+func TestSimpleGraph(t *testing.T) {
+	// A ┬─➤ B
+	//   └─➤ C
+	a, b, c := DummyVertex("a"), DummyVertex("b"), DummyVertex("c")
+	d := NewDirected[DummyVertex]()
+	d.AddVertex(a)
+	d.AddVertex(b)
+	d.AddVertex(c)
+	d.AddEdge(a, b)
+	d.AddEdge(a, c)
+
+	test(t, "roots", func(assert *assert.Assertions) {
+		assert.Equal([]DummyVertex{a}, d.Roots())
+	})
+	test(t, "outgoing nodes", func(assert *assert.Assertions) {
+		assert.ElementsMatch([]DummyVertex{b, c}, d.OutgoingVertices(a))
+	})
+	test(t, "outgoing edges", func(assert *assert.Assertions) {
+		assert.ElementsMatch(
+			[]Edge[DummyVertex]{
+				Edge[DummyVertex]{
+					Source:      a,
+					Destination: b,
+				},
+				Edge[DummyVertex]{
+					Source:      a,
+					Destination: c,
+				},
+			},
+			d.OutgoingEdges(a))
+	})
+}
+
+func TestCycleToSelf(t *testing.T) {
+	assert := assert.New(t)
+	d := NewDirected[DummyVertex]()
+	v := DummyVertex("dummy")
+	d.AddVertex(v)
+	d.AddEdge(v, v)
+	assert.Equal(
+		[]Edge[DummyVertex]{
+			Edge[DummyVertex]{
+				Source:      v,
+				Destination: v,
+			},
+		},
+		d.OutgoingEdges(v))
+}
+
+func TestCycle(t *testing.T) {
+	assert := assert.New(t)
+	d := NewDirected[DummyVertex]()
+	v1 := DummyVertex("hello")
+	v2 := DummyVertex("world")
+	d.AddVertex(v1)
+	d.AddVertex(v2)
+	d.AddEdge(v1, v2)
+	d.AddEdge(v2, v1)
+	assert.Equal(
+		[]Edge[DummyVertex]{
+			Edge[DummyVertex]{
+				Source:      v1,
+				Destination: v2,
+			},
+		},
+		d.OutgoingEdges(v1))
+	assert.Equal(
+		[]Edge[DummyVertex]{
+			Edge[DummyVertex]{
+				Source:      v2,
+				Destination: v1,
+			},
+		},
+		d.OutgoingEdges(v2))
+}
+
+func TestNegativeCases(t *testing.T) {
+	test(t, "duplicate vertex", func(assert *assert.Assertions) {
+		d := NewDirected[DummyVertex]()
+		v := DummyVertex("dummy")
+		d.AddVertex(v)
+		d.AddVertex(v)
+		assert.Equal([]DummyVertex{v}, d.Roots())
+	})
+	test(t, "duplicate edge", func(assert *assert.Assertions) {
+		d := NewDirected[DummyVertex]()
+		v1 := DummyVertex("hello")
+		v2 := DummyVertex("world")
+		d.AddVertex(v1)
+		d.AddVertex(v2)
+		d.AddEdge(v1, v2)
+		d.AddEdge(v1, v2)
+		assert.Equal(
+			[]Edge[DummyVertex]{
+				Edge[DummyVertex]{
+					Source:      v1,
+					Destination: v2,
+				},
+			},
+			d.OutgoingEdges(v1))
+	})
+}
+
+type DummyVertex string
+
+func (v DummyVertex) Id() string {
+	return string(v)
+}
+
+func test(t *testing.T, name string, f func(assert *assert.Assertions)) {
+	t.Run(name, func(t *testing.T) {
+		assert := assert.New(t)
+		f(assert)
+	})
+}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #374 

Creating the compilation document and outputTo method for it. 

This change will break all existing functionality until we switch over plugins to using the documents input files rather than looking for them within the compilation result. The next step is to start removing CloudResource and replace it with what is currently named ProviderResource and start using the graphs

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
