### PR TITLE
base provider spike - iam role, ecr, lambda

### DIFF
--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+)
+
 type (
 	// ExecutionUnit is how execution unit Klotho constructs are represented in the klotho configuration
 	ExecutionUnit struct {
@@ -87,4 +93,21 @@ func (a Application) GetExecutionUnit(id string) ExecutionUnit {
 		cfg.InfraParams = defaultParams
 	}
 	return cfg
+}
+
+func (cfg ExecutionUnit) GetExecutionUnitParamsAsKubernetes() KubernetesTypeParams {
+
+	infraParams := cfg.InfraParams
+	jsonString, err := json.Marshal(infraParams)
+	if err != nil {
+		zap.S().Debug(err)
+	}
+
+	params := KubernetesTypeParams{}
+	if err := json.Unmarshal(jsonString, &params); err != nil {
+		zap.S().Debug(err)
+		return params
+	} else {
+		return params
+	}
 }

--- a/pkg/core/construct_graph.go
+++ b/pkg/core/construct_graph.go
@@ -19,6 +19,10 @@ func NewConstructGraph() *ConstructGraph {
 	}
 }
 
+func (cg *ConstructGraph) GetRoots() []Construct {
+	return cg.underlying.Roots()
+}
+
 func (cg *ConstructGraph) AddConstruct(construct Construct) {
 	zap.S().Infof("Adding resource %s", construct.Id())
 	cg.underlying.AddVertex(construct)

--- a/pkg/core/exec_unit.go
+++ b/pkg/core/exec_unit.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -154,6 +155,7 @@ func (unit *ExecutionUnit) AddSourceFile(f File) {
 
 func (unit *ExecutionUnit) AddStaticAsset(f File) {
 	if f != nil {
+		fmt.Println(unit)
 		unit.files.Set(f.Path(), f)
 		unit.Executable.StaticAssets[f.Path()] = struct{}{}
 	}

--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -27,3 +27,11 @@ func (cg *ResourceGraph) AddDependency(source Resource, dest Resource) {
 func (cg *ResourceGraph) GetResource(id string) Resource {
 	return cg.underlying.GetVertex(id)
 }
+
+func (cg *ResourceGraph) ListConstructs() []Resource {
+	return cg.underlying.GetAllVertices()
+}
+
+func (cg *ResourceGraph) ListDependencies() []graph.Edge[Resource] {
+	return cg.underlying.GetAllEdges()
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -154,12 +154,12 @@ func (d *Directed[V]) GetAllEdges() []Edge[V] {
 	for _, edges := range fullAdjacency {
 		for _, edge := range edges {
 			sourceV, err := d.underlying.Vertex(edge.Source)
-			if err == nil {
+			if err != nil {
 				zap.S().With(zap.Error(err)).Errorf(
 					`Ignoring edge %v because I couldn't resolve the source vertex. %s`, edge, ourFault)
 			}
 			destV, err := d.underlying.Vertex(edge.Target)
-			if err == nil {
+			if err != nil {
 				zap.S().With(zap.Error(err)).Errorf(
 					`Ignoring edge %v because I couldn't resolve the destination vertex. %s`, edge, ourFault)
 			}

--- a/pkg/lang/javascript/aws_runtime/aws.go
+++ b/pkg/lang/javascript/aws_runtime/aws.go
@@ -9,14 +9,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/klothoplatform/klotho/pkg/sanitization"
-
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/lang/javascript"
 	"github.com/klothoplatform/klotho/pkg/provider/aws"
-	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 	"github.com/klothoplatform/klotho/pkg/runtime"
+	"github.com/klothoplatform/klotho/pkg/sanitization"
+	"github.com/klothoplatform/klotho/pkg/sanitization/aws/s3"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -330,7 +329,7 @@ func (r *AwsRuntime) AddRuntimeFiles(unit *core.ExecutionUnit, files embed.FS) e
 	templateData := TemplateData{
 		TemplateConfig:     r.TemplateConfig,
 		ExecUnitName:       unit.ID,
-		PayloadsBucketName: resources.SanitizeS3BucketName(r.Config.AppName),
+		PayloadsBucketName: s3.SanitizeS3BucketName(r.Config.AppName),
 	}
 	err := javascript.AddRuntimeFiles(unit, files, templateData)
 	return err
@@ -340,7 +339,7 @@ func (r *AwsRuntime) AddRuntimeFile(unit *core.ExecutionUnit, path string, conte
 	templateData := TemplateData{
 		TemplateConfig:     r.TemplateConfig,
 		ExecUnitName:       unit.ID,
-		PayloadsBucketName: resources.SanitizeS3BucketName(r.Config.AppName),
+		PayloadsBucketName: s3.SanitizeS3BucketName(r.Config.AppName),
 	}
 	err := javascript.AddRuntimeFile(unit, templateData, path, content)
 	return err

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/ecr"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/iam"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/lambda"
+	"go.uber.org/zap"
+)
+
+func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, dag *core.ResourceGraph) error {
+	log := zap.S()
+
+	execUnitCfg := a.Config.GetExecutionUnit(unit.ID)
+
+	// See if we have already created an ecr repository for the app and if not create one, otherwise add a ref to this exec unit
+	repo := dag.GetResource(ecr.GenerateRepoId(a.Config.AppName))
+	if repo == nil {
+		repo = ecr.NewEcrRepository(a.Config.AppName, unit.Provenance())
+		dag.AddResource(repo)
+	} else {
+		repo, ok := repo.(*ecr.EcrRepository)
+		if !ok {
+			return fmt.Errorf("expected resource with id, %s, to be ecr repository", repo.Id())
+		}
+		repo.ConstructsRef = append(repo.ConstructsRef, unit.Provenance())
+	}
+
+	// Create image and make it dependent on the repository
+	image := ecr.NewEcrImage(unit, a.Config.AppName)
+	dag.AddResource(image)
+	dag.AddDependency(repo, image)
+
+	// Create and add role
+	role := iam.NewIamRole(a.Config.AppName, fmt.Sprintf("%s-ExecutionRole", unit.ID), unit.Provenance(), GetAssumeRolePolicyForType(execUnitCfg))
+
+	dag.AddResource(role)
+
+	switch execUnitCfg.Type {
+	case Lambda:
+		lambda := lambda.NewLambdaFunction(unit, a.Config.AppName, role)
+		dag.AddResource(lambda)
+		dag.AddDependency(role, lambda)
+		dag.AddDependency(image, lambda)
+		return nil
+	case Eks:
+	case Ecs:
+	default:
+		log.Errorf("Unsupported type, %s, for aws execution units", execUnitCfg.Type)
+
+	}
+	return nil
+}
+
+func GetAssumeRolePolicyForType(cfg config.ExecutionUnit) string {
+	switch cfg.Type {
+	case Lambda:
+		return iam.LAMBDA_ASSUMER_ROLE_POLICY
+	case Ecs:
+		return iam.ECS_ASSUMER_ROLE_POLICY
+	case Eks:
+		eksConfig := cfg.GetExecutionUnitParamsAsKubernetes()
+		if eksConfig.NodeType == string(resources.Fargate) {
+			return iam.EKS_FARGATE_ASSUME_ROLE_POLICY
+		}
+		return iam.EC2_ASSUMER_ROLE_POLICY
+	}
+	return ""
+}

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/annotation"
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/graph"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/ecr"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/iam"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/lambda"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateExecUnitResources(t *testing.T) {
+	unit := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}}
+	repo := ecr.NewEcrRepository("test", core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability})
+	image := ecr.NewEcrImage(&core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}}, "test")
+	role := iam.NewIamRole("test", "test-ExecutionRole", core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}, iam.LAMBDA_ASSUMER_ROLE_POLICY)
+	lambda := lambda.NewLambdaFunction(unit, "test", role)
+	type testResult struct {
+		nodes []core.Resource
+		deps  []graph.Edge[core.Resource]
+		err   bool
+	}
+	cases := []struct {
+		name              string
+		existingResources []core.Resource
+		cfg               config.Application
+		want              testResult
+	}{
+		{
+			name: "generate lambda",
+			cfg: config.Application{
+				AppName: "test",
+				ExecutionUnits: map[string]*config.ExecutionUnit{
+					"test": &config.ExecutionUnit{Type: "lambda"},
+				},
+			},
+			want: testResult{
+				nodes: []core.Resource{
+					repo, image, role, lambda,
+				},
+				deps: []graph.Edge[core.Resource]{
+					graph.Edge[core.Resource]{
+						Source:      repo,
+						Destination: image,
+					},
+					graph.Edge[core.Resource]{
+						Source:      image,
+						Destination: lambda,
+					},
+					graph.Edge[core.Resource]{
+						Source:      role,
+						Destination: lambda,
+					},
+				},
+			},
+		},
+		{
+			name: "ecr repo already exists",
+			cfg: config.Application{
+				AppName: "test",
+				ExecutionUnits: map[string]*config.ExecutionUnit{
+					"test": &config.ExecutionUnit{Type: "lambda"},
+				},
+			},
+			existingResources: []core.Resource{ecr.NewEcrRepository("test", core.AnnotationKey{ID: "test2", Capability: annotation.ExecutionUnitCapability})},
+			want: testResult{
+				nodes: []core.Resource{
+					repo, image, role, lambda,
+				},
+				deps: []graph.Edge[core.Resource]{
+					graph.Edge[core.Resource]{
+						Source:      repo,
+						Destination: image,
+					},
+					graph.Edge[core.Resource]{
+						Source:      image,
+						Destination: lambda,
+					},
+					graph.Edge[core.Resource]{
+						Source:      role,
+						Destination: lambda,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			aws := AWS{
+				Config: &tt.cfg,
+			}
+			dag := core.NewResourceGraph()
+
+			for _, res := range tt.existingResources {
+				dag.AddResource(res)
+			}
+
+			err := aws.GenerateExecUnitResources(unit, dag)
+			if tt.want.err {
+				assert.Error(err)
+				return
+			}
+			if !assert.NoError(err) {
+				return
+			}
+			for _, node := range tt.want.nodes {
+				found := false
+				for _, res := range dag.ListConstructs() {
+					if res.Id() == node.Id() {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+
+			for _, dep := range tt.want.deps {
+				found := false
+				for _, res := range dag.ListDependencies() {
+					if res.Source.Id() == dep.Source.Id() && res.Destination.Id() == dep.Destination.Id() {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+
+			for _, res := range dag.ListConstructs() {
+				if repo, ok := res.(*ecr.EcrRepository); ok {
+					if len(tt.existingResources) != 0 {
+						assert.Len(repo.ConstructsRef, 2)
+					} else {
+						assert.Len(repo.ConstructsRef, 1)
+					}
+				}
+			}
+		})
+
+	}
+}
+
+func Test_GetAssumeRolePolicyForType(t *testing.T) {
+	cases := []struct {
+		name  string
+		cfg   config.ExecutionUnit
+		wants string
+	}{
+		{
+			name:  `lambda`,
+			cfg:   config.ExecutionUnit{Type: Lambda},
+			wants: "{\n\tVersion: '2012-10-17',\n\tStatement: [\n\t\t{\n\t\t\tAction: 'sts:AssumeRole',\n\t\t\tPrincipal: {\n\t\t\t\tService: 'lambda.amazonaws.com',\n\t\t\t},\n\t\t\tEffect: 'Allow',\n\t\t\tSid: '',\n\t\t},\n\t],\n}",
+		},
+		{
+			name:  `ecs`,
+			cfg:   config.ExecutionUnit{Type: Ecs},
+			wants: "{\n\tVersion: '2012-10-17',\n\tStatement: [\n\t\t{\n\t\t\tAction: 'sts:AssumeRole',\n\t\t\tPrincipal: {\n\t\t\t\tService: 'ecs-tasks.amazonaws.com',\n\t\t\t},\n\t\t\tEffect: 'Allow',\n\t\t\tSid: '',\n\t\t},\n\t],\n}",
+		},
+		{
+			name:  `eks fargate`,
+			cfg:   config.ExecutionUnit{Type: Eks, InfraParams: config.ConvertToInfraParams(config.KubernetesTypeParams{NodeType: string(resources.Fargate)})},
+			wants: "{\n\tVersion: '2012-10-17',\n\tStatement: [\n\t\t{\n\t\t\tAction: 'sts:AssumeRole',\n\t\t\tPrincipal: {\n\t\t\t\tService: 'eks-fargate-pods.amazonaws.com',\n\t\t\t},\n\t\t\tEffect: 'Allow',\n\t\t\tSid: '',\n\t\t},\n\t],\n}",
+		},
+		{
+			name:  `eks node`,
+			cfg:   config.ExecutionUnit{Type: Eks, InfraParams: config.ConvertToInfraParams(config.KubernetesTypeParams{NodeType: string(resources.Node)})},
+			wants: "{\n\tVersion: '2012-10-17',\n\tStatement: [\n\t\t{\n\t\t\tAction: 'sts:AssumeRole',\n\t\t\tPrincipal: {\n\t\t\t\tService: 'ec2.amazonaws.com',\n\t\t\t},\n\t\t\tEffect: 'Allow',\n\t\t\tSid: '',\n\t\t},\n\t],\n}",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			actual := GetAssumeRolePolicyForType(tt.cfg)
+			assert.Equal(tt.wants, actual)
+		})
+
+	}
+}

--- a/pkg/provider/aws/infra_template.go
+++ b/pkg/provider/aws/infra_template.go
@@ -1,9 +1,44 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/klothoplatform/klotho/pkg/core"
+	"go.uber.org/zap"
 )
 
 func (a *AWS) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (Links []core.CloudResourceLink, err error) {
+	fmt.Println(dag.ListConstructs())
+	fmt.Println(dag.ListDependencies())
+
+	log := zap.S()
+
+	rootConstructs := result.GetRoots()
+	for _, construct := range rootConstructs {
+		log.Debugf("Converting construct with id, %s, to aws resources", construct.Id())
+		switch construct := construct.(type) {
+		case *core.Gateway:
+			log.Errorf("Unsupported resource %s", construct.Id())
+		case *core.ExecutionUnit:
+			err = a.GenerateExecUnitResources(construct, dag)
+			if err != nil {
+				return
+			}
+		case *core.StaticUnit:
+			log.Errorf("Unsupported resource %s", construct.Id())
+
+		default:
+			log.Warnf("Unsupported resource %s", construct.Id())
+		}
+
+	}
+	constructs := dag.ListConstructs()
+	for _, c := range constructs {
+		fmt.Println(c)
+	}
+	deps := dag.ListDependencies()
+	for _, c := range deps {
+		fmt.Printf("Source: %s, Dest: %s\n", c.Source.Id(), c.Destination.Id())
+	}
 	return
 }

--- a/pkg/provider/aws/resources/constants.go
+++ b/pkg/provider/aws/resources/constants.go
@@ -1,0 +1,10 @@
+package resources
+
+const AWS_PROVIDER = "aws"
+
+type EksNodeType string
+
+const (
+	Fargate EksNodeType = "fargate"
+	Node    EksNodeType = "node"
+)

--- a/pkg/provider/aws/resources/ecr/image.go
+++ b/pkg/provider/aws/resources/ecr/image.go
@@ -1,0 +1,45 @@
+package ecr
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+)
+
+const ECR_IMAGE_TYPE = "ecr_image"
+
+type (
+	EcrImage struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		Context       string
+		Dockerfile    string
+		ExtraOptions  []string
+	}
+)
+
+func NewEcrImage(unit *core.ExecutionUnit, appName string) *EcrImage {
+	return &EcrImage{
+		Name:          fmt.Sprintf("%s-%s", appName, unit.ID),
+		ConstructsRef: []core.AnnotationKey{unit.Provenance()},
+		Context:       fmt.Sprintf("./%s", unit.ID),
+		Dockerfile:    fmt.Sprintf("./%s/%s", unit.ID, unit.DockerfilePath),
+		ExtraOptions:  []string{"--platform", "linux/amd64", "--quiet"},
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (image *EcrImage) Provider() string {
+	return resources.AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (image *EcrImage) KlothoConstructRef() []core.AnnotationKey {
+	return image.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (image *EcrImage) Id() string {
+	return fmt.Sprintf("%s_%s", ECR_IMAGE_TYPE, image.Name)
+}

--- a/pkg/provider/aws/resources/ecr/image_test.go
+++ b/pkg/provider/aws/resources/ecr/image_test.go
@@ -1,0 +1,41 @@
+package ecr
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewImage(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test-eu"}, DockerfilePath: "somedir"}
+	image := NewEcrImage(eu, "test-app")
+	assert.Equal(image.Name, "test-app-test-eu")
+	assert.Equal(image.ConstructsRef, []core.AnnotationKey{eu.AnnotationKey})
+	assert.Equal(image.Context, "./test-eu")
+	assert.Equal(image.Dockerfile, "./test-eu/somedir")
+	assert.Equal(image.ExtraOptions, []string{"--platform", "linux/amd64", "--quiet"})
+}
+
+func Test_ImageProvider(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrImage(eu, "test-app")
+	assert.Equal(image.Provider(), resources.AWS_PROVIDER)
+}
+
+func Test_ImageId(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrImage(eu, "test-app")
+	assert.Equal(image.Id(), "ecr_image_test-app-test")
+}
+
+func Test_ImageKlothoConstructRef(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrImage(eu, "test-app")
+	assert.Equal(image.KlothoConstructRef(), []core.AnnotationKey{eu.Provenance()})
+}

--- a/pkg/provider/aws/resources/ecr/repository.go
+++ b/pkg/provider/aws/resources/ecr/repository.go
@@ -1,0 +1,45 @@
+package ecr
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+)
+
+const ECR_REPO_TYPE = "ecr_repo"
+
+type (
+	EcrRepository struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		ForceDelete   bool
+	}
+)
+
+func NewEcrRepository(appName string, ref core.AnnotationKey) *EcrRepository {
+	return &EcrRepository{
+		Name:          appName,
+		ForceDelete:   true,
+		ConstructsRef: []core.AnnotationKey{ref},
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (repo *EcrRepository) Provider() string {
+	return resources.AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (repo *EcrRepository) KlothoConstructRef() []core.AnnotationKey {
+	return repo.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (repo *EcrRepository) Id() string {
+	return GenerateRepoId(repo.Name)
+}
+
+func GenerateRepoId(name string) string {
+	return fmt.Sprintf("%s_%s", ECR_REPO_TYPE, name)
+}

--- a/pkg/provider/aws/resources/ecr/repository_test.go
+++ b/pkg/provider/aws/resources/ecr/repository_test.go
@@ -1,0 +1,45 @@
+package ecr
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewRepo(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test-eu"}, DockerfilePath: "somedir"}
+	image := NewEcrRepository("test-app", eu.Provenance())
+	assert.Equal(image.Name, "test-app")
+	assert.Equal(image.ConstructsRef, []core.AnnotationKey{eu.AnnotationKey})
+	assert.True(image.ForceDelete)
+}
+
+func Test_RepoProvider(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrRepository("test-app", eu.Provenance())
+	assert.Equal(image.Provider(), resources.AWS_PROVIDER)
+}
+
+func Test_RepoId(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrRepository("test-app", eu.Provenance())
+	assert.Equal(image.Id(), "ecr_repo_test-app")
+}
+
+func Test_RepoKlothoConstructRef(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	image := NewEcrRepository("test-app", eu.Provenance())
+	assert.Equal(image.KlothoConstructRef(), []core.AnnotationKey{eu.Provenance()})
+}
+
+func Test_GenerateRepoId(t *testing.T) {
+	assert := assert.New(t)
+	id := GenerateRepoId("test-app")
+	assert.Equal(id, "ecr_repo_test-app")
+}

--- a/pkg/provider/aws/resources/iam/role.go
+++ b/pkg/provider/aws/resources/iam/role.go
@@ -1,0 +1,101 @@
+package iam
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
+)
+
+const IAM_ROLE_TYPE = "iam_role"
+
+var sanitizer = aws.IamRoleSanitizer
+
+type (
+	IamRole struct {
+		Name                string
+		ConstructsRef       []core.AnnotationKey
+		AssumeRolePolicyDoc string
+		ManagedPolicyArns   []string
+	}
+)
+
+func NewIamRole(appName string, roleName string, ref core.AnnotationKey, assumeRolePolicy string) *IamRole {
+	return &IamRole{
+		Name:                sanitizer.Apply(fmt.Sprintf("%s-%s", appName, roleName)),
+		ConstructsRef:       []core.AnnotationKey{ref},
+		AssumeRolePolicyDoc: assumeRolePolicy,
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (role *IamRole) Provider() string {
+	return resources.AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (role *IamRole) KlothoConstructRef() []core.AnnotationKey {
+	return role.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (role *IamRole) Id() string {
+	return fmt.Sprintf("%s_%s", IAM_ROLE_TYPE, role.Name)
+}
+
+const LAMBDA_ASSUMER_ROLE_POLICY = `{
+	Version: '2012-10-17',
+	Statement: [
+		{
+			Action: 'sts:AssumeRole',
+			Principal: {
+				Service: 'lambda.amazonaws.com',
+			},
+			Effect: 'Allow',
+			Sid: '',
+		},
+	],
+}`
+
+const ECS_ASSUMER_ROLE_POLICY = `{
+	Version: '2012-10-17',
+	Statement: [
+		{
+			Action: 'sts:AssumeRole',
+			Principal: {
+				Service: 'ecs-tasks.amazonaws.com',
+			},
+			Effect: 'Allow',
+			Sid: '',
+		},
+	],
+}`
+
+const EC2_ASSUMER_ROLE_POLICY = `{
+	Version: '2012-10-17',
+	Statement: [
+		{
+			Action: 'sts:AssumeRole',
+			Principal: {
+				Service: 'ec2.amazonaws.com',
+			},
+			Effect: 'Allow',
+			Sid: '',
+		},
+	],
+}`
+
+const EKS_FARGATE_ASSUME_ROLE_POLICY = `{
+	Version: '2012-10-17',
+	Statement: [
+		{
+			Action: 'sts:AssumeRole',
+			Principal: {
+				Service: 'eks-fargate-pods.amazonaws.com',
+			},
+			Effect: 'Allow',
+			Sid: '',
+		},
+	],
+}`

--- a/pkg/provider/aws/resources/iam/role_test.go
+++ b/pkg/provider/aws/resources/iam/role_test.go
@@ -1,0 +1,38 @@
+package iam
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewLambdaFunction(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test-eu"}}
+	role := NewIamRole("test-app", "test-role@#$%@#^$%&_?/;/aslk;lajsfjafkljasgfjalsfhaksjalsfakjhlkkljh;lkhlkjhl;kna;lfbkjkhaksjb;lkj", eu.Provenance(), EC2_ASSUMER_ROLE_POLICY)
+	assert.Equal(role.Name, "test-app-test-role@___@__________aslk_lajsfjafkljasgfjalsfhaksja")
+
+}
+
+func Test_Provider(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := NewIamRole("test-app", "test-role", eu.Provenance(), EC2_ASSUMER_ROLE_POLICY)
+	assert.Equal(role.Provider(), resources.AWS_PROVIDER)
+}
+
+func Test_Id(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := NewIamRole("test-app", "test-role", eu.Provenance(), EC2_ASSUMER_ROLE_POLICY)
+	assert.Equal(role.Id(), "iam_role_test-app-test-role")
+}
+
+func Test_KlothoConstructRef(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := NewIamRole("test-app", "test-role", eu.Provenance(), EC2_ASSUMER_ROLE_POLICY)
+	assert.Equal(role.KlothoConstructRef(), []core.AnnotationKey{eu.Provenance()})
+}

--- a/pkg/provider/aws/resources/lambda/function.go
+++ b/pkg/provider/aws/resources/lambda/function.go
@@ -1,0 +1,52 @@
+package lambda
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/iam"
+	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
+)
+
+const LAMBDA_FUNCTION_TYPE = "lambda_function"
+
+var sanitizer = aws.LambdaFunctionSanitizer
+
+type (
+	LambdaFunction struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		// Role points to the id of the cloud resource
+		Role      *iam.IamRole
+		VpcConfig LambdaVpcConfig
+	}
+
+	LambdaVpcConfig struct {
+		SecurityGroupIds []string
+		SubnetIds        []string
+	}
+)
+
+func NewLambdaFunction(unit *core.ExecutionUnit, appName string, role *iam.IamRole) *LambdaFunction {
+	return &LambdaFunction{
+		Name:          sanitizer.Apply(fmt.Sprintf("%s-%s", appName, unit.ID)),
+		ConstructsRef: []core.AnnotationKey{unit.Provenance()},
+		Role:          role,
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (lambda *LambdaFunction) Provider() string {
+	return resources.AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (lambda *LambdaFunction) KlothoConstructRef() []core.AnnotationKey {
+	return lambda.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (lambda *LambdaFunction) Id() string {
+	return fmt.Sprintf("%s_%s", LAMBDA_FUNCTION_TYPE, lambda.Name)
+}

--- a/pkg/provider/aws/resources/lambda/function_test.go
+++ b/pkg/provider/aws/resources/lambda/function_test.go
@@ -1,0 +1,45 @@
+package lambda
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/iam"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewLambdaFunction(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "somelongWackyId%^&**thatsgoingtobewayoverthecharcountificontinuetotypethingsouthere"}}
+	role := &iam.IamRole{Name: "testRole"}
+	lambda := NewLambdaFunction(eu, "test-app", role)
+	assert.Equal(lambda.Name, "test_app_somelongWackyIdthatsgoingtobewayoverthecharcountificont")
+	assert.Equal(lambda.ConstructsRef, []core.AnnotationKey{eu.AnnotationKey})
+	assert.Equal(lambda.Role, role)
+	assert.Equal(lambda.VpcConfig, LambdaVpcConfig{})
+}
+
+func Test_Provider(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := &iam.IamRole{Name: "testRole"}
+	lambda := NewLambdaFunction(eu, "test-app", role)
+	assert.Equal(lambda.Provider(), resources.AWS_PROVIDER)
+}
+
+func Test_Id(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := &iam.IamRole{Name: "testRole"}
+	lambda := NewLambdaFunction(eu, "test-app", role)
+	assert.Equal(lambda.Id(), "lambda_function_test_app_test")
+}
+
+func Test_KlothoConstructRef(t *testing.T) {
+	assert := assert.New(t)
+	eu := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	role := &iam.IamRole{Name: "testRole"}
+	lambda := NewLambdaFunction(eu, "test-app", role)
+	assert.Equal(lambda.KlothoConstructRef(), []core.AnnotationKey{eu.Provenance()})
+}

--- a/pkg/sanitization/aws/iam.go
+++ b/pkg/sanitization/aws/iam.go
@@ -1,0 +1,17 @@
+package aws
+
+import (
+	"regexp"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
+)
+
+// EnvVarKeySanitizer returns a sanitized environment key when applied.
+var IamRoleSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
+		// replace "-" or whitespace with "_"
+		{
+			Pattern:     regexp.MustCompile(`[^\w+=,.@-]`),
+			Replacement: "_",
+		},
+	}, 64)

--- a/pkg/sanitization/aws/lambda.go
+++ b/pkg/sanitization/aws/lambda.go
@@ -1,12 +1,14 @@
-package sanitization
+package aws
 
 import (
 	"regexp"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
 )
 
 // EnvVarKeySanitizer returns a sanitized environment key when applied.
-var EnvVarKeySanitizer = NewSanitizer(
-	[]Rule{
+var LambdaFunctionSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
 		// strip any leading non alpha characters
 		{
 			Pattern:     regexp.MustCompile(`^[^a-zA-Z]+`),
@@ -22,4 +24,4 @@ var EnvVarKeySanitizer = NewSanitizer(
 			Pattern:     regexp.MustCompile(`[^a-zA-Z0-9_]+`),
 			Replacement: "",
 		},
-	}, 0)
+	}, 64)

--- a/pkg/sanitization/aws/s3/s3.go
+++ b/pkg/sanitization/aws/s3/s3.go
@@ -1,4 +1,4 @@
-package resources
+package s3
 
 import (
 	"regexp"

--- a/pkg/sanitization/aws/s3/s3_test.go
+++ b/pkg/sanitization/aws/s3/s3_test.go
@@ -1,4 +1,4 @@
-package resources
+package s3
 
 import (
 	"testing"

--- a/pkg/sanitization/identifier.go
+++ b/pkg/sanitization/identifier.go
@@ -6,18 +6,20 @@ import (
 
 // IdentifierSanitizer returns a sanitized identifier that can be injected into source code when applied.
 var IdentifierSanitizer = NewSanitizer(
-	// strip any leading non alpha characters
-	Rule{
-		Pattern:     regexp.MustCompile(`^[^a-zA-Z]+`),
-		Replacement: "",
-	},
-	// replace "-" or whitespace with "_"
-	Rule{
-		Pattern:     regexp.MustCompile(`[-\s]+`),
-		Replacement: "_",
-	},
-	// strip any other invalid characters
-	Rule{
-		Pattern:     regexp.MustCompile(`[^a-zA-Z0-9_]+`),
-		Replacement: "",
-	})
+	[]Rule{
+		// strip any leading non alpha characters
+		{
+			Pattern:     regexp.MustCompile(`^[^a-zA-Z]+`),
+			Replacement: "",
+		},
+		// replace "-" or whitespace with "_"
+		{
+			Pattern:     regexp.MustCompile(`[-\s]+`),
+			Replacement: "_",
+		},
+		// strip any other invalid characters
+		{
+			Pattern:     regexp.MustCompile(`[^a-zA-Z0-9_]+`),
+			Replacement: "",
+		},
+	}, 0)

--- a/pkg/sanitization/sanitizer.go
+++ b/pkg/sanitization/sanitizer.go
@@ -1,10 +1,13 @@
 package sanitization
 
-import "regexp"
+import (
+	"regexp"
+)
 
 type (
 	Sanitizer struct {
-		rules []Rule
+		rules     []Rule
+		maxLength int
 	}
 
 	Rule struct {
@@ -19,10 +22,13 @@ func (s *Sanitizer) Apply(input string) string {
 	for _, rule := range s.rules {
 		output = rule.Pattern.ReplaceAllString(output, rule.Replacement)
 	}
+	if s.maxLength != 0 && s.maxLength < len(output) {
+		output = output[:s.maxLength]
+	}
 	return output
 }
 
 // NewSanitizer returns a new Sanitizer that applies the supplied rules to inputs.
-func NewSanitizer(rules ...Rule) *Sanitizer {
-	return &Sanitizer{rules: rules}
+func NewSanitizer(rules []Rule, maxLength int) *Sanitizer {
+	return &Sanitizer{rules: rules, maxLength: maxLength}
 }


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? 

This PR Provides the initial code for the spike on the provider (Still a little rough/first pass so feedback = good(

This pr enables taking a ConstructGraph from our compiler and transforming it into the necessary ResourceGraph

What is enabled:
  - ECR Repo
  - ECR Image
  - IAM Role
  - Lambda Function

The internal representation of each aws resource is specified in the `provider/aws/resources/{{service}}` directory. Each of these resources implements the necessary functions to make it compliant with Resource interface.

We also try to use Constructors where we have sanitization so that theres a centralized method for creation.

Sanitization is still very basic and can only do max length + regex replacements. We will want to expand on this to get parity with the deploy lib version.


### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
