### PR TITLE
cleanup: refactor in AssignFileToUnits

### DIFF
--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -94,13 +94,12 @@ func (t *HelmChart) AssignFilesToUnits() error {
 			// only one exec unit or (b) there are multiple units, but this one's name matches the k8s object name.
 			// It returns whether that condition matched.
 			setAst := func(k8sObject metav1.Object, handle **core.SourceFile) bool {
-				needsMetadataName := len(t.ExecutionUnits) > 1
-				shouldSet := (!needsMetadataName) || (k8sObject.GetName() == unit.Name)
-				if shouldSet {
+				if len(t.ExecutionUnits) <= 1 || (k8sObject.GetName() == unit.Name) {
 					log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
 					*handle = ast
+					return true
 				}
-				return shouldSet
+				return false
 			}
 
 			obj, err := readFile(ast)

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
 
@@ -81,7 +82,6 @@ func (t *HelmChart) OutputTo(dest string) error {
 }
 
 func (t *HelmChart) AssignFilesToUnits() error {
-	needsMetadataName := len(t.ExecutionUnits) > 1
 	for _, unit := range t.ExecutionUnits {
 		for _, f := range t.Files {
 			ast, ok := f.(*core.SourceFile)
@@ -89,6 +89,19 @@ func (t *HelmChart) AssignFilesToUnits() error {
 				continue
 			}
 			log := zap.L().Sugar().With(logging.FileField(f), zap.String("unit", unit.Name))
+
+			// setAst sets the given *core.SourceFile field (hence the double-pointer), as long as either (a) there's
+			// only one exec unit or (b) there are multiple units, but this one's name matches the k8s object name.
+			// It returns whether that condition matched.
+			setAst := func(k8sObject metav1.Object, handle **core.SourceFile) bool {
+				needsMetadataName := len(t.ExecutionUnits) > 1
+				shouldSet := (!needsMetadataName) || (k8sObject.GetName() == unit.Name)
+				if shouldSet {
+					log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
+					*handle = ast
+				}
+				return shouldSet
+			}
 
 			obj, err := readFile(ast)
 			if err != nil {
@@ -98,61 +111,21 @@ func (t *HelmChart) AssignFilesToUnits() error {
 			// and match each type-case
 			switch o := obj.(type) {
 			case *corev1.Pod:
-				pod := o
-				if needsMetadataName {
-					if pod.Name == unit.Name {
-						log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-						if unit.Deployment != nil {
-							return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
-						}
-						unit.Pod = ast
-					}
-				} else {
-					log.Debug("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-					if unit.Deployment != nil {
-						return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
-					}
-					unit.Pod = ast
+				if setAst(o, &unit.Pod) && unit.Deployment != nil {
+					// Don't set this pod if there's already a spec for deployment. That means there's both a deployment
+					// manifest and a pod manifest for the same exec unit, which is a confusing scenario (since a
+					// deployment itself contains a pod spec). For now, we just disallow it.
+					return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
 				}
 			case *apps.Deployment:
-				deployment := o
-				if needsMetadataName {
-					if deployment.Name == unit.Name {
-						log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-						if unit.Pod != nil {
-							return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
-						}
-						unit.Deployment = ast
-					}
-				} else {
-					log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-					if unit.Pod != nil {
-						return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
-					}
-					unit.Deployment = ast
+				if setAst(o, &unit.Deployment) && unit.Pod != nil {
+					// Don't set this deployment if there's already a spec for this pod. See comment above.
+					return fmt.Errorf("can not support multiple pod specifications for unit %s", unit.Name)
 				}
 			case *corev1.ServiceAccount:
-				serviceAccount := o
-				if needsMetadataName {
-					if serviceAccount.Name == unit.Name {
-						log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-						unit.ServiceAccount = ast
-					}
-				} else {
-					log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-					unit.ServiceAccount = ast
-				}
+				setAst(o, &unit.ServiceAccount)
 			case *corev1.Service:
-				service := o
-				if needsMetadataName {
-					if service.Name == unit.Name {
-						log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-						unit.Service = ast
-					}
-				} else {
-					log.Debugf("Found unit, %s's, pod manifest in file, %s", unit.Name, f.Path())
-					unit.Service = ast
-				}
+				setAst(o, &unit.Service)
 			default:
 				log.Debug("Unrecognized type")
 			}


### PR DESCRIPTION
I need to add another file to this switch, and it's getting a bit unruly with all the duplication. This pulls the shared logic (which is pretty much all of the `case` bodies) out.

### Standard checks

- **Unit tests**: passing (and they do fail if, for example, I comment out `*handle = ast`)
- **Docs**: n/a
- **Backwards compatibility**: no issues
