### PR TITLE
cloudfront for iac2

### DIFF
--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -47,7 +47,6 @@ type (
 )
 
 const (
-	ARN_IAC_VALUE                  = "arn"
-	ALL_BUCKET_DIRECTORY_IAC_VALUE = "all_bucket_directory"
-	ALL_RESOURCES_IAC_VALUE        = "*"
+	ARN_IAC_VALUE           = "arn"
+	ALL_RESOURCES_IAC_VALUE = "*"
 )

--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -91,6 +91,9 @@ func TestKnownTemplates(t *testing.T) {
 		&resources.SecurityGroup{},
 		&resources.AvailabilityZones{},
 		&resources.AccountId{},
+		&resources.CloudfrontDistribution{},
+		&resources.OriginAccessIdentity{},
+		&resources.S3BucketPolicy{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/templates/cloudfront_distribution/factory.ts
+++ b/pkg/infra/iac2/templates/cloudfront_distribution/factory.ts
@@ -1,0 +1,25 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+
+interface Args {
+    Name: string
+    Origins: pulumi.Input<aws.types.input.cloudfront.DistributionOrigin>[]
+    CloudfrontDefaultCertificate: boolean
+    Enabled: boolean
+    DefaultCacheBehavior: aws.types.input.cloudfront.DistributionDefaultCacheBehavior
+    Restrictions: aws.types.input.cloudfront.DistributionRestrictions
+    DefaultRootObject: string
+}
+
+function create(args: Args): aws.cloudfront.Distribution {
+    return new aws.cloudfront.Distribution(args.Name, {
+        origins: args.Origins,
+        enabled: args.Enabled,
+        viewerCertificate: {
+            cloudfrontDefaultCertificate: args.CloudfrontDefaultCertificate,
+        },
+        defaultCacheBehavior: args.DefaultCacheBehavior,
+        restrictions: args.Restrictions,
+        defaultRootObject: args.DefaultRootObject,
+    })
+}

--- a/pkg/infra/iac2/templates/cloudfront_distribution/package.json
+++ b/pkg/infra/iac2/templates/cloudfront_distribution/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "dynamodb_table",
+    "name": "cloudfront_distribution",
     "dependencies": {
         "@pulumi/aws": "^5.16.0",
         "@pulumi/pulumi": "^3.40.2"

--- a/pkg/infra/iac2/templates/origin_access_identity/factory.ts
+++ b/pkg/infra/iac2/templates/origin_access_identity/factory.ts
@@ -1,5 +1,4 @@
 import * as aws from '@pulumi/aws'
-import * as pulumi from '@pulumi/pulumi'
 
 interface Args {
     Name: string

--- a/pkg/infra/iac2/templates/origin_access_identity/factory.ts
+++ b/pkg/infra/iac2/templates/origin_access_identity/factory.ts
@@ -1,0 +1,14 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+
+interface Args {
+    Name: string
+    Comment: string
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.cloudfront.OriginAccessIdentity {
+    return new aws.cloudfront.OriginAccessIdentity(args.Name, {
+        comment: args.Comment,
+    })
+}

--- a/pkg/infra/iac2/templates/origin_access_identity/package.json
+++ b/pkg/infra/iac2/templates/origin_access_identity/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "origin_access_identity",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates/s3_bucket_policy/factory.ts
+++ b/pkg/infra/iac2/templates/s3_bucket_policy/factory.ts
@@ -9,7 +9,7 @@ interface Args {
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.s3.BucketPolicy {
     return new aws.s3.BucketPolicy(args.Name, {
-        bucket: args.Bucket.id, // refer to the bucket created earlier
+        bucket: args.Bucket.id,
         policy: args.Policy,
     })
 }

--- a/pkg/infra/iac2/templates/s3_bucket_policy/factory.ts
+++ b/pkg/infra/iac2/templates/s3_bucket_policy/factory.ts
@@ -1,0 +1,15 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    Bucket: aws.s3.Bucket
+    Policy: aws.iam.PolicyDocument
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.s3.BucketPolicy {
+    return new aws.s3.BucketPolicy(args.Name, {
+        bucket: args.Bucket.id, // refer to the bucket created earlier
+        policy: args.Policy,
+    })
+}

--- a/pkg/infra/iac2/templates/s3_bucket_policy/package.json
+++ b/pkg/infra/iac2/templates/s3_bucket_policy/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "s3_bucket_policy",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates/vpc/factory.ts
+++ b/pkg/infra/iac2/templates/vpc/factory.ts
@@ -13,5 +13,8 @@ function create(args: Args): aws.ec2.Vpc {
         cidrBlock: args.CidrBlock,
         enableDnsHostnames: args.EnableDnsHostnames,
         enableDnsSupport: args.EnableDnsSupport,
+        tags: {
+            Name: args.Name,
+        },
     })
 }

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -55,7 +55,7 @@ func TestOutputBody(t *testing.T) {
 			"				fizzMyHello,",
 			"				{",
 			"					buzz: buzzShared,",
-			"					nestedDoc: {Fizz: fizzMyHello,",
+			"					nestedDoc: {fizz: fizzMyHello,",
 			"}",
 			"					nestedTemplate: ",
 			"		{",

--- a/pkg/provider/aws/content_delivery_network.go
+++ b/pkg/provider/aws/content_delivery_network.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/pkg/errors"
+)
+
+// createCDNs is responsible for generating resources for any constructs who have an id set for their content delivery network.
+//
+// Each constructs config will be read to determine its cdnId and will be grouped behind the same cdn if the id matches.
+func (a *AWS) createCDNs(result *core.ConstructGraph, dag *core.ResourceGraph) error {
+	cloudfrontMap := make(map[string][]core.Construct)
+	for _, res := range result.ListConstructs() {
+		switch construct := res.(type) {
+		case *core.Gateway:
+			cfg := a.Config.GetExpose(construct.ID)
+			cfId := cfg.ContentDeliveryNetwork.Id
+			if cfId != "" {
+				cf, ok := cloudfrontMap[cfId]
+				if ok {
+					cloudfrontMap[cfId] = append(cf, res)
+				} else {
+					cloudfrontMap[cfId] = []core.Construct{res}
+				}
+			}
+		case *core.StaticUnit:
+			cfg := a.Config.GetStaticUnit(construct.ID)
+			cfId := cfg.ContentDeliveryNetwork.Id
+			if cfId != "" {
+				cf, ok := cloudfrontMap[cfId]
+				if ok {
+					cloudfrontMap[cfId] = append(cf, res)
+				} else {
+					cloudfrontMap[cfId] = []core.Construct{res}
+				}
+			}
+		}
+	}
+
+	for name, keys := range cloudfrontMap {
+		distro := resources.NewCloudfrontDistribution(a.Config.AppName, name)
+		for _, construct := range keys {
+			switch construct := construct.(type) {
+			case *core.Gateway:
+				res, found := a.GetResourcesDirectlyTiedToConstruct(construct)
+				if !found {
+					return errors.Errorf("Could not find any resource mapped to gateway %s", construct.ID)
+				}
+				var apiStage *resources.ApiStage
+				for _, r := range res {
+					if stage, ok := r.(*resources.ApiStage); ok {
+						apiStage = stage
+					}
+				}
+				if apiStage == nil {
+					return errors.Errorf("Could not find an api stage mapped to gateway %s", construct.ID)
+				}
+				dag.AddDependency2(distro, apiStage)
+				distro.DefaultCacheBehavior.DefaultTtl = 0
+				resources.CreateCustomOrigin(construct, apiStage, distro)
+				distro.ConstructsRef = append(distro.ConstructsRef, construct.Provenance())
+			case *core.StaticUnit:
+				res, found := a.GetResourcesDirectlyTiedToConstruct(construct)
+				if !found {
+					return errors.Errorf("Could not find any resource mapped to static unit %s", construct.ID)
+				}
+				var bucket *resources.S3Bucket
+				for _, r := range res {
+					if b, ok := r.(*resources.S3Bucket); ok {
+						bucket = b
+					}
+				}
+				if bucket == nil {
+					return errors.Errorf("Could not find an api stage mapped to gateway %s", construct.ID)
+				}
+				dag.AddDependency2(distro, bucket)
+				distro.DefaultRootObject = bucket.IndexDocument
+				resources.CreateS3Origin(construct, bucket, distro, dag)
+				distro.ConstructsRef = append(distro.ConstructsRef, construct.Provenance())
+			}
+		}
+		dag.AddDependenciesReflect(distro)
+	}
+	return nil
+}

--- a/pkg/provider/aws/content_delivery_network_test.go
+++ b/pkg/provider/aws/content_delivery_network_test.go
@@ -1,0 +1,184 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/core/coretesting"
+	"github.com/klothoplatform/klotho/pkg/graph"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_createCDNs(t *testing.T) {
+	appName := "test"
+	cdn1 := "cdn"
+	cdn2 := "otherCdn"
+	su := &core.StaticUnit{AnnotationKey: core.AnnotationKey{ID: "su"}}
+	gw := &core.Gateway{AnnotationKey: core.AnnotationKey{ID: "gw"}}
+	distro := resources.NewCloudfrontDistribution(appName, cdn1)
+	distro2 := resources.NewCloudfrontDistribution(appName, cdn2)
+
+	cases := []struct {
+		name                   string
+		constructs             []core.Construct
+		constructIdToResources map[string][]core.Resource
+		cfg                    config.Application
+		want                   coretesting.ResourcesExpectation
+		wantRefs               map[string][]core.AnnotationKey
+		wantErr                bool
+	}{
+		{
+			name: "single static unit",
+			constructs: []core.Construct{
+				su,
+			},
+			constructIdToResources: map[string][]core.Resource{
+				su.Id(): {
+					resources.NewS3Bucket(su, appName),
+				},
+			},
+			cfg: config.Application{
+				StaticUnit: map[string]*config.StaticUnit{
+					su.ID: {
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: cdn1},
+					},
+				},
+				AppName: appName,
+			},
+			want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:cloudfront_distribution:test-cdn",
+					"aws:cloudfront_origin_access_identity:test-su-su",
+					"aws:s3_bucket:test-su",
+					"aws:s3_bucket_policy:test-su-su",
+				},
+				Deps: []graph.Edge[string]{
+					{Source: "aws:cloudfront_distribution:test-cdn", Destination: "aws:cloudfront_origin_access_identity:test-su-su"},
+					{Source: "aws:cloudfront_distribution:test-cdn", Destination: "aws:s3_bucket:test-su"},
+					{Source: "aws:s3_bucket_policy:test-su-su", Destination: "aws:cloudfront_origin_access_identity:test-su-su"},
+					{Source: "aws:s3_bucket_policy:test-su-su", Destination: "aws:s3_bucket:test-su"},
+				},
+			},
+			wantRefs: map[string][]core.AnnotationKey{
+				distro.Id(): {su.Provenance()},
+			},
+		},
+		{
+			name: "single expose",
+			constructs: []core.Construct{
+				gw,
+			},
+			constructIdToResources: map[string][]core.Resource{
+				gw.Id(): {
+					resources.NewApiStage(resources.NewApiDeployment(resources.NewRestApi(appName, gw), nil, nil), "stage", nil),
+				},
+			},
+			cfg: config.Application{
+				Exposed: map[string]*config.Expose{
+					gw.ID: {
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: cdn1},
+					},
+				},
+				AppName: appName,
+			},
+			want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:api_stage:test-gw-stage",
+					"aws:cloudfront_distribution:test-cdn",
+				},
+				Deps: []graph.Edge[string]{
+					{Source: "aws:cloudfront_distribution:test-cdn", Destination: "aws:api_stage:test-gw-stage"},
+				},
+			},
+			wantRefs: map[string][]core.AnnotationKey{
+				distro.Id(): {gw.Provenance()},
+			},
+		},
+		{
+			name: "multiple cdns",
+			constructs: []core.Construct{
+				gw, su,
+			},
+			constructIdToResources: map[string][]core.Resource{
+				gw.Id(): {
+					resources.NewApiStage(resources.NewApiDeployment(resources.NewRestApi(appName, gw), nil, nil), "stage", nil),
+				},
+				su.Id(): {
+					resources.NewS3Bucket(su, appName),
+				},
+			},
+			cfg: config.Application{
+				StaticUnit: map[string]*config.StaticUnit{
+					su.ID: {
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: cdn1},
+					},
+				},
+				Exposed: map[string]*config.Expose{
+					gw.ID: {
+						ContentDeliveryNetwork: config.ContentDeliveryNetwork{Id: cdn2},
+					},
+				},
+				AppName: appName,
+			},
+			want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:api_stage:test-gw-stage",
+					"aws:cloudfront_distribution:test-cdn",
+					"aws:cloudfront_distribution:test-otherCdn",
+					"aws:cloudfront_origin_access_identity:test-su-su",
+					"aws:s3_bucket:test-su",
+					"aws:s3_bucket_policy:test-su-su",
+				},
+				Deps: []graph.Edge[string]{
+					{Source: "aws:cloudfront_distribution:test-cdn", Destination: "aws:cloudfront_origin_access_identity:test-su-su"},
+					{Source: "aws:cloudfront_distribution:test-cdn", Destination: "aws:s3_bucket:test-su"},
+					{Source: "aws:cloudfront_distribution:test-otherCdn", Destination: "aws:api_stage:test-gw-stage"},
+					{Source: "aws:s3_bucket_policy:test-su-su", Destination: "aws:cloudfront_origin_access_identity:test-su-su"},
+					{Source: "aws:s3_bucket_policy:test-su-su", Destination: "aws:s3_bucket:test-su"},
+				},
+			},
+			wantRefs: map[string][]core.AnnotationKey{
+				distro.Id():  {su.Provenance()},
+				distro2.Id(): {gw.Provenance()},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			aws := AWS{
+				Config:                 &tt.cfg,
+				constructIdToResources: tt.constructIdToResources,
+			}
+			dag := core.NewResourceGraph()
+
+			for _, resources := range tt.constructIdToResources {
+				for _, res := range resources {
+					dag.AddResource(res)
+				}
+			}
+			result := core.NewConstructGraph()
+			for _, unit := range tt.constructs {
+				result.AddConstruct(unit)
+			}
+
+			err := aws.createCDNs(result, dag)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			if !assert.NoError(err) {
+				return
+			}
+
+			tt.want.Assert(t, dag)
+
+			for key, val := range tt.wantRefs {
+				assert.ElementsMatch(val, dag.GetResource(key).KlothoConstructRef())
+			}
+		})
+
+	}
+}

--- a/pkg/provider/aws/expose.go
+++ b/pkg/provider/aws/expose.go
@@ -120,6 +120,8 @@ func (a *AWS) CreateRestApi(gateway *core.Gateway, result *core.ConstructGraph, 
 
 	stage := resources.NewApiStage(deployment, "stage", api_references)
 	dag.AddDependenciesReflect(stage)
+	a.MapResourceDirectlyToConstruct(stage, gateway)
+	a.MapResourceDirectlyToConstruct(api, gateway)
 	return errs.ErrOrNil()
 }
 

--- a/pkg/provider/aws/expose_test.go
+++ b/pkg/provider/aws/expose_test.go
@@ -233,6 +233,9 @@ func Test_CreateRestApi(t *testing.T) {
 			}
 
 			tt.want.Assert(t, dag)
+			resources, found := aws.GetResourcesDirectlyTiedToConstruct(tt.gw)
+			assert.True(found)
+			assert.Len(resources, 2)
 		})
 
 	}

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -16,7 +16,7 @@ func (a *AWS) GenerateFsResources(construct *core.Fs, result *core.ConstructGrap
 			actions := []string{"s3:*"}
 			policyResources := []core.IaCValue{
 				{Resource: bucket, Property: core.ARN_IAC_VALUE},
-				{Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE},
+				{Resource: bucket, Property: resources.ALL_BUCKET_DIRECTORY_IAC_VALUE},
 			}
 			policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
 			policy := resources.NewIamPolicy(a.Config.AppName, construct.Id(), construct.Provenance(), policyDoc)

--- a/pkg/provider/aws/persist_test.go
+++ b/pkg/provider/aws/persist_test.go
@@ -18,7 +18,7 @@ func Test_GenerateFsResources(t *testing.T) {
 	actions := []string{"s3:*"}
 	policyResources := []core.IaCValue{
 		{Resource: bucket, Property: core.ARN_IAC_VALUE},
-		{Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE},
+		{Resource: bucket, Property: resources.ALL_BUCKET_DIRECTORY_IAC_VALUE},
 	}
 	policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
 	policy := resources.NewIamPolicy("test", fs.Id(), fs.Provenance(), policyDoc)
@@ -114,7 +114,7 @@ func Test_GenerateFsResources(t *testing.T) {
 						if val.Property == core.ARN_IAC_VALUE {
 							foundArnVal = true
 						}
-						if val.Property == core.ALL_BUCKET_DIRECTORY_IAC_VALUE {
+						if val.Property == resources.ALL_BUCKET_DIRECTORY_IAC_VALUE {
 							foundDirVal = true
 						}
 					}

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -55,6 +55,10 @@ func (a *AWS) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (l
 	if err != nil {
 		return
 	}
+	err = a.createCDNs(result, dag)
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/pkg/provider/aws/resources/api_gateway.go
+++ b/pkg/provider/aws/resources/api_gateway.go
@@ -18,6 +18,7 @@ const (
 
 	LAMBDA_INTEGRATION_URI_IAC_VALUE = "lambda_integration_uri"
 	ALL_RESOURCES_ARN_IAC_VALUE      = "all_resources_arn"
+	STAGE_INVOKE_URL_IAC_VALUE       = "stage_invoke_url"
 )
 
 var restApiSanitizer = aws.RestApiSanitizer

--- a/pkg/provider/aws/resources/cloudfront.go
+++ b/pkg/provider/aws/resources/cloudfront.go
@@ -1,30 +1,204 @@
 package resources
 
 import (
+	"fmt"
+
 	"github.com/klothoplatform/klotho/pkg/core"
-	"go.uber.org/zap"
+	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
 )
 
-type CloudfrontDistribution struct {
-	Id                string
-	Origins           []core.AnnotationKey
-	DefaultRootObject string
+var cloudfrontDistributionSanitizer = aws.CloudfrontDistributionSanitizer
+
+const (
+	CLOUDFRONT_DISTRIBUTION_TYPE = "cloudfront_distribution"
+	ORIGIN_ACCESS_IDENTITY_TYPE  = "cloudfront_origin_access_identity"
+)
+
+type (
+	CloudfrontDistribution struct {
+		Name                         string
+		ConstructsRef                []core.AnnotationKey
+		Origins                      []*CloudfrontOrigin `render:"document"`
+		CloudfrontDefaultCertificate bool
+		Enabled                      bool
+		DefaultCacheBehavior         *DefaultCacheBehavior `render:"document"`
+		Restrictions                 *Restrictions         `render:"document"`
+		DefaultRootObject            string
+	}
+
+	DefaultCacheBehavior struct {
+		AllowedMethods       []string
+		CachedMethods        []string
+		TargetOriginId       string
+		ForwardedValues      ForwardedValues `render:"document"`
+		MinTtl               int
+		DefaultTtl           int
+		MaxTtl               int
+		ViewerProtocolPolicy string
+	}
+
+	ForwardedValues struct {
+		QueryString bool
+		Cookies     Cookies `render:"document"`
+	}
+
+	Cookies struct {
+		Forward string
+	}
+
+	Restrictions struct {
+		GeoRestriction GeoRestriction `render:"document"`
+	}
+
+	GeoRestriction struct {
+		RestrictionType string
+	}
+
+	CloudfrontOrigin struct {
+		DomainName         core.IaCValue
+		OriginId           string
+		OriginPath         string
+		S3OriginConfig     S3OriginConfig     `render:"document"`
+		CustomOriginConfig CustomOriginConfig `render:"document"`
+	}
+
+	S3OriginConfig struct {
+		OriginAccessIdentity core.IaCValue
+	}
+
+	CustomOriginConfig struct {
+		HttpPort             int
+		HttpsPort            int
+		OriginProtocolPolicy string
+		OriginSslProtocols   []string
+	}
+
+	OriginAccessIdentity struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		Comment       string
+	}
+)
+
+// CreateS3Origin creates an origin for a static unit, given its bucket, and attaches it to the Cloudfront distribution passed in
+func CreateS3Origin(unit *core.StaticUnit, bucket *S3Bucket, distribution *CloudfrontDistribution, dag *core.ResourceGraph) {
+
+	oai := &OriginAccessIdentity{
+		Name:          fmt.Sprintf("%s-%s", bucket.Name, unit.ID),
+		ConstructsRef: []core.AnnotationKey{unit.AnnotationKey},
+		Comment:       "this is needed to setup s3 polices and make s3 not public.",
+	}
+
+	policyDoc := &PolicyDocument{
+		Version: VERSION,
+		Statement: []StatementEntry{
+			{
+				Effect: "Allow",
+				Principal: &Principal{
+					AWS: core.IaCValue{
+						Resource: oai,
+						Property: core.ARN_IAC_VALUE,
+					},
+				},
+				Action: []string{"s3:GetObject"},
+				Resource: []core.IaCValue{
+					{
+						Resource: bucket,
+						Property: ALL_BUCKET_DIRECTORY_IAC_VALUE,
+					},
+				},
+			},
+		},
+	}
+	bucketPolicy := NewBucketPolicy(unit.ID, bucket, policyDoc)
+	dag.AddDependency2(bucketPolicy, oai)
+	dag.AddDependency2(distribution, oai)
+	dag.AddDependency2(bucketPolicy, bucket)
+	s3OriginConfig := S3OriginConfig{
+		OriginAccessIdentity: core.IaCValue{
+			Resource: oai,
+		},
+	}
+	origin := &CloudfrontOrigin{
+		S3OriginConfig: s3OriginConfig,
+		DomainName: core.IaCValue{
+			Resource: bucket,
+			Property: BUCKET_REGIONAL_DOMAIN_NAME_IAC_VALUE,
+		},
+		OriginId: unit.ID,
+	}
+	distribution.Origins = append(distribution.Origins, origin)
+	distribution.DefaultCacheBehavior.TargetOriginId = origin.OriginId
 }
 
-func CreateCloudfrontDistribution(resources []core.Construct) *CloudfrontDistribution {
-	distribution := &CloudfrontDistribution{}
-
-	for _, res := range resources {
-		switch construct := res.(type) {
-		case *core.Gateway:
-			distribution.Origins = append(distribution.Origins, res.Provenance())
-		case *core.StaticUnit:
-			distribution.Origins = append(distribution.Origins, res.Provenance())
-			if distribution.DefaultRootObject != "" {
-				zap.S().Warn("Cannot have a cdn with multiple root objects")
-			}
-			distribution.DefaultRootObject = construct.IndexDocument
-		}
+// CreateCustomOrigin creates an origin for a gateway, given its api stage, and attaches it to the Cloudfront distribution passed in
+func CreateCustomOrigin(gw *core.Gateway, apiStage *ApiStage, distribution *CloudfrontDistribution) {
+	origin := &CloudfrontOrigin{
+		CustomOriginConfig: CustomOriginConfig{
+			HttpPort:             80,
+			HttpsPort:            443,
+			OriginProtocolPolicy: "https-only",
+			OriginSslProtocols:   []string{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"},
+		},
+		DomainName: core.IaCValue{
+			Resource: apiStage,
+			Property: STAGE_INVOKE_URL_IAC_VALUE,
+		},
+		OriginId:   gw.ID,
+		OriginPath: fmt.Sprintf("/%s", apiStage.StageName),
 	}
-	return distribution
+	distribution.Origins = append(distribution.Origins, origin)
+	distribution.DefaultCacheBehavior.TargetOriginId = origin.OriginId
+}
+
+func NewCloudfrontDistribution(appName string, cdnId string) *CloudfrontDistribution {
+	return &CloudfrontDistribution{
+		Name: cloudfrontDistributionSanitizer.Apply(fmt.Sprintf("%s-%s", appName, cdnId)),
+		DefaultCacheBehavior: &DefaultCacheBehavior{
+			AllowedMethods: []string{"DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"},
+			CachedMethods:  []string{"HEAD", "GET"},
+			ForwardedValues: ForwardedValues{
+				QueryString: true,
+				Cookies:     Cookies{Forward: "none"},
+			},
+			MinTtl:               0,
+			DefaultTtl:           3600,
+			MaxTtl:               86400,
+			ViewerProtocolPolicy: "allow-all",
+		},
+		Restrictions: &Restrictions{
+			GeoRestriction: GeoRestriction{RestrictionType: "none"},
+		},
+		CloudfrontDefaultCertificate: true,
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (distro *CloudfrontDistribution) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (distro *CloudfrontDistribution) KlothoConstructRef() []core.AnnotationKey {
+	return distro.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (distro *CloudfrontDistribution) Id() string {
+	return fmt.Sprintf("%s:%s:%s", distro.Provider(), CLOUDFRONT_DISTRIBUTION_TYPE, distro.Name)
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (oai *OriginAccessIdentity) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (oai *OriginAccessIdentity) KlothoConstructRef() []core.AnnotationKey {
+	return oai.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (oai *OriginAccessIdentity) Id() string {
+	return fmt.Sprintf("%s:%s:%s", oai.Provider(), ORIGIN_ACCESS_IDENTITY_TYPE, oai.Name)
 }

--- a/pkg/provider/aws/resources/cloudfront_test.go
+++ b/pkg/provider/aws/resources/cloudfront_test.go
@@ -1,0 +1,94 @@
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CreateS3Origin(t *testing.T) {
+
+	unit := &core.StaticUnit{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	bucket := NewS3Bucket(&core.Fs{AnnotationKey: core.AnnotationKey{ID: "bucket"}}, "test")
+	distro := NewCloudfrontDistribution("test", "1")
+
+	assert := assert.New(t)
+	dag := core.NewResourceGraph()
+	CreateS3Origin(unit, bucket, distro, dag)
+
+	assert.NotNil(dag.GetDependency("aws:s3_bucket_policy:test-bucket-test", "aws:cloudfront_origin_access_identity:test-bucket-test"))
+	assert.NotNil(dag.GetDependency("aws:s3_bucket_policy:test-bucket-test", "aws:s3_bucket:test-bucket"))
+	assert.NotNil(dag.GetDependency("aws:cloudfront_distribution:test-1", "aws:cloudfront_origin_access_identity:test-bucket-test"))
+
+	oai := dag.GetResource(fmt.Sprintf("aws:cloudfront_origin_access_identity:%s-%s", bucket.Name, unit.ID))
+	if !assert.NotNil(oai) {
+		return
+	}
+	res := dag.GetResource(fmt.Sprintf("aws:s3_bucket_policy:%s-%s", bucket.Name, unit.ID))
+	if !assert.NotNil(res) {
+		return
+	}
+	bucketPolicy, ok := res.(*S3BucketPolicy)
+	if !ok {
+		assert.True(ok)
+		return
+	}
+
+	assert.Equal(bucketPolicy.Policy.Statement[0], StatementEntry{
+		Effect: "Allow",
+		Principal: &Principal{
+			AWS: core.IaCValue{
+				Resource: oai,
+				Property: core.ARN_IAC_VALUE,
+			},
+		},
+		Action: []string{"s3:GetObject"},
+		Resource: []core.IaCValue{
+			{
+				Resource: bucket,
+				Property: ALL_BUCKET_DIRECTORY_IAC_VALUE,
+			},
+		},
+	})
+
+	assert.Len(distro.Origins, 1)
+	s3Origin := distro.Origins[0]
+	assert.Equal(s3Origin.DomainName, core.IaCValue{
+		Resource: bucket,
+		Property: BUCKET_REGIONAL_DOMAIN_NAME_IAC_VALUE,
+	})
+	assert.Equal(s3Origin.OriginId, unit.ID)
+	assert.Equal(s3Origin.S3OriginConfig, S3OriginConfig{
+		OriginAccessIdentity: core.IaCValue{
+			Resource: oai,
+		},
+	})
+
+}
+
+func Test_CreateCustomOrigin(t *testing.T) {
+	gw := &core.Gateway{AnnotationKey: core.AnnotationKey{ID: "test"}}
+	apiStage := NewApiStage(NewApiDeployment(NewRestApi("test", gw), nil, nil), "stage", nil)
+	distro := NewCloudfrontDistribution("test", "1")
+
+	assert := assert.New(t)
+	CreateCustomOrigin(gw, apiStage, distro)
+
+	assert.Len(distro.Origins, 1)
+	customOrigin := distro.Origins[0]
+
+	assert.Equal(customOrigin.CustomOriginConfig, CustomOriginConfig{
+		HttpPort:             80,
+		HttpsPort:            443,
+		OriginProtocolPolicy: "https-only",
+		OriginSslProtocols:   []string{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"},
+	})
+	assert.Equal(customOrigin.DomainName, core.IaCValue{
+		Resource: apiStage,
+		Property: STAGE_INVOKE_URL_IAC_VALUE,
+	})
+	assert.Equal(customOrigin.OriginPath, "/"+apiStage.StageName)
+	assert.Equal(customOrigin.OriginId, gw.ID)
+}

--- a/pkg/provider/aws/resources/cloudfront_test.go
+++ b/pkg/provider/aws/resources/cloudfront_test.go
@@ -31,8 +31,7 @@ func Test_CreateS3Origin(t *testing.T) {
 		return
 	}
 	bucketPolicy, ok := res.(*S3BucketPolicy)
-	if !ok {
-		assert.True(ok)
+	if !assert.True(ok) {
 		return
 	}
 

--- a/pkg/provider/aws/resources/iam.go
+++ b/pkg/provider/aws/resources/iam.go
@@ -120,6 +120,7 @@ type (
 	Principal struct {
 		Service   string
 		Federated core.IaCValue
+		AWS       core.IaCValue
 	}
 
 	Condition struct {

--- a/pkg/provider/aws/resources/iam_test.go
+++ b/pkg/provider/aws/resources/iam_test.go
@@ -22,11 +22,11 @@ func Test_AddAllowPolicyToUnit(t *testing.T) {
 			name:             "Add policy, none exists",
 			existingPolicies: map[string][]*IamPolicy{},
 			actions:          []string{"s3:*"},
-			resource:         []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE}},
+			resource:         []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: ALL_BUCKET_DIRECTORY_IAC_VALUE}},
 			want: StatementEntry{
 				Effect:   "Allow",
 				Action:   []string{"s3:*"},
-				Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE}},
+				Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: ALL_BUCKET_DIRECTORY_IAC_VALUE}},
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func Test_AddAllowPolicyToUnit(t *testing.T) {
 								{
 									Effect:   "Allow",
 									Action:   []string{"dynamodb:*"},
-									Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE}},
+									Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: ALL_BUCKET_DIRECTORY_IAC_VALUE}},
 								},
 							},
 						},
@@ -49,11 +49,11 @@ func Test_AddAllowPolicyToUnit(t *testing.T) {
 				},
 			},
 			actions:  []string{"s3:*"},
-			resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE}},
+			resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: ALL_BUCKET_DIRECTORY_IAC_VALUE}},
 			want: StatementEntry{
 				Effect:   "Allow",
 				Action:   []string{"dynamodb:*"},
-				Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: core.ALL_BUCKET_DIRECTORY_IAC_VALUE}},
+				Resource: []core.IaCValue{{Resource: bucket, Property: core.ARN_IAC_VALUE}, {Resource: bucket, Property: ALL_BUCKET_DIRECTORY_IAC_VALUE}},
 			},
 		},
 	}

--- a/pkg/provider/aws/resources/s3.go
+++ b/pkg/provider/aws/resources/s3.go
@@ -11,8 +11,12 @@ var objectSanitizer = aws.S3ObjectSanitizer
 var bucketSanitizer = aws.S3BucketSanitizer
 
 const (
-	S3_BUCKET_TYPE = "s3_bucket"
-	S3_OBJECT_TYPE = "s3_object"
+	S3_BUCKET_TYPE        = "s3_bucket"
+	S3_OBJECT_TYPE        = "s3_object"
+	S3_BUCKET_POLICY_TYPE = "s3_bucket_policy"
+
+	ALL_BUCKET_DIRECTORY_IAC_VALUE        = "all_bucket_directory"
+	BUCKET_REGIONAL_DOMAIN_NAME_IAC_VALUE = "bucket_regional_domain_name"
 )
 
 type (
@@ -29,6 +33,13 @@ type (
 		Bucket        *S3Bucket
 		Key           string
 		FilePath      string
+	}
+
+	S3BucketPolicy struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		Bucket        *S3Bucket
+		Policy        *PolicyDocument `render:"document"`
 	}
 )
 
@@ -78,4 +89,28 @@ func (object *S3Object) KlothoConstructRef() []core.AnnotationKey {
 // ID returns the id of the cloud resource
 func (object *S3Object) Id() string {
 	return fmt.Sprintf("%s:%s:%s", object.Provider(), S3_OBJECT_TYPE, object.Name)
+}
+
+func NewBucketPolicy(policyName string, bucket *S3Bucket, policy *PolicyDocument) *S3BucketPolicy {
+	return &S3BucketPolicy{
+		Name:          objectSanitizer.Apply(fmt.Sprintf("%s-%s", bucket.Name, policyName)),
+		ConstructsRef: bucket.KlothoConstructRef(),
+		Policy:        policy,
+		Bucket:        bucket,
+	}
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (policy *S3BucketPolicy) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (policy *S3BucketPolicy) KlothoConstructRef() []core.AnnotationKey {
+	return policy.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (policy *S3BucketPolicy) Id() string {
+	return fmt.Sprintf("%s:%s:%s", policy.Provider(), S3_BUCKET_POLICY_TYPE, policy.Name)
 }

--- a/pkg/provider/aws/static_unit.go
+++ b/pkg/provider/aws/static_unit.go
@@ -16,6 +16,8 @@ func (a *AWS) GenerateStaticUnitResources(unit *core.StaticUnit, dag *core.Resou
 		object := resources.NewS3Object(bucket, filepath.Base(f.Path()), f.Path(), filepath.Join(unit.ID, f.Path()))
 		dag.AddResource(object)
 		dag.AddDependency2(object, bucket)
+		a.MapResourceDirectlyToConstruct(object, unit)
 	}
+	a.MapResourceDirectlyToConstruct(bucket, unit)
 	return nil
 }

--- a/pkg/provider/aws/static_unit_test.go
+++ b/pkg/provider/aws/static_unit_test.go
@@ -1,11 +1,13 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/core/coretesting"
 	"github.com/klothoplatform/klotho/pkg/graph"
 	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 	"github.com/stretchr/testify/assert"
@@ -15,39 +17,27 @@ func Test_GenerateStaticUnitResources(t *testing.T) {
 	unit := &core.StaticUnit{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}}
 	unit.AddSharedFile(&core.FileRef{FPath: "test/Shared"})
 	unit.AddStaticFile(&core.FileRef{FPath: "test/Static"})
-	bucket := resources.NewS3Bucket(unit, "test-app")
-	obj1 := resources.NewS3Object(bucket, "Shared", "test/Shared", "test/test/Shared")
-	obj2 := resources.NewS3Object(bucket, "Static", "test/Static", "test/test/Static")
-
-	type testResult struct {
-		nodes []core.Resource
-		deps  []graph.Edge[core.Resource]
-		err   bool
-	}
 	cases := []struct {
 		name          string
 		indexDocument string
 		cfg           config.Application
-		want          testResult
+		want          coretesting.ResourcesExpectation
+		wantErr       bool
 	}{
 		{
 			name: "generate static unit with no index document",
 			cfg: config.Application{
 				AppName: "test-app",
 			},
-			want: testResult{
-				nodes: []core.Resource{
-					bucket, obj1, obj2,
+			want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:s3_bucket:test-app-test",
+					"aws:s3_object:test-app-test-Shared",
+					"aws:s3_object:test-app-test-Static",
 				},
-				deps: []graph.Edge[core.Resource]{
-					{
-						Source:      obj1,
-						Destination: obj1.Bucket,
-					},
-					{
-						Source:      obj2,
-						Destination: obj2.Bucket,
-					},
+				Deps: []graph.Edge[string]{
+					{Source: "aws:s3_object:test-app-test-Shared", Destination: "aws:s3_bucket:test-app-test"},
+					{Source: "aws:s3_object:test-app-test-Static", Destination: "aws:s3_bucket:test-app-test"},
 				},
 			},
 		},
@@ -57,19 +47,15 @@ func Test_GenerateStaticUnitResources(t *testing.T) {
 				AppName: "test-app",
 			},
 			indexDocument: "index.html",
-			want: testResult{
-				nodes: []core.Resource{
-					bucket, obj1, obj2,
+			want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:s3_bucket:test-app-test",
+					"aws:s3_object:test-app-test-Shared",
+					"aws:s3_object:test-app-test-Static",
 				},
-				deps: []graph.Edge[core.Resource]{
-					{
-						Source:      obj1,
-						Destination: obj1.Bucket,
-					},
-					{
-						Source:      obj2,
-						Destination: obj2.Bucket,
-					},
+				Deps: []graph.Edge[string]{
+					{Source: "aws:s3_object:test-app-test-Shared", Destination: "aws:s3_bucket:test-app-test"},
+					{Source: "aws:s3_object:test-app-test-Static", Destination: "aws:s3_bucket:test-app-test"},
 				},
 			},
 		},
@@ -84,36 +70,27 @@ func Test_GenerateStaticUnitResources(t *testing.T) {
 			unit.IndexDocument = tt.indexDocument
 
 			err := aws.GenerateStaticUnitResources(unit, dag)
-			if tt.want.err {
+			if tt.wantErr {
 				assert.Error(err)
 				return
 			}
 			if !assert.NoError(err) {
 				return
 			}
-			for _, node := range tt.want.nodes {
-				found := false
-				for _, res := range dag.ListResources() {
-					if res.Id() == node.Id() {
-						found = true
-					}
-					if res.Id() == bucket.Id() {
-						if b, ok := res.(*resources.S3Bucket); ok {
-							assert.Equal(b.IndexDocument, tt.indexDocument)
-						}
-					}
-				}
-				assert.True(found)
-			}
 
-			for _, dep := range tt.want.deps {
-				found := false
-				for _, res := range dag.ListDependencies() {
-					if res.Source.Id() == dep.Source.Id() && res.Destination.Id() == dep.Destination.Id() {
-						found = true
-					}
+			fmt.Println(coretesting.ResoucesFromDAG(dag).GoString())
+			tiedResources, found := aws.GetResourcesDirectlyTiedToConstruct(unit)
+			assert.True(found)
+			mappedIds := []string{}
+			for _, res := range tiedResources {
+				mappedIds = append(mappedIds, res.Id())
+			}
+			assert.ElementsMatch(tt.want.Nodes, mappedIds)
+			for _, res := range dag.ListResources() {
+				if bucket, ok := res.(*resources.S3Bucket); ok {
+					assert.Equal(bucket.IndexDocument, tt.indexDocument)
+
 				}
-				assert.True(found)
 			}
 		})
 

--- a/pkg/sanitization/aws/cloudfront.go
+++ b/pkg/sanitization/aws/cloudfront.go
@@ -1,0 +1,17 @@
+package aws
+
+import (
+	"regexp"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
+)
+
+// ApiResourceSanitizer returns a sanitized api resource name key when applied.
+var CloudfrontDistributionSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
+		// strip any leading non alpha characters
+		{
+			Pattern:     regexp.MustCompile(`[^a-zA-Z0-9_-]+`),
+			Replacement: "-",
+		},
+	}, 64)


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? #422 and #423 

This adds the following IRs and factories:
- Cloudfront Distribution
- Cloudfront Origin Access Identity
- S3 Bucket Policy
- 
Which gives us the ability to:
- Front an api gateway stage with cloudfront(expose)
- Front an s3 bucket with cloudfront(static unit)

Until we understand how to do path based routing on the identities we can only support a single origin behind cloudfront, which was our previous and now current state.


```
     pulumi:pulumi:Stack             ts-re-test
 +   └─ aws:cloudfront:Distribution  ts-re-cdn1  created (233s)

```

### Standard checks

- **Unit tests**: Any special considerations? added for newly added functions and remodeled the static unit one to use the new coretesting lib
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
