### PR TITLE
Abililty to add s3 env var to lambda and tempalte templates

### DIFF
--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -33,6 +33,14 @@ type (
 		Type() string
 	}
 
+	// IaCValue is a struct that defines a value we need to grab from a specific resource. It is up to the plugins to make the determination of how to retrieve the value
+	IaCValue struct {
+		// Resource is the resource the IaCValue is correlated to
+		Resource Resource
+		// Value defines the intended characteristic of the resource we want to retrieve
+		Value string
+	}
+
 	HasLocalOutput interface {
 		OutputTo(dest string) error
 	}

--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -37,8 +37,8 @@ type (
 	IaCValue struct {
 		// Resource is the resource the IaCValue is correlated to
 		Resource Resource
-		// Value defines the intended characteristic of the resource we want to retrieve
-		Value string
+		// Property defines the intended characteristic of the resource we want to retrieve
+		Property string
 	}
 
 	HasLocalOutput interface {

--- a/pkg/infra/iac2/plugin.go
+++ b/pkg/infra/iac2/plugin.go
@@ -42,7 +42,7 @@ func (p Plugin) Translate(cloudGraph *core.ResourceGraph) ([]core.File, error) {
 		return nil, err
 	}
 
-	buf.Write([]byte("export = async () => {\n"))
+	buf.Write([]byte("export default async () => {\n"))
 	if err := tc.RenderBody(buf); err != nil {
 		return nil, err
 	}

--- a/pkg/infra/iac2/resource_creation_template.go
+++ b/pkg/infra/iac2/resource_creation_template.go
@@ -44,6 +44,7 @@ var (
 
 	parameterizeArgsRegex = regexp.MustCompile(`\bargs(\.\w+)`)
 	curlyEscapes          = regexp.MustCompile(`({+)(args\.)`)
+	templateComments      = regexp.MustCompile(`//*TMPL\s+(.*)`)
 
 	//go:embed find_args.scm
 	findArgsQuery string
@@ -124,6 +125,7 @@ func parameterizeArgs(contents string) string {
 	// invalid go-template. So, we first turn "{args." into "{{`{`}}args.", which will eventually result in
 	// "{{`{`}}{{.Foo}}" — which, while ugly, will result in the correct template execution.
 	contents = curlyEscapes.ReplaceAllString(contents, "{{`$1`}}$2")
+	contents = templateComments.ReplaceAllString(contents, "{{`$1`}}")
 	contents = parameterizeArgsRegex.ReplaceAllString(contents, `{{$1}}`)
 	return contents
 }

--- a/pkg/infra/iac2/resource_creation_template.go
+++ b/pkg/infra/iac2/resource_creation_template.go
@@ -125,7 +125,7 @@ func parameterizeArgs(contents string) string {
 	// invalid go-template. So, we first turn "{args." into "{{`{`}}args.", which will eventually result in
 	// "{{`{`}}{{.Foo}}" — which, while ugly, will result in the correct template execution.
 	contents = curlyEscapes.ReplaceAllString(contents, "{{`$1`}}$2")
-	contents = templateComments.ReplaceAllString(contents, "{{`$1`}}")
+	contents = templateComments.ReplaceAllString(contents, "$1")
 	contents = parameterizeArgsRegex.ReplaceAllString(contents, `{{$1}}`)
 	return contents
 }

--- a/pkg/infra/iac2/templates/lambda_function/factory.ts
+++ b/pkg/infra/iac2/templates/lambda_function/factory.ts
@@ -1,14 +1,12 @@
 import * as aws from '@pulumi/aws'
-import { LogGroup } from '@pulumi/aws/cloudwatch'
 import * as pulumi from '@pulumi/pulumi'
 
 interface Args {
     Name: string
     // lambdaName: string,
     // image: pulumi.Output<string>,
-    CloudwatchGroup: LogGroup
     Role: aws.iam.Role
-    // envVars: Record<string, pulumi.Output<string>>,
+    EnvironmentVariables: Record<string, pulumi.Output<string>>,
     // dependsOn: []
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
 }
@@ -22,6 +20,9 @@ function create(args: Args): aws.lambda.Function {
             imageUri: 'TODO-image-uri',
             role: args.Role.arn,
             name: args.Name,
+            environment: {
+                variables:  args.EnvironmentVariables
+            },
             tags: {
                 env: 'production',
                 service: args.Name,

--- a/pkg/infra/iac2/templates/lambda_function/factory.ts
+++ b/pkg/infra/iac2/templates/lambda_function/factory.ts
@@ -6,7 +6,7 @@ interface Args {
     // lambdaName: string,
     // image: pulumi.Output<string>,
     Role: aws.iam.Role
-    EnvironmentVariables: Record<string, pulumi.Output<string>>,
+    EnvironmentVariables: Record<string, pulumi.Output<string>>
     // dependsOn: []
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
 }
@@ -21,7 +21,7 @@ function create(args: Args): aws.lambda.Function {
             role: args.Role.arn,
             name: args.Name,
             environment: {
-                variables:  args.EnvironmentVariables
+                variables: args.EnvironmentVariables,
             },
             tags: {
                 env: 'production',

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -210,7 +210,6 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value, useDouble
 		} else if typedChild, ok := childVal.Interface().(core.IaCValue); ok {
 			return tc.handleIaCValue(typedChild)
 		} else {
-
 			return ""
 		}
 	case reflect.Array, reflect.Slice:
@@ -240,7 +239,6 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value, useDouble
 			}
 		}
 		buf.WriteRune('}')
-		buf.WriteRune(',')
 		return buf.String()
 	case reflect.Interface:
 		// This happens when the value is inside a map, slice, or array. Basically, the reflected type is interface{},
@@ -254,6 +252,9 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value, useDouble
 
 // handleIaCValue determines how to retrieve values from a resource given a specific value identifier.
 func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue) string {
+	if v.Resource == nil {
+		return tc.resolveStructInput(reflect.ValueOf(v.Value), false)
+	}
 	switch v.Value {
 	case string(core.BUCKET_NAME):
 		return fmt.Sprintf("%s.bucket", tc.getVarName(v.Resource))

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/klothoplatform/klotho/pkg/core"
-	"github.com/klothoplatform/klotho/pkg/graph"
 	"github.com/klothoplatform/klotho/pkg/lang/javascript"
 	"github.com/klothoplatform/klotho/pkg/multierr"
 	"github.com/pkg/errors"
@@ -150,7 +149,7 @@ func (tc TemplatesCompiler) renderResource(out io.Writer, resource core.Resource
 			continue
 		}
 		childVal := resourceVal.FieldByName(fieldName)
-		resolvedValue := tc.resolveStructInput(childVal)
+		resolvedValue := tc.resolveStructInput(childVal, false)
 		if resolvedValue == "" {
 			errs.Append(errors.Errorf(`child struct of %v is not of a known type: %v`, resource, childVal.Interface()))
 		} else {
@@ -189,7 +188,7 @@ func (tc TemplatesCompiler) resolveDependencies(resource core.Resource) string {
 }
 
 // resolveStructInput translates a value to a form suitable to inject into the typescript as an input to a function.
-func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value) string {
+func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value, useDoubleQuotedStrings bool) string {
 	var zeroValue reflect.Value
 	if childVal == zeroValue {
 		return `null`
@@ -201,14 +200,17 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value) string {
 		reflect.Float32, reflect.Float64:
 		return fmt.Sprintf("%v", childVal.Interface())
 	case reflect.String:
-		return quoteTsString(childVal.Interface().(string))
+		return quoteTsString(childVal.Interface().(string), useDoubleQuotedStrings)
 	case reflect.Struct, reflect.Pointer:
 		if childVal.Kind() == reflect.Pointer && childVal.IsNil() {
 			return "null"
 		}
 		if typedChild, ok := childVal.Interface().(core.Resource); ok {
 			return tc.getVarName(typedChild)
+		} else if typedChild, ok := childVal.Interface().(core.IaCValue); ok {
+			return tc.handleIaCValue(typedChild)
 		} else {
+
 			return ""
 		}
 	case reflect.Array, reflect.Slice:
@@ -217,7 +219,7 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value) string {
 		buf := strings.Builder{}
 		buf.WriteRune('[')
 		for i := 0; i < sliceLen; i++ {
-			buf.WriteString(tc.resolveStructInput(childVal.Index(i)))
+			buf.WriteString(tc.resolveStructInput(childVal.Index(i), false))
 			if i < (sliceLen - 1) {
 				buf.WriteRune(',')
 			}
@@ -230,22 +232,31 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value) string {
 		buf := strings.Builder{}
 		buf.WriteRune('{')
 		for i, key := range childVal.MapKeys() {
-			buf.WriteString(tc.resolveStructInput(key))
+			buf.WriteString(tc.resolveStructInput(key, true))
 			buf.WriteRune(':')
-			buf.WriteString(tc.resolveStructInput(childVal.MapIndex(key)))
+			buf.WriteString(tc.resolveStructInput(childVal.MapIndex(key), false))
 			if i < (mapLen - 1) {
 				buf.WriteRune(',')
 			}
 		}
 		buf.WriteRune('}')
-
+		buf.WriteRune(',')
 		return buf.String()
 	case reflect.Interface:
 		// This happens when the value is inside a map, slice, or array. Basically, the reflected type is interface{},
 		// instead of being the actual type. So, we basically pull the item out of the collection, and then reflect on
 		// it directly.
 		underlyingVal := childVal.Interface()
-		return tc.resolveStructInput(reflect.ValueOf(underlyingVal))
+		return tc.resolveStructInput(reflect.ValueOf(underlyingVal), false)
+	}
+	return ""
+}
+
+// handleIaCValue determines how to retrieve values from a resource given a specific value identifier.
+func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue) string {
+	switch v.Value {
+	case string(core.BUCKET_NAME):
+		return fmt.Sprintf("%s.bucket", tc.getVarName(v.Resource))
 	}
 	return ""
 }

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -253,9 +253,9 @@ func (tc TemplatesCompiler) resolveStructInput(childVal reflect.Value, useDouble
 // handleIaCValue determines how to retrieve values from a resource given a specific value identifier.
 func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue) string {
 	if v.Resource == nil {
-		return tc.resolveStructInput(reflect.ValueOf(v.Value), false)
+		return tc.resolveStructInput(reflect.ValueOf(v.Property), false)
 	}
-	switch v.Value {
+	switch v.Property {
 	case string(core.BUCKET_NAME):
 		return fmt.Sprintf("%s.bucket", tc.getVarName(v.Resource))
 	}

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -2,7 +2,6 @@ package iac2
 
 import (
 	"bytes"
-	"fmt"
 	"io/fs"
 	"reflect"
 	"strings"
@@ -136,7 +135,7 @@ func TestResolveStructInput(t *testing.T) {
 				"MyStruct": DummyBuzz{},
 			},
 			withVars:               map[string]string{`buzz-shared`: `myVar`},
-			want:                   `{"MyStruct":myVar},`,
+			want:                   `{"MyStruct":myVar}`,
 			useDoubleQuotedStrings: true,
 		},
 	}
@@ -161,7 +160,7 @@ func Test_handleIaCValue(t *testing.T) {
 		want                 string
 	}{
 		{
-			name: "string",
+			name: "bucket name",
 			value: core.IaCValue{
 				Resource: s3.NewS3Bucket(&core.Fs{}, "test-app", resources.NewAccountId()),
 				Value:    string(core.BUCKET_NAME),
@@ -171,6 +170,13 @@ func Test_handleIaCValue(t *testing.T) {
 			},
 			want: "testBucket.bucket",
 		},
+		{
+			name: "string value, nil resource",
+			value: core.IaCValue{
+				Value: "TestValue",
+			},
+			want: "`TestValue`",
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -178,7 +184,6 @@ func Test_handleIaCValue(t *testing.T) {
 			tc := TemplatesCompiler{
 				resourceVarNamesById: tt.resourceVarNamesById,
 			}
-			fmt.Println(tt.value.Resource.Id())
 			actual := tc.handleIaCValue(tt.value)
 			assert.Equal(tt.want, actual)
 		})

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -163,7 +163,7 @@ func Test_handleIaCValue(t *testing.T) {
 			name: "bucket name",
 			value: core.IaCValue{
 				Resource: s3.NewS3Bucket(&core.Fs{}, "test-app", resources.NewAccountId()),
-				Value:    string(core.BUCKET_NAME),
+				Property: string(core.BUCKET_NAME),
 			},
 			resourceVarNamesById: map[string]string{
 				"aws:s3_bucket:test-app-": "testBucket",
@@ -173,7 +173,7 @@ func Test_handleIaCValue(t *testing.T) {
 		{
 			name: "string value, nil resource",
 			value: core.IaCValue{
-				Value: "TestValue",
+				Property: "TestValue",
 			},
 			want: "`TestValue`",
 		},

--- a/pkg/infra/iac2/util_test.go
+++ b/pkg/infra/iac2/util_test.go
@@ -2,8 +2,9 @@ package iac2
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSnakeToLower(t *testing.T) {
@@ -61,30 +62,12 @@ func TestQuoteTsString(t *testing.T) {
 	for orig, want := range cases {
 		t.Run(fmt.Sprintf("[%s]>[%s]", orig, want), func(t *testing.T) {
 			assert := assert.New(t)
-			assert.Equal(want, quoteTsString(orig))
+			assert.Equal(want, quoteTsString(orig, false))
 		})
 	}
 }
 
-func TestGetStructValues(t *testing.T) {
-	assert := assert.New(t)
-	s := MyStruct{
-		MyInt:        123,
-		MyStr:        "hello world",
-		myPrivateInt: 456,
-	}
-
-	assert.Equal(
-		map[string]any{
-			"MyInt": 123,
-			"MyStr": "hello world",
-		},
-		getStructValues(s),
-	)
-}
-
 type MyStruct struct {
-	MyInt        int
-	MyStr        string
-	myPrivateInt int
+	MyInt int
+	MyStr string
 }

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -65,24 +65,24 @@ func (a *AWS) convertExecUnitParams(result *core.ConstructGraph, dag *core.Resou
 					}
 					resourceEnvVars[envVar.Name] = core.IaCValue{
 						Resource: resource,
-						Value:    envVar.Value,
+						Property: envVar.Value,
 					}
 				} else {
 					return fmt.Errorf("resource not found for construct with id, %s", envVar.GetConstruct().Id())
 				}
 			} else {
 				resourceEnvVars[envVar.Name] = core.IaCValue{
-					Value: envVar.Value,
+					Property: envVar.Value,
 				}
 			}
 		}
 
 		// This set of environment variables are added to all Execution Unit's corresponding Resources
 		resourceEnvVars["APP_NAME"] = core.IaCValue{
-			Value: a.Config.AppName,
+			Property: a.Config.AppName,
 		}
 		resourceEnvVars["EXECUNIT_NAME"] = core.IaCValue{
-			Value: unit.ID,
+			Property: unit.ID,
 		}
 
 		// Retrieve the actual resource and set the environment variables on it

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// GenerateExecUnitResources generates the neccessary AWS resources for a given execution unit and adds them to the resource graph
 func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, dag *core.ResourceGraph) error {
 	log := zap.S()
 
@@ -45,25 +46,46 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, dag *core.Reso
 	return nil
 }
 
+// convertExecUnitParams transforms the execution units environment variables to a map of key names and their corresponding core.IaCValue struct
+//
+// If an environment variable does not pertain to a construct and is just a key, value string, the resource of the IaCValue will be left null
 func (a *AWS) convertExecUnitParams(result *core.ConstructGraph, dag *core.ResourceGraph) error {
 	execUnits := core.GetResourcesOfType[*core.ExecutionUnit](result)
 	for _, unit := range execUnits {
 		resourceEnvVars := make(resources.EnvironmentVariables)
+
+		// This set of environment variables correspond to the specific needs of the execution units and its dependencies
 		for _, envVar := range unit.EnvironmentVariables {
-			resourceId, ok := a.ConstructIdToResourceId[envVar.GetConstruct().Id()]
-			if ok {
-				resource := dag.GetResource(resourceId)
-				if resource == nil {
-					return fmt.Errorf("resource not found for id, %s", resourceId)
-				}
-				resourceEnvVars[envVar.Name] = core.IaCValue{
-					Resource: resource,
-					Value:    envVar.Value,
+			if envVar.Construct != nil {
+				resourceId, ok := a.ConstructIdToResourceId[envVar.GetConstruct().Id()]
+				if ok {
+					resource := dag.GetResource(resourceId)
+					if resource == nil {
+						return fmt.Errorf("resource not found for id, %s", resourceId)
+					}
+					resourceEnvVars[envVar.Name] = core.IaCValue{
+						Resource: resource,
+						Value:    envVar.Value,
+					}
+				} else {
+					return fmt.Errorf("resource not found for construct with id, %s", envVar.GetConstruct().Id())
 				}
 			} else {
-				return fmt.Errorf("resource not found for construct with id, %s", envVar.GetConstruct().Id())
+				resourceEnvVars[envVar.Name] = core.IaCValue{
+					Value: envVar.Value,
+				}
 			}
 		}
+
+		// This set of environment variables are added to all Execution Unit's corresponding Resources
+		resourceEnvVars["APP_NAME"] = core.IaCValue{
+			Value: a.Config.AppName,
+		}
+		resourceEnvVars["EXECUNIT_NAME"] = core.IaCValue{
+			Value: unit.ID,
+		}
+
+		// Retrieve the actual resource and set the environment variables on it
 		resourceId, ok := a.ConstructIdToResourceId[unit.Id()]
 		if ok {
 			resource := dag.GetResource(resourceId)
@@ -81,6 +103,7 @@ func (a *AWS) convertExecUnitParams(result *core.ConstructGraph, dag *core.Resou
 	return nil
 }
 
+// GetAssumeRolePolicyForType returns an assume role policy doc as a string, for the execution units corresponding IAM role
 func GetAssumeRolePolicyForType(cfg config.ExecutionUnit) string {
 	switch cfg.Type {
 	case Lambda:

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -142,7 +142,27 @@ func Test_convertExecUnitParams(t *testing.T) {
 			},
 			testresource: &lambda.LambdaFunction{},
 			wants: resources.EnvironmentVariables{
+				"APP_NAME":           core.IaCValue{Resource: nil, Value: "test"},
+				"EXECUNIT_NAME":      core.IaCValue{Resource: nil, Value: "unit"},
 				"BUCKET_BUCKET_NAME": core.IaCValue{Resource: s3Bucket, Value: "bucket_name"},
+			},
+		},
+		{
+			name: `lambda`,
+			construct: &core.ExecutionUnit{
+				AnnotationKey: core.AnnotationKey{ID: "unit"},
+				EnvironmentVariables: core.EnvironmentVariables{
+					core.NewEnvironmentVariable("TestVar", nil, "TestValue"),
+				},
+			},
+			constructIdToResourceId: map[string]string{
+				":unit": "aws:lambda_function:",
+			},
+			testresource: &lambda.LambdaFunction{},
+			wants: resources.EnvironmentVariables{
+				"APP_NAME":      core.IaCValue{Resource: nil, Value: "test"},
+				"EXECUNIT_NAME": core.IaCValue{Resource: nil, Value: "unit"},
+				"TestVar":       core.IaCValue{Resource: nil, Value: "TestValue"},
 			},
 		},
 	}
@@ -151,6 +171,7 @@ func Test_convertExecUnitParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			aws := AWS{
+				Config:                  &config.Application{AppName: "test"},
 				ConstructIdToResourceId: tt.constructIdToResourceId,
 			}
 

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -142,9 +142,9 @@ func Test_convertExecUnitParams(t *testing.T) {
 			},
 			testresource: &lambda.LambdaFunction{},
 			wants: resources.EnvironmentVariables{
-				"APP_NAME":           core.IaCValue{Resource: nil, Value: "test"},
-				"EXECUNIT_NAME":      core.IaCValue{Resource: nil, Value: "unit"},
-				"BUCKET_BUCKET_NAME": core.IaCValue{Resource: s3Bucket, Value: "bucket_name"},
+				"APP_NAME":           core.IaCValue{Resource: nil, Property: "test"},
+				"EXECUNIT_NAME":      core.IaCValue{Resource: nil, Property: "unit"},
+				"BUCKET_BUCKET_NAME": core.IaCValue{Resource: s3Bucket, Property: "bucket_name"},
 			},
 		},
 		{
@@ -160,9 +160,9 @@ func Test_convertExecUnitParams(t *testing.T) {
 			},
 			testresource: &lambda.LambdaFunction{},
 			wants: resources.EnvironmentVariables{
-				"APP_NAME":      core.IaCValue{Resource: nil, Value: "test"},
-				"EXECUNIT_NAME": core.IaCValue{Resource: nil, Value: "unit"},
-				"TestVar":       core.IaCValue{Resource: nil, Value: "TestValue"},
+				"APP_NAME":      core.IaCValue{Resource: nil, Property: "test"},
+				"EXECUNIT_NAME": core.IaCValue{Resource: nil, Property: "unit"},
+				"TestVar":       core.IaCValue{Resource: nil, Property: "TestValue"},
 			},
 		},
 	}

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/ecr"
 	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/iam"
 	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/lambda"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/s3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,7 +73,8 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			aws := AWS{
-				Config: &tt.cfg,
+				Config:                  &tt.cfg,
+				ConstructIdToResourceId: make(map[string]string),
 			}
 			dag := core.NewResourceGraph()
 
@@ -106,6 +108,73 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 					}
 				}
 				assert.True(found)
+			}
+		})
+
+	}
+}
+
+func Test_convertExecUnitParams(t *testing.T) {
+	s3Bucket := s3.NewS3Bucket(&core.Fs{AnnotationKey: core.AnnotationKey{ID: "bucket"}}, "test-app", resources.NewAccountId())
+	cases := []struct {
+		name                    string
+		construct               core.Construct
+		resources               []core.Resource
+		testresource            core.Resource
+		wants                   resources.EnvironmentVariables
+		constructIdToResourceId map[string]string
+		wantErr                 bool
+	}{
+		{
+			name: `lambda`,
+			construct: &core.ExecutionUnit{
+				AnnotationKey: core.AnnotationKey{ID: "unit"},
+				EnvironmentVariables: core.EnvironmentVariables{
+					core.GenerateBucketEnvVar(&core.Fs{AnnotationKey: core.AnnotationKey{ID: "bucket"}}),
+				},
+			},
+			resources: []core.Resource{
+				s3Bucket,
+			},
+			constructIdToResourceId: map[string]string{
+				":unit":   "aws:lambda_function:",
+				":bucket": "aws:s3_bucket:test-app-bucket",
+			},
+			testresource: &lambda.LambdaFunction{},
+			wants: resources.EnvironmentVariables{
+				"BUCKET_BUCKET_NAME": core.IaCValue{Resource: s3Bucket, Value: "bucket_name"},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			aws := AWS{
+				ConstructIdToResourceId: tt.constructIdToResourceId,
+			}
+
+			result := core.NewConstructGraph()
+			result.AddConstruct(tt.construct)
+
+			dag := core.NewResourceGraph()
+			dag.AddResource(tt.testresource)
+			for _, res := range tt.resources {
+				dag.AddResource(res)
+			}
+
+			err := aws.convertExecUnitParams(result, dag)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			if !assert.NoError(err) {
+				return
+			}
+			switch res := tt.testresource.(type) {
+			case *lambda.LambdaFunction:
+				assert.Equal(tt.wants, res.EnvironmentVariables)
+
 			}
 		})
 

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -1,7 +1,10 @@
 package aws
 
-import "github.com/klothoplatform/klotho/pkg/config"
+import (
+	"github.com/klothoplatform/klotho/pkg/config"
+)
 
 type AWS struct {
-	Config *config.Application
+	Config                  *config.Application
+	ConstructIdToResourceId map[string]string
 }

--- a/pkg/provider/aws/resources/environment_variable.go
+++ b/pkg/provider/aws/resources/environment_variable.go
@@ -1,0 +1,12 @@
+package resources
+
+import "github.com/klothoplatform/klotho/pkg/core"
+
+type (
+	EnvironmentVariable struct {
+		Resource core.Resource
+		Value    string
+	}
+
+	EnvironmentVariables map[string]EnvironmentVariable
+)

--- a/pkg/provider/aws/resources/environment_variable.go
+++ b/pkg/provider/aws/resources/environment_variable.go
@@ -3,10 +3,5 @@ package resources
 import "github.com/klothoplatform/klotho/pkg/core"
 
 type (
-	EnvironmentVariable struct {
-		Resource core.Resource
-		Value    string
-	}
-
-	EnvironmentVariables map[string]EnvironmentVariable
+	EnvironmentVariables map[string]core.IaCValue
 )

--- a/pkg/provider/aws/resources/lambda/function.go
+++ b/pkg/provider/aws/resources/lambda/function.go
@@ -19,9 +19,10 @@ type (
 		Name          string
 		ConstructsRef []core.AnnotationKey
 		// Role points to the id of the cloud resource
-		Role      *iam.IamRole
-		VpcConfig LambdaVpcConfig
-		Image     *ecr.EcrImage
+		Role                 *iam.IamRole
+		VpcConfig            LambdaVpcConfig
+		Image                *ecr.EcrImage
+		EnvironmentVariables resources.EnvironmentVariables
 	}
 
 	LambdaVpcConfig struct {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

Able to add environment variables for s3. We now have a core.IaCValue type struct in our core package so that it is common across iac plugins. We implement special handling for this struct so that map types will get printed out correctly if they contain them as a value.

For maps we also have to wrap keys in " and not ` so we add a wrap variable parameter to our quoteTsString functions.

The abililty to write template lines as comments also exists in here although its not used

we would write the comment such as ` //TMPL {{ if eq .EnvironmentVaribles.Name "test" }}` and so forth. Leaving that in as we can expand upon that but will need to document when finalized


### Standard checks

- **Unit tests**: Any special considerations? added and updated
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
