### PR TITLE
allow the env var to be referenced by multiple exec units

### DIFF
--- a/pkg/env_var/plugin.go
+++ b/pkg/env_var/plugin.go
@@ -136,12 +136,6 @@ func ParseDirectiveToEnvVars(cap *annotation.Capability) (EnvironmentVariableDir
 }
 
 func handlePersist(kind string, cap *annotation.Capability, unit *core.ExecutionUnit, result *core.CompilationResult, deps *core.Dependencies) error {
-	resources := core.GetResourcesOfType[*core.Persist](result)
-	for _, res := range resources {
-		if res.Name == cap.ID && string(res.Kind) == kind {
-			return nil
-		}
-	}
 	switch kind {
 	case string(core.PersistORMKind):
 		resource := core.Persist{


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

This was preventing multi exec from working with the annotations

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
