### PR TITLE
k8s configuration: for cpu and memory limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
+	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/tools v0.7.0
@@ -35,6 +36,7 @@ require (
 )
 
 require (
+	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
@@ -147,8 +149,8 @@ require (
 	google.golang.org/genproto v0.0.0-20230113154510-dbe35b8444a5 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/apiserver v0.26.0 // indirect
 	k8s.io/cli-runtime v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dominikbraun/graph v0.16.1 h1:ZtzDQFo32vxwSUsK4ioX8bfE45xoh8hQfavFMlKpaC8=
 github.com/dominikbraun/graph v0.16.1/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
+github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 h1:aRd8M7HJVZOqn/vhOzrGcQH0lNAMkqMn+pXUYkatmcA=
+github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
@@ -554,6 +556,7 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
@@ -646,6 +649,7 @@ github.com/schollz/progressbar/v3 v3.13.0 h1:9TeeWRcjW2qd05I8Kf9knPkW4vLM/hYoa6z
 github.com/schollz/progressbar/v3 v3.13.0/go.mod h1:ZBYnSuLAX2LU8P8UiKN/KgF2DY58AJC8yfVYLPC8Ly4=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -704,6 +708,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
+github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -1211,6 +1217,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -47,10 +47,10 @@ type (
 
 	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility
 	KubernetesLimits struct {
-		// Cpu specifies the limit per pod in millicores
-		Cpu int `json:"cpu,omitempty" yaml:"cpu,omitempty" toml:"cpu,omitempty"`
+		// Cpu specifies the limit per pod in millicores. It is "any" so that the user can specify it as either a string or a number
+		Cpu any `json:"cpu,omitempty" yaml:"cpu,omitempty" toml:"cpu,omitempty"`
 		// Memory specifies the limit per pod in MB
-		Memory int `json:"memory,omitempty" yaml:"memory,omitempty" toml:"memory,omitempty"`
+		Memory any `json:"memory,omitempty" yaml:"memory,omitempty" toml:"memory,omitempty"`
 	}
 
 	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility

--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -55,7 +55,7 @@ type (
 
 	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility
 	KubernetesHorizontalPodAutoScalingConfig struct {
-		// MemoryUtilization specifies he percentage of cpu a pod can utilize before the cluster will attempt to scale the pod
+		// MemoryUtilization specifies the percentage of cpu a pod can utilize before the cluster will attempt to scale the pod
 		CpuUtilization int `json:"cpu_utilization,omitempty" yaml:"cpu_utilization,omitempty" toml:"cpu_utilization,omitempty"`
 		// MemoryUtilization specifies the percentage of memory a pod can utilize before the cluster will attempt to scale the pod
 		MemoryUtilization int `json:"memory_utilization,omitempty" yaml:"memory_utilization,omitempty" toml:"memory_utilization,omitempty"`

--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -38,10 +38,10 @@ func (rg *ResourceGraph) AddResource(resource Resource) {
 //
 // And you would use it as:
 //
-//	 lambda := LambdaFunction {
-//			Role: executionRole
-//			...
-//		}
+//	lambda := LambdaFunction {
+//		Role: executionRole
+//		...
+//	}
 //
 //	rg.AddDependency(lambda, lambda.Role)
 func (rg *ResourceGraph) AddDependency(deployedSecond Resource, deployedFirst Resource) {

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -167,13 +167,6 @@ func (unit *HelmExecUnit) transformDeployment(cfg config.ExecutionUnit) ([]HelmC
 	return values, nil
 }
 
-func mapOrNew[K comparable, V any](input map[K]V) map[K]V {
-	if input == nil {
-		input = make(map[K]V)
-	}
-	return input
-}
-
 func (unit *HelmExecUnit) transformService() (values []HelmChartValue, err error) {
 	log := zap.L().Sugar().With(logging.FileField(unit.Service), zap.String("unit", unit.Name))
 	log.Debugf("Transforming file, %s, for exec unit, %s", unit.Service.Path(), unit.Name)
@@ -486,7 +479,9 @@ func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg co
 		return err
 	}
 	for name, quantity := range resourceReqs.Limits {
-		container.Resources.Limits = mapOrNew(container.Resources.Limits)
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = make(corev1.ResourceList)
+		}
 		container.Resources.Limits[name] = quantity
 	}
 

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -479,10 +479,16 @@ func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg co
 		return err
 	}
 	for name, quantity := range resourceReqs.Limits {
+		// We infer both limits and requestes from the k8sCfg limits. In order to get full utilization without overloading
+		// the nodes, for now we're hard-coding the requests as being the same as limits.
 		if container.Resources.Limits == nil {
 			container.Resources.Limits = make(corev1.ResourceList)
 		}
+		if container.Resources.Requests == nil {
+			container.Resources.Requests = make(corev1.ResourceList)
+		}
 		container.Resources.Limits[name] = quantity
+		container.Resources.Requests[name] = quantity
 	}
 
 	return nil

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -1387,7 +1387,6 @@ func Test_upsertOnlyContainer(t *testing.T) {
 
 func Test_configureContainer(t *testing.T) {
 	type result struct {
-		focusOnPath   string
 		containerYaml string
 		err           bool
 	}
@@ -1406,9 +1405,10 @@ func Test_configureContainer(t *testing.T) {
 				},
 			},
 			want: result{
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         cpu: "123"`),
 			},
 		},
@@ -1422,9 +1422,10 @@ func Test_configureContainer(t *testing.T) {
 				},
 			},
 			want: result{
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         cpu: "123"`), // gets converted to str ¯\_(ツ)_/¯
 			},
 		},
@@ -1442,9 +1443,10 @@ func Test_configureContainer(t *testing.T) {
 			},
 			want: result{
 				// From k8s docs:
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         cpu: 100m`), // k8s normalizes it to this
 			},
 		},
@@ -1458,9 +1460,10 @@ func Test_configureContainer(t *testing.T) {
 				},
 			},
 			want: result{
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         cpu: 123m`),
 			},
 		},
@@ -1487,9 +1490,10 @@ func Test_configureContainer(t *testing.T) {
 				},
 			},
 			want: result{
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         memory: 129M`),
 			},
 		},
@@ -1504,9 +1508,10 @@ func Test_configureContainer(t *testing.T) {
 				},
 			},
 			want: result{
-				focusOnPath: "$.resources",
 				containerYaml: testutil.UnIndent(`
-                    limits:
+                    name: ""
+                    resources:
+                      limits:
                         cpu: "123"
                         memory: 129M`),
 			},
@@ -1531,9 +1536,7 @@ func Test_configureContainer(t *testing.T) {
 				return
 			}
 
-			actualContainerYaml := testutil.SafeYamlPath(string(actualContainerYamlBs), tt.want.focusOnPath)
-
-			assert.Equal(tt.want.containerYaml, actualContainerYaml)
+			assert.Equal(tt.want.containerYaml, string(actualContainerYamlBs))
 		})
 	}
 

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -291,7 +291,7 @@ func Test_transformPod(t *testing.T) {
 				},
 			},
 			want: result{
-				values: []Value{
+				values: []HelmChartValue{
 					{
 						ExecUnitName: "testUnit",
 						Kind:         "Pod",
@@ -382,7 +382,7 @@ func Test_transformDeployment(t *testing.T) {
               containers:
               - name: nginx
                 image: nginx:1.14.2`)
-	wantValues := []Value{
+	wantValues := []HelmChartValue{
 		{
 			ExecUnitName: "testUnit",
 			Kind:         "Deployment",

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -1413,6 +1413,42 @@ func Test_configureContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "specify cpu int",
+			cfg: config.ExecutionUnit{
+				InfraParams: config.InfraParams{
+					"limits": map[string]any{
+						"cpu": 123,
+					},
+				},
+			},
+			want: result{
+				focusOnPath: "$.resources",
+				containerYaml: testutil.UnIndent(`
+                    limits:
+                        cpu: "123"`), // gets converted to str ¯\_(ツ)_/¯
+			},
+		},
+		{
+			// From k8s docs:
+			// > For CPU resource units, the quantity expression 0.1 is equivalent to the expression 100m, which can be
+			// > read as "one hundred millicpu"
+			name: "specify cpu float",
+			cfg: config.ExecutionUnit{
+				InfraParams: config.InfraParams{
+					"limits": map[string]any{
+						"cpu": 0.1,
+					},
+				},
+			},
+			want: result{
+				// From k8s docs:
+				focusOnPath: "$.resources",
+				containerYaml: testutil.UnIndent(`
+                    limits:
+                        cpu: 100m`), // k8s normalizes it to this
+			},
+		},
+		{
 			name: "specify cpu with unit",
 			cfg: config.ExecutionUnit{
 				InfraParams: config.InfraParams{

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -314,6 +314,8 @@ func Test_transformPod(t *testing.T) {
                         resources:
                           limits:
                             cpu: "123"
+                          requests:
+                            cpu: "123"
                       serviceAccountName: testUnit
                     status: {}`),
 			},
@@ -449,6 +451,8 @@ func Test_transformDeployment(t *testing.T) {
 				focusOnPath: "$.spec.template.spec.containers[0].resources",
 				newFile: testutil.UnIndent(`
                     limits:
+                        cpu: "123"
+                    requests:
                         cpu: "123"`),
 			},
 		},
@@ -1409,6 +1413,8 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        cpu: "123"
+                      requests:
                         cpu: "123"`),
 			},
 		},
@@ -1426,6 +1432,8 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        cpu: "123"
+                      requests:
                         cpu: "123"`), // gets converted to str ¯\_(ツ)_/¯
 			},
 		},
@@ -1447,6 +1455,8 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        cpu: 100m
+                      requests:
                         cpu: 100m`), // k8s normalizes it to this
 			},
 		},
@@ -1464,6 +1474,8 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        cpu: 123m
+                      requests:
                         cpu: 123m`),
 			},
 		},
@@ -1494,6 +1506,8 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        memory: 129M
+                      requests:
                         memory: 129M`),
 			},
 		},
@@ -1512,6 +1526,9 @@ func Test_configureContainer(t *testing.T) {
                     name: ""
                     resources:
                       limits:
+                        cpu: "123"
+                        memory: 129M
+                      requests:
                         cpu: "123"
                         memory: 129M`),
 			},

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/testutil"
 	"strings"
 	"testing"
 
@@ -316,23 +318,24 @@ func Test_transformDeployment(t *testing.T) {
 	}{
 		{
 			name: "Basic Deployment",
-			file: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2`,
+			file: testutil.UnIndent(`
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: nginx-deployment
+                spec:
+                  replicas: 3
+                  selector:
+                    matchLabels:
+                      app: nginx
+                  template:
+                    metadata:
+                      labels:
+                        app: nginx
+                    spec:
+                      containers:
+                      - name: nginx
+                        image: nginx:1.14.2`),
 			want: result{
 				values: []Value{
 					{
@@ -342,57 +345,58 @@ spec:
 						Key:          "testUnitImage",
 					},
 				},
-				newFile: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    execUnit: testUnit
-  name: nginx-deployment
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: nginx
-      execUnit: testUnit
-  strategy: {}
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: nginx
-        execUnit: testUnit
-    spec:
-      containers:
-      - image: '{{ .Values.testUnitImage }}'
-        name: nginx
-        resources: {}
-      serviceAccountName: testUnit
-status: {}
-`,
+				newFile: testutil.UnIndent(`
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    metadata:
+                      creationTimestamp: null
+                      labels:
+                        execUnit: testUnit
+                      name: nginx-deployment
+                    spec:
+                      replicas: 3
+                      selector:
+                        matchLabels:
+                          app: nginx
+                          execUnit: testUnit
+                      strategy: {}
+                      template:
+                        metadata:
+                          creationTimestamp: null
+                          labels:
+                            app: nginx
+                            execUnit: testUnit
+                        spec:
+                          containers:
+                          - image: '{{ .Values.testUnitImage }}'
+                            name: nginx
+                            resources: {}
+                          serviceAccountName: testUnit
+                    status: {}`),
 			},
 		},
 		{
 			name: "reject Deployment with multiple containers",
-			file: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2
-	  - name: nginx2
-        image: nginx:1.14.3`,
+			file: testutil.UnIndent(`
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: nginx-deployment
+                spec:
+                  replicas: 3
+                  selector:
+                    matchLabels:
+                      app: nginx
+                  template:
+                    metadata:
+                      labels:
+                        app: nginx
+                    spec:
+                      containers:
+                      - name: nginx
+                        image: nginx:1.14.2
+                      - name: nginx2
+                        image: nginx:1.14.3`),
 			wantErr: true,
 		},
 	}

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -162,7 +162,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 			}
 			values = append(values, deploymentValues...)
 		} else if unit.Pod != nil {
-			podValues, err := unit.transformPod()
+			podValues, err := unit.transformPod(cfg)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -156,7 +156,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 
 	if shouldTransformImage(eu) {
 		if unit.Deployment != nil {
-			deploymentValues, err := unit.transformDeployment()
+			deploymentValues, err := unit.transformDeployment(cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -260,7 +260,7 @@ func (chart *HelmChart) addDeployment(unit *HelmExecUnit) ([]Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	values, err := unit.transformDeployment()
+	values, err := unit.transformDeployment(config.ExecutionUnit{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/yaml_util/yaml_util.go
+++ b/pkg/yaml_util/yaml_util.go
@@ -115,7 +115,6 @@ func YamlErrors(err error) []string {
 	default:
 		return []string{err.Error()}
 	}
-
 }
 
 func findChild(within []*yaml.Node, named string) *yaml.Node {


### PR DESCRIPTION
Write cpu limits to k8s the manifest, both for deployments and for pods.

This includes a bit of refactoring work, to combine the "make sure there's no more than 1 container, and then configure it" that both deploy and pod were doing. That approach lets us test that configuration separately from the spec that's being configured, which means we don't need to do the full combination of all possible inputs for both deploy and pod.

In service of #419.

### Standard checks

- **Unit tests**: added test; also, note the use of yamlpath I added, to help shorten the test spec and make it easier for humans to focus in on the specific thing we're trying ot test
- **Docs**: n/a
- **Backwards compatibility**: n/a
