### PR TITLE
Read cors middleware to setup OPTIONS routes for go

### DIFF
--- a/pkg/lang/golang/plugin_expose.go
+++ b/pkg/lang/golang/plugin_expose.go
@@ -504,8 +504,8 @@ func (h *restAPIHandler) findMiddleware(n *sitter.Node) []*sitter.Node {
 			break
 		}
 		args := match["args"]
-		for i := 0; i < int(args.ChildCount()); i++ {
-			mw = append(mw, args.Child(i))
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			mw = append(mw, args.NamedChild(i))
 		}
 	}
 	return mw
@@ -533,7 +533,7 @@ func (h *restAPIHandler) isMiddlewareCors(mw *sitter.Node) bool {
 	// TODO this is a pretty hacky way to check, but it will work for now.
 	// r.Use(cors.Handler(cors.Options{}))
 	// r.Use(cors.AllowAll().Handler)
-	// r.Use(&cors.Cors{})
+	// r.Use(&cors.Cors{}.Handler)
 	if dot := strings.Index(mw.Content(), "."); dot > 0 {
 		pkg := mw.Content()[:dot]
 		return strings.HasSuffix(pkg, "cors")

--- a/pkg/lang/golang/queries.go
+++ b/pkg/lang/golang/queries.go
@@ -25,6 +25,9 @@ var findRouterMounts string
 //go:embed queries/expose/function.scm
 var findFunction string
 
+//go:embed queries/expose/router_middleware.scm
+var routerMiddleware string
+
 //go:embed queries/package.scm
 var packageQuery string
 

--- a/pkg/lang/golang/queries/expose/router_middleware.scm
+++ b/pkg/lang/golang/queries/expose/router_middleware.scm
@@ -1,0 +1,8 @@
+(call_expression ;; router.Use(..)
+	(selector_expression
+		(identifier) @router_name
+    (field_identifier) @method
+    (#eq? @method "Use")
+	)
+  (argument_list) @args
+)@call_expression


### PR DESCRIPTION
Tested locally that the headers get set and the routes get added.
![image_360](https://user-images.githubusercontent.com/90645437/227512674-d63bcc87-c846-4ee5-80d4-6bec62a91316.png)

Did not have a repro case that would actually send the preflight OPTIONS requests.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
