### PR TITLE
start docs and static unit

### DIFF
--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -76,6 +76,7 @@ func TestKnownTemplates(t *testing.T) {
 		&iam.IamPolicy{},
 		&ecr.EcrRepository{},
 		&s3.S3Bucket{},
+		&s3.S3Object{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/templates/s3_bucket/factory.ts
+++ b/pkg/infra/iac2/templates/s3_bucket/factory.ts
@@ -1,9 +1,9 @@
 import * as aws from '@pulumi/aws'
-import * as pulumi from '@pulumi/pulumi'
 
 interface Args {
     Name: string
     ForceDestroy: boolean
+    IndexDocument: string
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -19,6 +19,9 @@ function create(args: Args): aws.s3.Bucket {
                     },
                     bucketKeyEnabled: true,
                 },
+            },
+            website: {
+                indexDocument: args.IndexDocument,
             },
         },
         { protect: true }

--- a/pkg/infra/iac2/templates/s3_bucket/package.json
+++ b/pkg/infra/iac2/templates/s3_bucket/package.json
@@ -1,7 +1,6 @@
 {
     "name": "iac-fragment",
     "dependencies": {
-        "@pulumi/aws": "^5.16.0",
-        "@pulumi/pulumi": "^3.40.2"
+        "@pulumi/aws": "^5.16.0"
     }
 }

--- a/pkg/infra/iac2/templates/s3_object/factory.ts
+++ b/pkg/infra/iac2/templates/s3_object/factory.ts
@@ -1,0 +1,20 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import * as mime from 'mime'
+
+interface Args {
+    Name: string
+    Bucket: aws.s3.Bucket
+    Key: string
+    FilePath: string
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.s3.BucketObject {
+    return new aws.s3.BucketObject(args.Name, {
+        bucket: args.Bucket,
+        key: args.Key,
+        source: new pulumi.asset.FileAsset(args.FilePath), // use FileAsset to point to a file
+        contentType: mime.getType(args.FilePath) || undefined, // set the MIME type of the file
+    })
+}

--- a/pkg/infra/iac2/templates/s3_object/package.json
+++ b/pkg/infra/iac2/templates/s3_object/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "iac-fragment",
+    "dependencies": {
+        "mime": "^2.0.0",
+        "@pulumi/aws": "^5.16.0",
+        "@pulumi/pulumi": "^3.40.2"
+    }
+}

--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -1,0 +1,6 @@
+// Package aws provides the [compiler.ProviderPlugin] ito generate architectures on AWS.
+//
+// Within the package, in the resources sub directories, the provider contains an internal representation of all
+// aws resources (resource is defined as something which can be represented by an arn).
+// These internal representations all implement the [core.Resource] interface so that they can be added to the [core.ResourceGraph]
+package aws

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -23,6 +23,11 @@ func (a *AWS) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (L
 			if err != nil {
 				return
 			}
+		case *core.StaticUnit:
+			err = a.GenerateStaticUnitResources(construct, dag)
+			if err != nil {
+				return
+			}
 		case *core.Fs:
 			err = a.GenerateFsResources(construct, result, dag)
 			if err != nil {

--- a/pkg/provider/aws/resources/s3/bucket.go
+++ b/pkg/provider/aws/resources/s3/bucket.go
@@ -17,12 +17,13 @@ type (
 		Name          string
 		ConstructsRef []core.AnnotationKey
 		ForceDestroy  bool
+		IndexDocument string
 	}
 )
 
-func NewS3Bucket(fs *core.Fs, appName string) *S3Bucket {
+func NewS3Bucket(fs core.Construct, appName string) *S3Bucket {
 	return &S3Bucket{
-		Name:          sanitizer.Apply(fmt.Sprintf("%s-%s", appName, fs.ID)),
+		Name:          sanitizer.Apply(fmt.Sprintf("%s-%s", appName, fs.Provenance().ID)),
 		ConstructsRef: []core.AnnotationKey{fs.Provenance()},
 		ForceDestroy:  true,
 	}

--- a/pkg/provider/aws/resources/s3/bucket_test.go
+++ b/pkg/provider/aws/resources/s3/bucket_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_NewLambdaFunction(t *testing.T) {
+func Test_NewS3Bucket(t *testing.T) {
 	assert := assert.New(t)
 	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test@#$#@$^%#$&wacjyksdjhgklSJDHGFAJHGT3O474oh43o"}}
 	bucket := NewS3Bucket(fs, "test-app")
@@ -17,21 +17,21 @@ func Test_NewLambdaFunction(t *testing.T) {
 	assert.Equal(bucket.ForceDestroy, true)
 }
 
-func Test_Provider(t *testing.T) {
+func Test_BucketProvider(t *testing.T) {
 	assert := assert.New(t)
 	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
 	bucket := NewS3Bucket(fs, "test-app")
 	assert.Equal(bucket.Provider(), resources.AWS_PROVIDER)
 }
 
-func Test_Id(t *testing.T) {
+func Test_BucketId(t *testing.T) {
 	assert := assert.New(t)
 	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
 	bucket := NewS3Bucket(fs, "test-app")
 	assert.Equal(bucket.Id(), "aws:s3_bucket:test-app-test")
 }
 
-func Test_KlothoConstructRef(t *testing.T) {
+func Test_BucketKlothoConstructRef(t *testing.T) {
 	assert := assert.New(t)
 	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
 	bucket := NewS3Bucket(fs, "test-app")

--- a/pkg/provider/aws/resources/s3/object.go
+++ b/pkg/provider/aws/resources/s3/object.go
@@ -1,0 +1,48 @@
+package s3
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
+)
+
+const S3_OBJECT_TYPE = "s3_object"
+
+var objectSanitizer = aws.S3ObjectSanitizer
+
+type (
+	S3Object struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		Bucket        *S3Bucket
+		Key           string
+		FilePath      string
+	}
+)
+
+func NewS3Object(bucket *S3Bucket, objectName string, key string, path string) *S3Object {
+	return &S3Object{
+		Name:          objectSanitizer.Apply(fmt.Sprintf("%s-%s", bucket.Name, objectName)),
+		ConstructsRef: bucket.KlothoConstructRef(),
+		Key:           key,
+		FilePath:      path,
+		Bucket:        bucket,
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (object *S3Object) Provider() string {
+	return resources.AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (object *S3Object) KlothoConstructRef() []core.AnnotationKey {
+	return object.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (object *S3Object) Id() string {
+	return fmt.Sprintf("%s:%s:%s", object.Provider(), S3_OBJECT_TYPE, object.Name)
+}

--- a/pkg/provider/aws/resources/s3/object_test.go
+++ b/pkg/provider/aws/resources/s3/object_test.go
@@ -1,0 +1,45 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewS3Object(t *testing.T) {
+	assert := assert.New(t)
+	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	bucket := NewS3Bucket(fs, "test-app")
+	object := NewS3Object(bucket, "test-name", "test-key", "test-path")
+	assert.Equal(object.Name, "test-app-test-test-name")
+	assert.Equal(object.ConstructsRef, []core.AnnotationKey{fs.AnnotationKey})
+	assert.Equal(object.FilePath, "test-path")
+	assert.Equal(object.Key, "test-key")
+	assert.Equal(object.Bucket, bucket)
+}
+
+func Test_ObjectProvider(t *testing.T) {
+	assert := assert.New(t)
+	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	bucket := NewS3Bucket(fs, "test-app")
+	object := NewS3Object(bucket, "test-name", "test-key", "test-path")
+	assert.Equal(object.Provider(), resources.AWS_PROVIDER)
+}
+
+func Test_ObjectId(t *testing.T) {
+	assert := assert.New(t)
+	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	bucket := NewS3Bucket(fs, "test-app")
+	object := NewS3Object(bucket, "test-name", "test-key", "test-path")
+	assert.Equal(object.Id(), "aws:s3_object:test-app-test-test-name")
+}
+
+func Test_ObjectKlothoConstructRef(t *testing.T) {
+	assert := assert.New(t)
+	fs := &core.Fs{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	bucket := NewS3Bucket(fs, "test-app")
+	object := NewS3Object(bucket, "test-name", "test-key", "test-path")
+	assert.Equal(object.KlothoConstructRef(), []core.AnnotationKey{fs.Provenance()})
+}

--- a/pkg/provider/aws/static_unit.go
+++ b/pkg/provider/aws/static_unit.go
@@ -1,0 +1,23 @@
+package aws
+
+import (
+	"path/filepath"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/s3"
+)
+
+func (a *AWS) GenerateStaticUnitResources(unit *core.StaticUnit, dag *core.ResourceGraph) error {
+
+	bucket := s3.NewS3Bucket(unit, a.Config.AppName)
+	if unit.IndexDocument != "" {
+		bucket.IndexDocument = unit.IndexDocument
+	}
+	dag.AddResource(bucket)
+	for _, f := range unit.Files() {
+		object := s3.NewS3Object(bucket, filepath.Base(f.Path()), f.Path(), filepath.Join(unit.ID, f.Path()))
+		dag.AddResource(object)
+		dag.AddDependency(bucket, object)
+	}
+	return nil
+}

--- a/pkg/provider/aws/static_unit_test.go
+++ b/pkg/provider/aws/static_unit_test.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/annotation"
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/graph"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateStaticUnitResources(t *testing.T) {
+	unit := &core.StaticUnit{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}}
+	unit.AddSharedFile(&core.FileRef{FPath: "test/Shared"})
+	unit.AddStaticFile(&core.FileRef{FPath: "test/Static"})
+	bucket := s3.NewS3Bucket(unit, "test-app")
+	obj1 := s3.NewS3Object(bucket, "Shared", "test/Shared", "test/test/Shared")
+	obj2 := s3.NewS3Object(bucket, "Static", "test/Static", "test/test/Static")
+
+	type testResult struct {
+		nodes []core.Resource
+		deps  []graph.Edge[core.Resource]
+		err   bool
+	}
+	cases := []struct {
+		name          string
+		indexDocument string
+		cfg           config.Application
+		want          testResult
+	}{
+		{
+			name: "generate static unit with no index document",
+			cfg: config.Application{
+				AppName: "test-app",
+			},
+			want: testResult{
+				nodes: []core.Resource{
+					bucket, obj1, obj2,
+				},
+				deps: []graph.Edge[core.Resource]{
+					{
+						Source:      bucket,
+						Destination: obj1,
+					},
+					{
+						Source:      bucket,
+						Destination: obj2,
+					},
+				},
+			},
+		},
+		{
+			name: "generate static unit with index document as website",
+			cfg: config.Application{
+				AppName: "test-app",
+			},
+			indexDocument: "index.html",
+			want: testResult{
+				nodes: []core.Resource{
+					bucket, obj1, obj2,
+				},
+				deps: []graph.Edge[core.Resource]{
+					{
+						Source:      bucket,
+						Destination: obj1,
+					},
+					{
+						Source:      bucket,
+						Destination: obj2,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			aws := AWS{
+				Config:                  &tt.cfg,
+				ConstructIdToResourceId: make(map[string]string),
+			}
+			dag := core.NewResourceGraph()
+
+			if tt.indexDocument != "" {
+				unit.IndexDocument = tt.indexDocument
+			}
+
+			err := aws.GenerateStaticUnitResources(unit, dag)
+			if tt.want.err {
+				assert.Error(err)
+				return
+			}
+			if !assert.NoError(err) {
+				return
+			}
+			for _, node := range tt.want.nodes {
+				found := false
+				for _, res := range dag.ListResources() {
+					if res.Id() == node.Id() {
+						found = true
+					}
+					if res.Id() == bucket.Id() && tt.indexDocument != "" {
+						if b, ok := res.(*s3.S3Bucket); ok {
+							assert.Equal(b.IndexDocument, tt.indexDocument)
+						}
+					}
+				}
+				assert.True(found)
+			}
+
+			for _, dep := range tt.want.deps {
+				found := false
+				for _, res := range dag.ListDependencies() {
+					if res.Source.Id() == dep.Source.Id() && res.Destination.Id() == dep.Destination.Id() {
+						found = true
+					}
+				}
+				assert.True(found)
+			}
+		})
+
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,3 +1,22 @@
+// Package Provider provides the interface for providers which satisfy the [compiler.ProviderPlugin].
+//
+// A Provider is a centralized location containing all necessary logic to transform an architecture, representated as klotho constructs,
+// into the necessary resources to run on the given provider and achieve the same functionality.
+//
+// In addition to implementing the [compiler.ProviderPlugin] interface, a provider must:
+//   - Provide mappings of a Kind of resource (ex. Fs or Execution Unit) to the types supported in the provider (can be services, such as s3 or lambda)
+//   - Provide a Default configuration for all of the specified types that the provider offers
+//
+// The Provider Plugins are responsible for translating the [core.ConstructGraph] into a [core.ResourceGraph] with the necessary resources defined by each provider.
+// Each specific provider is responsible for generating their own internal representation's of their resources as a [core.Resource]
+//
+// These internal representations are what will eventually be used by the [compiler.IaCPlugin] and their fields can be parsed if they meet the following criteria
+//   - They are a native Go Type
+//   - They satisfy the core.Resource interface
+//   - They are a core.IaCValue
+//   - The struct field is tagged with `render: "document`
+//
+// The `render: "document` signals that the field within the struct contains other nested fields and needs to be rendered as an object, native to the language the IaCPlugin uses
 package provider
 
 import (

--- a/pkg/sanitization/aws/s3.go
+++ b/pkg/sanitization/aws/s3.go
@@ -17,3 +17,14 @@ var S3BucketSanitizer = sanitization.NewSanitizer(
 	},
 	52, // We know that we will prepend account id onto the names here, so we want to shorten this further until we do that in the iac level
 )
+
+// EnvVarKeySanitizer returns a sanitized environment key when applied.
+var S3ObjectSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
+		{
+			Pattern:     regexp.MustCompile(`^.$`),
+			Replacement: "-",
+		},
+	},
+	0,
+)


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #424 

Also adds some package level documentation around providers and the aws provider

Adds the ability to create static units in the provider, resulting in:
- a new s3 bucket, with the index document set if needed
- an object per file that exists within the static unit

Adds the following to IaC:
- IndexDocument arg for s3 buckets
- s3 objects


### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
