### PR TITLE
nicer formatting for yaml-based tests

### DIFF
--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -106,8 +106,6 @@ func (cfg ExecutionUnit) GetExecutionUnitParamsAsKubernetes() KubernetesTypePara
 	params := KubernetesTypeParams{}
 	if err := json.Unmarshal(jsonString, &params); err != nil {
 		zap.S().Error(err)
-		return params
-	} else {
-		return params
 	}
+	return params
 }

--- a/pkg/infra/kubernetes/helm_chart_test.go
+++ b/pkg/infra/kubernetes/helm_chart_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"github.com/klothoplatform/klotho/pkg/testutil"
 	"strings"
 	"testing"
 
@@ -36,12 +37,14 @@ func Test_AssignFilesToUnits(t *testing.T) {
 					{Name: "unit1"},
 				},
 			},
-			fileUnits: map[string]string{"pod.yaml": `apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: web
-    image: nginx`},
+			fileUnits: map[string]string{
+				"pod.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Pod
+                    spec:
+                      containers:
+                      - name: web
+                        image: nginx`)},
 			want: []TestUnit{
 				{
 					name:    "unit1",
@@ -56,22 +59,23 @@ spec:
 					{Name: "unit1"},
 				},
 			},
-			fileUnits: map[string]string{"deployment.yaml": `apiVersion: apps/v1
-kind: Deployment
-spec:
-  replicas: 3
-  selector:
-  matchLabels:
-    app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
-			},
+			fileUnits: map[string]string{
+				"deployment.yaml": testutil.UnIndent(`
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    spec:
+                      replicas: 3
+                      selector:
+                      matchLabels:
+                        app: nginx
+                      template:
+                        metadata:
+                          labels:
+                            app: nginx
+                        spec:
+                          containers:
+                          - name: nginx
+                            image: nginx:1.14.2`)},
 			want: []TestUnit{
 				{
 					name:           "unit1",
@@ -86,12 +90,13 @@ spec:
 					{Name: "unit1"},
 				},
 			},
-			fileUnits: map[string]string{"ServiceAccount.yaml": `apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: release-name-nginx-ingress
-  namespace: default`,
-			},
+			fileUnits: map[string]string{
+				"ServiceAccount.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: ServiceAccount
+                    metadata:
+                      name: release-name-nginx-ingress
+                      namespace: default`)},
 			want: []TestUnit{
 				{
 					name:               "unit1",
@@ -106,16 +111,17 @@ metadata:
 					{Name: "unit1"},
 				},
 			},
-			fileUnits: map[string]string{"Service.yaml": `apiVersion: v1
-kind: Service
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 3000
-  selector:
-    execUnit: name`,
-			},
+			fileUnits: map[string]string{
+				"Service.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Service
+                    spec:
+                      ports:
+                      - port: 80
+                        protocol: TCP
+                        targetPort: 3000
+                      selector:
+                        execUnit: name`)},
 			want: []TestUnit{
 				{
 					name:        "unit1",
@@ -131,22 +137,25 @@ spec:
 					{Name: "unit2"},
 				},
 			},
-			fileUnits: map[string]string{"pod.yaml": `apiVersion: v1
-kind: Pod
-metadata:
-  name: unit1
-spec:
-  containers:
-  - name: web
-    image: nginx`,
-				"pod2.yaml": `apiVersion: v1
-kind: Pod
-metadata:
-  name: notunit2
-spec:
-  containers:
-  - name: web
-    image: nginx`},
+			fileUnits: map[string]string{
+				"pod.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      name: unit1
+                    spec:
+                      containers:
+                      - name: web
+                        image: nginx`),
+				"pod2.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      name: notunit2
+                    spec:
+                      containers:
+                      - name: web
+                        image: nginx`)},
 			want: []TestUnit{
 				{
 					name:    "unit1",
@@ -165,40 +174,43 @@ spec:
 					{Name: "unit2"},
 				},
 			},
-			fileUnits: map[string]string{"deployment.yaml": `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: unit1
-spec:
-  replicas: 3
-  selector:
-  matchLabels:
-    app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
-				"deployment2.yaml": `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: notunit2
-spec:
-  replicas: 3
-  selector:
-  matchLabels:
-    app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
+			fileUnits: map[string]string{
+				"deployment.yaml": testutil.UnIndent(`
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: unit1
+                    spec:
+                      replicas: 3
+                      selector:
+                      matchLabels:
+                        app: nginx
+                      template:
+                        metadata:
+                          labels:
+                            app: nginx
+                        spec:
+                          containers:
+                          - name: nginx
+                            image: nginx:1.14.2`),
+				"deployment2.yaml": testutil.UnIndent(`
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: notunit2
+                    spec:
+                      replicas: 3
+                      selector:
+                      matchLabels:
+                        app: nginx
+                      template:
+                        metadata:
+                          labels:
+                            app: nginx
+                        spec:
+                          containers:
+                          - name: nginx
+                            image: nginx:1.14.2`),
 			},
 			want: []TestUnit{
 				{
@@ -218,16 +230,19 @@ spec:
 					{Name: "unit2"},
 				},
 			},
-			fileUnits: map[string]string{"ServiceAccount.yaml": `apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: unit1
-  namespace: default`,
-				"ServiceAccount2.yaml": `apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: notunit2
-  namespace: default`,
+			fileUnits: map[string]string{
+				"ServiceAccount.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: ServiceAccount
+                    metadata:
+                      name: unit1
+                      namespace: default`),
+				"ServiceAccount2.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: ServiceAccount
+                    metadata:
+                      name: notunit2
+                      namespace: default`),
 			},
 			want: []TestUnit{
 				{
@@ -247,28 +262,31 @@ metadata:
 					{Name: "unit2"},
 				},
 			},
-			fileUnits: map[string]string{"Service.yaml": `apiVersion: v1
-kind: Service
-metadata:
-  name: unit1
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 3000
-  selector:
-    execUnit: name`,
-				"Service2.yaml": `apiVersion: v1
-kind: Service
-metadata:
-  name: notunit2
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 3000
-  selector:
-    execUnit: name`,
+			fileUnits: map[string]string{
+				"Service.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Service
+                    metadata:
+                      name: unit1
+                    spec:
+                      ports:
+                      - port: 80
+                        protocol: TCP
+                        targetPort: 3000
+                      selector:
+                        execUnit: name`),
+				"Service2.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Service
+                    metadata:
+                      name: notunit2
+                    spec:
+                      ports:
+                      - port: 80
+                        protocol: TCP
+                        targetPort: 3000
+                      selector:
+                        execUnit: name`),
 			},
 			want: []TestUnit{
 				{
@@ -287,27 +305,30 @@ spec:
 					{Name: "unit1"},
 				},
 			},
-			fileUnits: map[string]string{"pod.yaml": `apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: web
-    image: nginx`,
-				"deployment.yaml": `apiVersion: apps/v1
-kind: Deployment
-spec:
-  replicas: 3
-  selector:
-  matchLabels:
-    app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
+			fileUnits: map[string]string{
+				"pod.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Pod
+                    spec:
+                      containers:
+                      - name: web
+                        image: nginx`),
+				"deployment.yaml": testutil.UnIndent(`
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    spec:
+                      replicas: 3
+                      selector:
+                      matchLabels:
+                        app: nginx
+                      template:
+                        metadata:
+                          labels:
+                            app: nginx
+                        spec:
+                          containers:
+                          - name: nginx
+                            image: nginx:1.14.2`),
 			},
 			wantErr: true,
 		},
@@ -319,31 +340,34 @@ spec:
 					{Name: "unit2"},
 				},
 			},
-			fileUnits: map[string]string{"pod.yaml": `apiVersion: v1
-kind: Pod
-metadata:
-  name: unit1
-spec:
-  containers:
-  - name: web
-    image: nginx`,
-				"deployment.yaml": `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: unit1
-spec:
-  replicas: 3
-  selector:
-  matchLabels:
-    app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
+			fileUnits: map[string]string{
+				"pod.yaml": testutil.UnIndent(`
+                    apiVersion: v1
+                    kind: Pod
+                    metadata:
+                      name: unit1
+                    spec:
+                      containers:
+                      - name: web
+                        image: nginx`),
+				"deployment.yaml": testutil.UnIndent(`
+					apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      name: unit1
+                    spec:
+                      replicas: 3
+                      selector:
+                      matchLabels:
+                        app: nginx
+                      template:
+                        metadata:
+                          labels:
+                            app: nginx
+                        spec:
+                          containers:
+                          - name: nginx
+                            image: nginx:1.14.2`),
 			},
 			wantErr: true,
 		},

--- a/pkg/testutil/strings.go
+++ b/pkg/testutil/strings.go
@@ -1,0 +1,52 @@
+package testutil
+
+import "strings"
+
+// UnIndent removes a level of indentation from the given string. The rules are very simple:
+//   - first, drop any leading newlines from the string
+//   - then, find the indentation in the first line, which is defined by the leading tabs-or-spaces in that line
+//   - then, trim that prefix from all lines
+//
+// The prefix must match exactly, and this method removes it just by invoke [strings.CutPrefix] -- nothing fancier.
+// In particular, this means that if you're mixing tabs and spaces, you may find yourself in for a bad time: if the
+// first string uses "<space><tab>" and the second uses "<tab><space>", the second does not count as an indentation,
+// and won't be affected.
+//
+// You can use this to embed yaml within test code as literal strings:
+//
+//	 ...
+//	 SomeField: MyStruct {
+//	 	foo: unIndent(`
+//	 		hello: world
+//	 		counts:
+//	 		  - 1
+//	 		  - 2
+//	 		hello: world`
+//	 	),
+//	...
+//
+// The resulting string will be:
+//
+//	┌────────────┐ ◁─ no newline
+//	│hello: world│ ◁─╮
+//	│counts:     │ ◁─┤
+//	│  - 1       │ ◁─┼─ no extra indentation
+//	│  - 2       │ ◁─┤
+//	│hello: world│ ◁─╯
+//	└────────────┘
+func UnIndent(y string) string {
+	y = strings.TrimLeft(y, "\n")
+	tabsCount := 0
+	for ; tabsCount < len(y) && y[tabsCount] == '\t' || y[tabsCount] == ' '; tabsCount += 1 {
+		// nothing; the tabsCount += 1 is the side effect we want
+	}
+	prefixTabs := y[:tabsCount]
+	sb := strings.Builder{}
+	sb.Grow(len(y))
+	for _, line := range strings.Split(y, "\n") {
+		line, _ = strings.CutPrefix(line, prefixTabs)
+		sb.WriteString(line)
+		sb.WriteRune('\n')
+	}
+	return sb.String()
+}


### PR DESCRIPTION
I found the current tests pretty hard to read because of this formatting, so I took a crack at cleaning them up. I find them a lot more readable now, but if people don't like the extra indirection/transform within the test-expect, I can retract this.

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: no issues
