### PR TITLE
Add elasticache and security group support

### DIFF
--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"github.com/klothoplatform/klotho/pkg/graph"
+	"go.uber.org/zap"
 )
 
 type (
@@ -18,6 +19,7 @@ func NewResourceGraph() *ResourceGraph {
 
 func (cg *ResourceGraph) AddResource(resource Resource) {
 	cg.underlying.AddVertex(resource)
+	zap.S().Debugf("adding resource: %s", resource.Id())
 }
 
 // AddDependency2 deliberately renamed from AddDependency in the short term to catch when dependencies were

--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -86,6 +86,9 @@ func TestKnownTemplates(t *testing.T) {
 		&resources.ApiResource{},
 		&resources.ApiStage{},
 		&resources.LambdaPermission{},
+		&resources.Elasticache{},
+		&resources.ElasticacheSubnetgroup{},
+		&resources.SecurityGroup{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/templates/elasticache/factory.ts
+++ b/pkg/infra/iac2/templates/elasticache/factory.ts
@@ -1,0 +1,32 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    Engine: string
+    CloudwatchGroup: aws.cloudwatch.LogGroup
+    SubnetGroup: aws.elasticache.SubnetGroup
+    SecurityGroups: aws.ec2.SecurityGroup[]
+}
+
+function create(args: Args): aws.elasticache.Cluster {
+    return new aws.elasticache.Cluster(args.Name, {
+        engine: 'redis',
+        clusterId: args.Engine,
+        logDeliveryConfigurations: [
+            {
+                destination: args.CloudwatchGroup.name,
+                destinationType: 'cloudwatch-logs',
+                logFormat: 'text',
+                logType: 'slow-log',
+            },
+            {
+                destination: args.CloudwatchGroup.name,
+                destinationType: 'cloudwatch-logs',
+                logFormat: 'json',
+                logType: 'engine-log',
+            },
+        ],
+        subnetGroupName: args.SubnetGroup.name,
+        securityGroupIds: args.SecurityGroups.map((sg) => sg.id),
+    })
+}

--- a/pkg/infra/iac2/templates/elasticache/package.json
+++ b/pkg/infra/iac2/templates/elasticache/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "elasticache",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates/elasticache_subnetgroup/factory.ts
+++ b/pkg/infra/iac2/templates/elasticache_subnetgroup/factory.ts
@@ -1,0 +1,12 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    Subnets: aws.ec2.Subnet[]
+}
+
+function create(args: Args): aws.elasticache.SubnetGroup {
+    return new aws.elasticache.SubnetGroup(args.Name, {
+        subnetIds: args.Subnets.map((sg) => sg.id),
+    })
+}

--- a/pkg/infra/iac2/templates/elasticache_subnetgroup/package.json
+++ b/pkg/infra/iac2/templates/elasticache_subnetgroup/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "elasticache_subnetgroup",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates/security_group/factory.ts
+++ b/pkg/infra/iac2/templates/security_group/factory.ts
@@ -1,0 +1,46 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    Vpc: aws.ec2.Vpc
+}
+
+function create(args: Args): aws.ec2.SecurityGroup {
+    return new aws.ec2.SecurityGroup(args.Name, {
+        name: args.Name,
+        vpcId: args.Vpc.id,
+        egress: [
+            {
+                cidrBlocks: ['0.0.0.0/0'],
+                description: 'Allows all outbound IPv4 traffic.',
+                fromPort: 0,
+                protocol: '-1',
+                toPort: 0,
+            },
+        ],
+        ingress: [
+            {
+                description:
+                    'Allows inbound traffic from network interfaces and instances that are assigned to the same security group.',
+                fromPort: 0,
+                protocol: '-1',
+                self: true,
+                toPort: 0,
+            },
+            {
+                description: 'For EKS control plane',
+                cidrBlocks: ['0.0.0.0/0'],
+                fromPort: 9443,
+                protocol: 'TCP',
+                toPort: 9443,
+            },
+            {
+                description: 'For private subnets internally',
+                cidrBlocks: [args.Vpc.cidrBlock],
+                fromPort: 0,
+                protocol: '-1',
+                toPort: 0,
+            },
+        ],
+    })
+}

--- a/pkg/infra/iac2/templates/security_group/package.json
+++ b/pkg/infra/iac2/templates/security_group/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "security_group",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -417,9 +417,19 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue) (string, error) {
 	case string(core.ALL_RESOURCES_IAC_VALUE):
 		return "*", nil
 	case string(core.HOST):
-		return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].address`", tc.getVarName(v.Resource)), nil
+		switch v.Resource.(type) {
+		case *resources.Elasticache:
+			return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].address`", tc.getVarName(v.Resource)), nil
+		default:
+			return "", errors.Errorf("unsupported resource type %T for '%s'", v.Resource, v.Property)
+		}
 	case string(core.PORT):
-		return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].port`", tc.getVarName(v.Resource)), nil
+		switch v.Resource.(type) {
+		case *resources.Elasticache:
+			return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].port`", tc.getVarName(v.Resource)), nil
+		default:
+			return "", errors.Errorf("unsupported resource type %T for '%s'", v.Resource, v.Property)
+		}
 	}
 	return "", errors.Errorf("unsupported IaC Value Property, %s", v.Property)
 }

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -416,6 +416,10 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue) (string, error) {
 		return fmt.Sprintf("%s.invokeArn", tc.getVarName(v.Resource)), nil
 	case string(core.ALL_RESOURCES_IAC_VALUE):
 		return "*", nil
+	case string(core.HOST):
+		return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].address`", tc.getVarName(v.Resource)), nil
+	case string(core.PORT):
+		return fmt.Sprintf("pulumi.interpolate`%s.cacheNodes[0].port`", tc.getVarName(v.Resource)), nil
 	}
 	return "", errors.Errorf("unsupported IaC Value Property, %s", v.Property)
 }

--- a/pkg/lang/javascript/plugin_persist.go
+++ b/pkg/lang/javascript/plugin_persist.go
@@ -562,7 +562,7 @@ func (p *persister) determinePersistType(f *core.SourceFile, annotation *core.An
 
 	redisKind, redis := p.queryRedis(f, annotation, false)
 	if redis != nil {
-		log.Sugar().Debugf("Determined persist type of '%s'", redisKind)
+		log.Sugar().Debugf("Determined persist type of redis: '%T'", redisKind)
 		return redisKind, redis
 	}
 

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -25,14 +25,6 @@ func (a *AWS) GenerateFsResources(construct *core.Fs, result *core.ConstructGrap
 
 func (a *AWS) GenerateRedisResources(construct core.Construct, result *core.ConstructGraph, dag *core.ResourceGraph) error {
 	ec := resources.CreateElasticache(a.Config, dag, construct)
-	upstreamResources := result.GetUpstreamConstructs(construct)
-	for _, res := range upstreamResources {
-		unit, ok := res.(*core.ExecutionUnit)
-		if ok {
-			unit.EnvironmentVariables.Add(core.GenerateRedisHostEnvVar(construct))
-			unit.EnvironmentVariables.Add(core.GenerateRedisPortEnvVar(construct))
-		}
-	}
 	a.MapResourceDirectlyToConstruct(ec, construct)
 	return nil
 }

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -22,3 +22,17 @@ func (a *AWS) GenerateFsResources(construct *core.Fs, result *core.ConstructGrap
 	dag.AddResource(bucket)
 	return nil
 }
+
+func (a *AWS) GenerateRedisResources(construct core.Construct, result *core.ConstructGraph, dag *core.ResourceGraph) error {
+	ec := resources.CreateElasticache(a.Config, dag, construct)
+	upstreamResources := result.GetUpstreamConstructs(construct)
+	for _, res := range upstreamResources {
+		unit, ok := res.(*core.ExecutionUnit)
+		if ok {
+			unit.EnvironmentVariables.Add(core.GenerateRedisHostEnvVar(construct))
+			unit.EnvironmentVariables.Add(core.GenerateRedisPortEnvVar(construct))
+		}
+	}
+	a.MapResourceDirectlyToConstruct(ec, construct)
+	return nil
+}

--- a/pkg/provider/aws/resources/elasticache.go
+++ b/pkg/provider/aws/resources/elasticache.go
@@ -1,0 +1,91 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+)
+
+type (
+	Elasticache struct {
+		Name            string
+		Engine          string
+		CloudwatchGroup *LogGroup
+		SubnetGroup     *ElasticacheSubnetgroup
+		SecurityGroups  []*SecurityGroup
+		ConstructsRef   []core.AnnotationKey
+	}
+
+	ElasticacheSubnetgroup struct {
+		Name          string
+		Subnets       []*Subnet
+		ConstructsRef []core.AnnotationKey
+	}
+)
+
+const (
+	EC_TYPE   = "elasticache"
+	ECSN_TYPE = "elasticache_subnetgroup"
+)
+
+// Provider returns name of the provider the resource is correlated to
+func (ec *Elasticache) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (ec *Elasticache) KlothoConstructRef() []core.AnnotationKey {
+	return ec.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (ec *Elasticache) Id() string {
+	return fmt.Sprintf("%s:%s:%s", ec.Provider(), EC_TYPE, ec.Name)
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (ecsn *ElasticacheSubnetgroup) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (ecsn *ElasticacheSubnetgroup) KlothoConstructRef() []core.AnnotationKey {
+	return ecsn.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (ecsn *ElasticacheSubnetgroup) Id() string {
+	return fmt.Sprintf("%s:%s:%s", ecsn.Provider(), ECSN_TYPE, ecsn.Name)
+}
+
+func CreateElasticache(cfg *config.Application, dag *core.ResourceGraph, source core.Construct) *Elasticache {
+	ec := &Elasticache{
+		Name:            source.Id(),
+		Engine:          "redis", // TODO determine this from the type of `source`
+		CloudwatchGroup: NewLogGroup(cfg.AppName, fmt.Sprintf("/aws/elasticache/%s-%s-persist-redis", cfg.AppName, source.Id()), source.Provenance(), 0),
+		SubnetGroup: &ElasticacheSubnetgroup{
+			Name:          source.Id(),
+			Subnets:       GetSubnets(cfg, dag),
+			ConstructsRef: []core.AnnotationKey{source.Provenance()},
+		},
+		SecurityGroups: []*SecurityGroup{GetSecurityGroup(cfg, dag)},
+		ConstructsRef:  []core.AnnotationKey{source.Provenance()},
+	}
+	dag.AddResource(ec)
+	dag.AddResource(ec.CloudwatchGroup)
+	dag.AddResource(ec.SubnetGroup)
+	dag.AddDependency2(ec, ec.CloudwatchGroup)
+	dag.AddDependency2(ec, ec.SubnetGroup)
+
+	for _, sg := range ec.SecurityGroups {
+		sg.ConstructsRef = append(sg.ConstructsRef, source.Provenance())
+		dag.AddDependency2(ec, sg)
+	}
+	for _, sn := range ec.SubnetGroup.Subnets {
+		sn.ConstructsRef = append(sn.ConstructsRef, source.Provenance())
+		dag.AddDependency2(ec.SubnetGroup, sn)
+	}
+
+	return ec
+}

--- a/pkg/provider/aws/resources/elasticache.go
+++ b/pkg/provider/aws/resources/elasticache.go
@@ -66,7 +66,7 @@ func CreateElasticache(cfg *config.Application, dag *core.ResourceGraph, source 
 		CloudwatchGroup: NewLogGroup(cfg.AppName, fmt.Sprintf("/aws/elasticache/%s-%s-persist-redis", cfg.AppName, source.Id()), source.Provenance(), 0),
 		SubnetGroup: &ElasticacheSubnetgroup{
 			Name:          source.Id(),
-			Subnets:       GetSubnets(cfg, dag),
+			Subnets:       GetSubnets(cfg, dag), // TODO when we allow for segmented networks, need to determine which network (subnets) this lives in
 			ConstructsRef: []core.AnnotationKey{source.Provenance()},
 		},
 		SecurityGroups: []*SecurityGroup{GetSecurityGroup(cfg, dag)},

--- a/pkg/provider/aws/resources/elasticache_test.go
+++ b/pkg/provider/aws/resources/elasticache_test.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateElasticache(t *testing.T) {
+	dag := core.NewResourceGraph()
+	cfg := &config.Application{AppName: "test"}
+	source := &core.RedisNode{}
+
+	ec := CreateElasticache(cfg, dag, source)
+
+	assert := assert.New(t)
+
+	assert.NotNil(ec)
+	assert.NotNil(dag.GetDependency(ec.Id(), ec.CloudwatchGroup.Id()))
+	assert.NotNil(dag.GetDependency(ec.Id(), ec.SubnetGroup.Id()))
+	for _, sn := range ec.SubnetGroup.Subnets {
+		assert.NotNil(dag.GetDependency(ec.SubnetGroup.Id(), sn.Id()))
+	}
+	for _, sg := range ec.SecurityGroups {
+		assert.NotNil(dag.GetDependency(ec.Id(), sg.Id()))
+	}
+	if assert.Len(ec.KlothoConstructRef(), 1) {
+		assert.Equal(source.Provenance(), ec.KlothoConstructRef()[0])
+	}
+}

--- a/pkg/provider/aws/resources/securitygroup.go
+++ b/pkg/provider/aws/resources/securitygroup.go
@@ -27,6 +27,7 @@ func GetSecurityGroup(cfg *config.Application, dag *core.ResourceGraph) *Securit
 		Vpc:  GetVpc(cfg, dag),
 	}
 	dag.AddResource(sg)
+	dag.AddDependency2(sg, sg.Vpc)
 	return sg
 }
 

--- a/pkg/provider/aws/resources/securitygroup.go
+++ b/pkg/provider/aws/resources/securitygroup.go
@@ -11,6 +11,7 @@ type SecurityGroup struct {
 	Name          string
 	Vpc           *Vpc
 	ConstructsRef []core.AnnotationKey
+	// TODO Add ingress rules - https://github.com/klothoplatform/klotho/issues/465
 }
 
 const SG_TYPE = "security_group"

--- a/pkg/provider/aws/resources/securitygroup.go
+++ b/pkg/provider/aws/resources/securitygroup.go
@@ -1,0 +1,46 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+)
+
+type SecurityGroup struct {
+	Name          string
+	Vpc           *Vpc
+	ConstructsRef []core.AnnotationKey
+}
+
+const SG_TYPE = "security_group"
+
+// GetSecurityGroup returns the security group if one exists, otherwise creates one, then returns it
+func GetSecurityGroup(cfg *config.Application, dag *core.ResourceGraph) *SecurityGroup {
+	for _, r := range dag.ListResources() {
+		if sg, ok := r.(*SecurityGroup); ok {
+			return sg
+		}
+	}
+	sg := &SecurityGroup{
+		Name: cfg.AppName,
+		Vpc:  GetVpc(cfg, dag),
+	}
+	dag.AddResource(sg)
+	return sg
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (sg *SecurityGroup) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (sg *SecurityGroup) KlothoConstructRef() []core.AnnotationKey {
+	return sg.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (sg *SecurityGroup) Id() string {
+	return fmt.Sprintf("%s:%s:%s", sg.Provider(), SG_TYPE, sg.Name)
+}


### PR DESCRIPTION
Running ts-redis sample app:
```ts
const awsElasticacheSubnetgroupPersistRedis = new aws.elasticache.SubnetGroup(`persist:redis`, {
        subnetIds: [awsVpcSubnetTestAppPublic1,awsVpcSubnetTestAppPublic2,awsVpcSubnetTestAppPrivate2,awsVpcSubnetTestAppPrivate1].map((sg) => sg.id),
    });

const awsLogGroupGgDevAwselasticacheggDevPersistredisPersistRedis = new aws.cloudwatch.LogGroup(`gg_dev_awselasticachegg_dev_persistredis_persist_redis`, {
        name: `/aws/elasticache/gg-dev-persist:redis-persist-redis`,
        retentionInDays: 0,
    });

const awsSecurityGroupGgDev = new aws.ec2.SecurityGroup(`gg-dev`, {
        name: `gg-dev`,
        vpcId: awsVpcTestApp.id,
        egress: [
            {
                cidrBlocks: ['0.0.0.0/0'],
                description: 'Allows all outbound IPv4 traffic.',
                fromPort: 0,
                protocol: '-1',
                toPort: 0,
            },
        ],
        ingress: [
            {
                description:
                    'Allows inbound traffic from network interfaces and instances that are assigned to the same security group.',
                fromPort: 0,
                protocol: '-1',
                self: true,
                toPort: 0,
            },
            {
                description: 'For EKS control plane',
                cidrBlocks: ['0.0.0.0/0'],
                fromPort: 9443,
                protocol: 'TCP',
                toPort: 9443,
            },
            {
                description: 'For private subnets internally',
                cidrBlocks: [awsVpcTestApp.cidrBlock],
                fromPort: 0,
                protocol: '-1',
                toPort: 0,
            },
        ],
    });

const awsElasticachePersistRedis = new aws.elasticache.Cluster(`persist:redis`, {
        engine: 'redis',
        clusterId: `redis`,
        logDeliveryConfigurations: [
            {
                destination: awsLogGroupGgDevAwselasticacheggDevPersistredisPersistRedis.name,
                destinationType: 'cloudwatch-logs',
                logFormat: 'text',
                logType: 'slow-log',
            },
            {
                destination: awsLogGroupGgDevAwselasticacheggDevPersistredisPersistRedis.name,
                destinationType: 'cloudwatch-logs',
                logFormat: 'json',
                logType: 'engine-log',
            },
        ],
        subnetGroupName: awsElasticacheSubnetgroupPersistRedis.name,
        securityGroupIds: [awsSecurityGroupGgDev].map((sg) => sg.id),
    });
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
