### PR TITLE
allow a construct to map to multiple resources

### DIFF
--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -12,7 +12,7 @@ type (
 	}
 )
 
-func (c *AWS) Name() string { return "aws" }
+func (a *AWS) Name() string { return "aws" }
 
 // Enums for the types we allow in the aws provider so that we can reuse the same string within the provider
 const (

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -18,7 +18,7 @@ func (a *AWS) GenerateFsResources(construct *core.Fs, result *core.ConstructGrap
 				})
 		}
 	}
-	a.ConstructIdToResourceId[construct.Id()] = bucket.Id()
+	a.MapResourceDirectlyToConstruct(bucket, construct)
 	dag.AddResource(bucket)
 	return nil
 }

--- a/pkg/provider/aws/persist_test.go
+++ b/pkg/provider/aws/persist_test.go
@@ -62,8 +62,7 @@ func Test_GenerateFsResources(t *testing.T) {
 				Config: &config.Application{
 					AppName: "test",
 				},
-				ConstructIdToResourceId: make(map[string]string),
-				PolicyGenerator:         resources.NewPolicyGenerator(),
+				PolicyGenerator: resources.NewPolicyGenerator(),
 			}
 			result := core.NewConstructGraph()
 

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAwsMapResourceDirectlyToConstruct(t *testing.T) {
+	t.Run("empty AWS struct, MapResourceDirectlyToConstruct", func(t *testing.T) {
+		assert := assert.New(t)
+		a := AWS{}
+		a.MapResourceDirectlyToConstruct(dummyResource("res"), dummyConstruct("cons"))
+		assert.Equal(
+			map[string][]core.Resource{
+				"cons": {dummyResource("res")},
+			},
+			a.constructIdToResources)
+	})
+	t.Run("empty AWS struct, MapResourceDirectlyToConstruct", func(t *testing.T) {
+		assert := assert.New(t)
+		a := AWS{}
+		_, found := a.GetResourcesDirectlyTiedToConstruct(dummyConstruct("cons"))
+		assert.False(found)
+	})
+	t.Run("resources get sorted", func(t *testing.T) {
+		assert := assert.New(t)
+		a := AWS{}
+		a.MapResourceDirectlyToConstruct(dummyResource("res_b"), dummyConstruct("cons"))
+		a.MapResourceDirectlyToConstruct(dummyResource("res_a"), dummyConstruct("cons"))
+		assert.Equal(
+			map[string][]core.Resource{
+				"cons": {dummyResource("res_a"), dummyResource("res_b")}, // note: NOT the order they were added above!
+			},
+			a.constructIdToResources)
+	})
+	t.Run("returns multiple resources", func(t *testing.T) {
+		assert := assert.New(t)
+		a := AWS{
+			constructIdToResources: map[string][]core.Resource{
+				"cons": {dummyResource("res_a"), dummyResource("res_b"), dummyResource("res_c")},
+			},
+		}
+		resList, found := a.GetResourcesDirectlyTiedToConstruct(dummyConstruct("cons"))
+		assert.True(found)
+		assert.Equal(
+			[]core.Resource{dummyResource("res_a"), dummyResource("res_b"), dummyResource("res_c")},
+			resList)
+	})
+}
+
+type (
+	dummyResource  string
+	dummyConstruct string
+)
+
+func (dr dummyResource) Provider() string { return "TEST" }
+
+func (dr dummyResource) KlothoConstructRef() []core.AnnotationKey { return nil }
+
+func (dr dummyResource) Id() string { return string(dr) }
+
+func (dc dummyConstruct) Provenance() core.AnnotationKey { return core.AnnotationKey{} }
+
+func (dc dummyConstruct) Id() string { return string(dc) }

--- a/pkg/provider/aws/static_unit_test.go
+++ b/pkg/provider/aws/static_unit_test.go
@@ -78,8 +78,7 @@ func Test_GenerateStaticUnitResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			aws := AWS{
-				Config:                  &tt.cfg,
-				ConstructIdToResourceId: make(map[string]string),
+				Config: &tt.cfg,
 			}
 			dag := core.NewResourceGraph()
 			unit.IndexDocument = tt.indexDocument

--- a/pkg/provider/providers/provider.go
+++ b/pkg/provider/providers/provider.go
@@ -16,9 +16,8 @@ func GetProvider(cfg *config.Application) (provider.Provider, error) {
 		fallthrough
 	case "aws":
 		return &aws.AWS{
-			Config:                  cfg,
-			ConstructIdToResourceId: make(map[string]string),
-			PolicyGenerator:         resources.NewPolicyGenerator(),
+			Config:          cfg,
+			PolicyGenerator: resources.NewPolicyGenerator(),
 		}, nil
 	}
 


### PR DESCRIPTION
We need this for secrets (#414), but it's noisy enough that I'm pulling it out to a separate pr.

### Standard checks

- **Unit tests**: added
- **Docs**: added
- **Backwards compatibility**: n/a
