### PR TITLE
add template for cloudwatch log group

### DIFF
--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -29,10 +29,10 @@ func (cg *ResourceGraph) GetResource(id string) Resource {
 }
 
 func (cg *ResourceGraph) GetDependency(source string, target string) graph.Edge[Resource] {
-	return cg.underlying.GetEdge(source, target)
+	return cg.Underlying.GetEdge(source, target)
 }
 
-func (cg *ResourceGraph) ListConstructs() []Resource {
+func (cg *ResourceGraph) ListResources() []Resource {
 	return cg.Underlying.GetAllVertices()
 }
 

--- a/pkg/infra/iac2/templates/ecr_image/package.json
+++ b/pkg/infra/iac2/templates/ecr_image/package.json
@@ -3,6 +3,6 @@
     "dependencies": {
         "@pulumi/aws": "^5.16.0",
         "@pulumi/pulumi": "^3.40.2",
-        "@pulumi/docker":  "^v4.1.0"
+        "@pulumi/docker": "^v4.1.0"
     }
 }

--- a/pkg/infra/iac2/templates/log_group/factory.ts
+++ b/pkg/infra/iac2/templates/log_group/factory.ts
@@ -1,8 +1,15 @@
 import * as aws from '@pulumi/aws'
 
-interface Args {}
+interface Args {
+    Name: string
+    LogGroupName: string
+    RetentionInDays: number
+}
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.cloudwatch.LogGroup {
-    return null // TODO
+    return new aws.cloudwatch.LogGroup(args.Name, {
+        name: args.LogGroupName,
+        retentionInDays: args.RetentionInDays,
+    })
 }

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -67,39 +67,6 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "ecr repo already exists",
-			cfg: config.Application{
-				AppName: "test",
-				ExecutionUnits: map[string]*config.ExecutionUnit{
-					"test": {Type: "lambda"},
-				},
-			},
-			existingResources: []core.Resource{ecr.NewEcrRepository("test", core.AnnotationKey{ID: "test2", Capability: annotation.ExecutionUnitCapability})},
-			want: testResult{
-				nodes: []core.Resource{
-					repo, image, role, lambda,
-				},
-				deps: []graph.Edge[core.Resource]{
-					{
-						Source:      repo,
-						Destination: image,
-					},
-					{
-						Source:      image,
-						Destination: lambda,
-					},
-					{
-						Source:      role,
-						Destination: lambda,
-					},
-					{
-						Source:      logGroup,
-						Destination: lambda,
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -123,7 +90,7 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 			}
 			for _, node := range tt.want.nodes {
 				found := false
-				for _, res := range dag.ListConstructs() {
+				for _, res := range dag.ListResources() {
 					if res.Id() == node.Id() {
 						found = true
 					}
@@ -139,16 +106,6 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 					}
 				}
 				assert.True(found)
-			}
-
-			for _, res := range dag.ListConstructs() {
-				if repo, ok := res.(*ecr.EcrRepository); ok {
-					if len(tt.existingResources) != 0 {
-						assert.Len(repo.ConstructsRef, 2)
-					} else {
-						assert.Len(repo.ConstructsRef, 1)
-					}
-				}
 			}
 		})
 

--- a/pkg/provider/aws/resources/vpc/subnet_test.go
+++ b/pkg/provider/aws/resources/vpc/subnet_test.go
@@ -79,7 +79,7 @@ func Test_CreatePrivateSubnet(t *testing.T) {
 			for _, dep := range tt.want.deps {
 				assert.NotNil(dag.GetDependency(dep.source, dep.dest))
 			}
-			assert.Len(dag.ListConstructs(), len(tt.want.nodes))
+			assert.Len(dag.ListResources(), len(tt.want.nodes))
 			assert.Len(dag.ListDependencies(), len(tt.want.deps))
 		})
 	}
@@ -122,7 +122,7 @@ func Test_CreatePublicSubnet(t *testing.T) {
 			for _, dep := range tt.want.deps {
 				assert.NotNil(dag.GetDependency(dep.source, dep.dest))
 			}
-			assert.Len(dag.ListConstructs(), len(tt.want.nodes))
+			assert.Len(dag.ListResources(), len(tt.want.nodes))
 			assert.Len(dag.ListDependencies(), len(tt.want.deps))
 		})
 	}

--- a/pkg/provider/aws/resources/vpc/vpc_endpoint_test.go
+++ b/pkg/provider/aws/resources/vpc/vpc_endpoint_test.go
@@ -85,7 +85,7 @@ func Test_CreateGatewayVpcEndpoint(t *testing.T) {
 			for _, dep := range tt.want.deps {
 				assert.NotNil(dag.GetDependency(dep.source, dep.dest))
 			}
-			assert.Len(dag.ListConstructs(), len(tt.want.nodes))
+			assert.Len(dag.ListResources(), len(tt.want.nodes))
 			assert.Len(dag.ListDependencies(), len(tt.want.deps))
 		})
 	}
@@ -131,7 +131,7 @@ func Test_CreateInterfaceVpcEndpoint(t *testing.T) {
 			for _, dep := range tt.want.deps {
 				assert.NotNil(dag.GetDependency(dep.source, dep.dest))
 			}
-			assert.Len(dag.ListConstructs(), len(tt.want.nodes))
+			assert.Len(dag.ListResources(), len(tt.want.nodes))
 			assert.Len(dag.ListDependencies(), len(tt.want.deps))
 		})
 	}

--- a/pkg/provider/aws/resources/vpc/vpc_test.go
+++ b/pkg/provider/aws/resources/vpc/vpc_test.go
@@ -93,7 +93,7 @@ func Test_CreateNetwork(t *testing.T) {
 			for _, dep := range tt.want.deps {
 				assert.NotNil(dag.GetDependency(dep.source, dep.dest))
 			}
-			assert.Len(dag.ListConstructs(), len(tt.want.nodes))
+			assert.Len(dag.ListResources(), len(tt.want.nodes))
 			assert.Len(dag.ListDependencies(), len(tt.want.deps))
 		})
 	}


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

adding the template for cloudwatch log groups.

Some small fixes that seem to be broken maybe from merge conflicts that didnt get caught

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
