### PR TITLE
Fixes issue where qualified module name is truncated for aliased nested submodule imports

### DIFF
--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -119,12 +119,10 @@ func FindImports(file *core.SourceFile) Imports {
 		qualifiedModuleName := parent
 		if qualifiedModuleName == "" {
 			qualifiedModuleName = moduleName
-		} else if module != nil {
-			if qualifiedModuleName != "" && qualifiedModuleName[len(qualifiedModuleName)-1] == '.' {
-				qualifiedModuleName += moduleName
-			} else {
-				qualifiedModuleName += "." + moduleName
-			}
+		} else if qualifiedModuleName[len(qualifiedModuleName)-1] == '.' {
+			qualifiedModuleName += moduleName
+		} else {
+			qualifiedModuleName += "." + moduleName
 		}
 		i := fileImports[qualifiedModuleName]
 		// technically, this may be a submodule, but we can't tell without deeper analysis of the imported file

--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -119,7 +119,7 @@ func FindImports(file *core.SourceFile) Imports {
 		qualifiedModuleName := parent
 		if qualifiedModuleName == "" {
 			qualifiedModuleName = moduleName
-		} else if qualifiedModuleName[len(qualifiedModuleName)-1] == '.' {
+		} else if strings.HasSuffix(qualifiedModuleName, ".") {
 			qualifiedModuleName += moduleName
 		} else {
 			qualifiedModuleName += "." + moduleName

--- a/pkg/lang/python/imports_test.go
+++ b/pkg/lang/python/imports_test.go
@@ -62,6 +62,18 @@ func TestFindImports(t *testing.T) {
 			},
 		},
 		{
+			name:   "import aliased nested submodule",
+			source: "import mymodule.submodule1.submodule2 as w",
+			want: map[string]Import{
+				"mymodule.submodule1.submodule2": {
+					ParentModule: "mymodule.submodule1",
+					Name:         "submodule2",
+					ImportedSelf: true,
+					Alias:        "w",
+				},
+			},
+		},
+		{
 			name:   "import relative module",
 			source: "from .. import mymodule\nfrom ..parent import child.attribute",
 			want: map[string]Import{
@@ -183,16 +195,10 @@ func TestFindImports(t *testing.T) {
 				fmt.Println(imports)
 			}
 			assert.Equal(len(tt.want), len(imports))
-			for _, i := range imports {
-				moduleKey := ""
-				if i.ParentModule != "" {
-					moduleKey = i.ParentModule
+			for qualifiedName, i := range imports {
+				if expected, ok := tt.want[qualifiedName]; assert.Truef(ok, "import not found for name: %s", qualifiedName) {
+					validateImport(assert, f.Program(), expected, i)
 				}
-				if moduleKey != "" && moduleKey[len(moduleKey)-1] != '.' {
-					moduleKey += "."
-				}
-				moduleKey += i.Name
-				validateImport(assert, f.Program(), tt.want[moduleKey], i)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes an issue where a qualified module name is truncated for aliased nested submodule imports by changing a check for a non-nil module node (not populated for these imports to a non-empty `moduleName` string, which is set regardless of the import type by looking at multiple potential sources for a module's name.

### Standard checks

- **Unit tests**: Any special considerations? no
- **Docs**: Do we need to update any docs, internal or public? no
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working? no
