### PR TITLE
rest of the k8s configs

### DIFF
--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -37,11 +37,11 @@ type (
 
 	// KubernetesKindParams represents the KindParams, configurability, of execution units which match the kubernetes compatibility
 	KubernetesTypeParams struct {
-		ClusterId                      string                                   `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty" toml:"cluster_id,omitempty"`
-		NodeType                       string                                   `json:"node_type,omitempty" yaml:"node_type,omitempty" toml:"node_type,omitempty"`
-		Replicas                       int                                      `json:"replicas,omitempty" yaml:"replicas,omitempty" toml:"replicas,omitempty"`
-		Limits                         KubernetesLimits                         `json:"limits,omitempty" yaml:"limits,omitempty" toml:"limits,omitempty"`
-		HorizontalPodAutoScalingConfig KubernetesHorizontalPodAutoScalingConfig `json:"horizontal_pod_autoscaling,omitempty" yaml:"horizontal_pod_autoscaling,omitempty" toml:"horizontal_pod_autoscaling,omitempty"`
+		ClusterId string           `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty" toml:"cluster_id,omitempty"`
+		NodeType  string           `json:"node_type,omitempty" yaml:"node_type,omitempty" toml:"node_type,omitempty"`
+		Replicas  int              `json:"replicas,omitempty" yaml:"replicas,omitempty" toml:"replicas,omitempty"`
+		Limits    KubernetesLimits `json:"limits,omitempty" yaml:"limits,omitempty" toml:"limits,omitempty"`
+		/* TODO */ HorizontalPodAutoScalingConfig KubernetesHorizontalPodAutoScalingConfig `json:"horizontal_pod_autoscaling,omitempty" yaml:"horizontal_pod_autoscaling,omitempty" toml:"horizontal_pod_autoscaling,omitempty"`
 	}
 
 	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility

--- a/pkg/config/execution_unit.go
+++ b/pkg/config/execution_unit.go
@@ -37,11 +37,11 @@ type (
 
 	// KubernetesKindParams represents the KindParams, configurability, of execution units which match the kubernetes compatibility
 	KubernetesTypeParams struct {
-		ClusterId string           `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty" toml:"cluster_id,omitempty"`
-		NodeType  string           `json:"node_type,omitempty" yaml:"node_type,omitempty" toml:"node_type,omitempty"`
-		Replicas  int              `json:"replicas,omitempty" yaml:"replicas,omitempty" toml:"replicas,omitempty"`
-		Limits    KubernetesLimits `json:"limits,omitempty" yaml:"limits,omitempty" toml:"limits,omitempty"`
-		/* TODO */ HorizontalPodAutoScalingConfig KubernetesHorizontalPodAutoScalingConfig `json:"horizontal_pod_autoscaling,omitempty" yaml:"horizontal_pod_autoscaling,omitempty" toml:"horizontal_pod_autoscaling,omitempty"`
+		ClusterId                      string                                   `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty" toml:"cluster_id,omitempty"`
+		NodeType                       string                                   `json:"node_type,omitempty" yaml:"node_type,omitempty" toml:"node_type,omitempty"`
+		Replicas                       int                                      `json:"replicas,omitempty" yaml:"replicas,omitempty" toml:"replicas,omitempty"`
+		Limits                         KubernetesLimits                         `json:"limits,omitempty" yaml:"limits,omitempty" toml:"limits,omitempty"`
+		HorizontalPodAutoScalingConfig KubernetesHorizontalPodAutoScalingConfig `json:"horizontal_pod_autoscaling,omitempty" yaml:"horizontal_pod_autoscaling,omitempty" toml:"horizontal_pod_autoscaling,omitempty"`
 	}
 
 	// KubernetesLimits represents the configurability of kubernetes limits for execution units which match the kubernetes compatibility
@@ -110,4 +110,9 @@ func (cfg ExecutionUnit) GetExecutionUnitParamsAsKubernetes() KubernetesTypePara
 		zap.S().Error(err)
 	}
 	return params
+}
+
+func (hpa KubernetesHorizontalPodAutoScalingConfig) NotEmpty() bool {
+	var zero KubernetesHorizontalPodAutoScalingConfig
+	return hpa != zero
 }

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -186,8 +186,7 @@ func (unit *HelmExecUnit) transformHorizontalPodAutoscaler(cfg config.ExecutionU
 	}
 	hpa, ok := obj.(*autoscaling.HorizontalPodAutoscaler)
 	if !ok {
-		err = fmt.Errorf("expected file %s to contain HorizontalPodAutoscaler Kind", unit.HorizontalPodAutoscaler.Path())
-		return nil, nil
+		return nil, fmt.Errorf("expected file %s to contain HorizontalPodAutoscaler Kind", unit.HorizontalPodAutoscaler.Path())
 	}
 	k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
 	hpaCfg := k8Cfg.HorizontalPodAutoScalingConfig

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -86,7 +86,7 @@ func (unit *HelmExecUnit) transformPod(cfg config.ExecutionUnit) (values []HelmC
 		return
 	}
 
-	value, err := unit.upsertOnlyContainer(&pod.Spec.Containers, cfg)
+	_, value, err := unit.upsertOnlyContainer(&pod.Spec.Containers, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -128,27 +128,35 @@ func (unit *HelmExecUnit) transformDeployment(cfg config.ExecutionUnit) ([]HelmC
 		return nil, err
 	}
 
-	value, err := unit.upsertOnlyContainer(&deployment.Spec.Template.Spec.Containers, cfg)
+	k8sCfg, value, err := unit.upsertOnlyContainer(&deployment.Spec.Template.Spec.Containers, cfg)
 	if err != nil {
 		return nil, err
 	}
+
+	extraLabels := generateLabels(k8sCfg)
 
 	if deployment.Labels == nil {
 		deployment.Labels = make(map[string]string)
 	}
 	deployment.Labels["execUnit"] = unit.Name
+	extraLabels.addTo(deployment.Labels)
+
+	if k8sCfg.Replicas != 0 {
+		*deployment.Spec.Replicas = int32(k8sCfg.Replicas)
+	}
 
 	if deployment.Spec.Template.Labels == nil {
 		deployment.Spec.Template.Labels = make(map[string]string)
 	}
 	deployment.Spec.Template.Labels["execUnit"] = unit.Name
+	deployment.Spec.Template.Spec.ServiceAccountName = unit.getServiceAccountName()
+	extraLabels.addTo(deployment.Spec.Template.Labels)
 
 	if deployment.Spec.Selector.MatchLabels == nil {
 		deployment.Spec.Selector.MatchLabels = make(map[string]string)
 	}
 	deployment.Spec.Selector.MatchLabels["execUnit"] = unit.Name
-
-	deployment.Spec.Template.Spec.ServiceAccountName = unit.getServiceAccountName()
+	extraLabels.addTo(deployment.Spec.Selector.MatchLabels)
 
 	output, err := yaml.Marshal(deployment)
 	if err != nil {
@@ -167,7 +175,7 @@ func (unit *HelmExecUnit) transformDeployment(cfg config.ExecutionUnit) ([]HelmC
 	return values, nil
 }
 
-func (unit *HelmExecUnit) transformService() (values []HelmChartValue, err error) {
+func (unit *HelmExecUnit) transformService(cfg config.ExecutionUnit) (values []HelmChartValue, err error) {
 	log := zap.L().Sugar().With(logging.FileField(unit.Service), zap.String("unit", unit.Name))
 	log.Debugf("Transforming file, %s, for exec unit, %s", unit.Service.Path(), unit.Name)
 	obj, err := readFile(unit.Service)
@@ -179,15 +187,22 @@ func (unit *HelmExecUnit) transformService() (values []HelmChartValue, err error
 		err = fmt.Errorf("expected file %s to contain ServiceAccount Kind", unit.ServiceAccount.Path())
 		return
 	}
+
+	k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
+	extraLabels := generateLabels(k8Cfg)
+
 	if service.Spec.Selector == nil {
 		service.Spec.Selector = make(map[string]string)
 	}
 	service.Spec.Selector["execUnit"] = unit.Name
+	extraLabels.addTo(service.Spec.Selector)
 
 	if service.Labels == nil {
 		service.Labels = make(map[string]string)
 	}
 	service.Labels["execUnit"] = unit.Name
+	extraLabels.addTo(service.Labels)
+
 	output, err := yaml.Marshal(service)
 	if err != nil {
 		return nil, err
@@ -430,7 +445,8 @@ func (unit *HelmExecUnit) addEnvVarToPod(envVars core.EnvironmentVariables) ([]H
 }
 
 // upsertOnlyContainer ensures that there is exactly one container in the given slice, and that it's correctly
-// configured. Along the way, it will also generate the image placeholder value, which it then returns.
+// configured. Along the way, it will also generate the image placeholder value, which it then returns. Finally, it
+// also returns the k8s-specific configs it had to generate along the way.
 //
 // If the provided containers slice is empty, this method will create a new container and inert it into the slice; this
 // modifies the call site's slice (which is why we pass in a pointer to a slice). Otherwise, we'll use the slice's
@@ -439,9 +455,10 @@ func (unit *HelmExecUnit) addEnvVarToPod(envVars core.EnvironmentVariables) ([]H
 // To configure the container, we:
 //  1. set its image to a template for the generated placeholder value
 //  2. call configureContainer on it
-func (unit *HelmExecUnit) upsertOnlyContainer(containers *[]corev1.Container, cfg config.ExecutionUnit) (string, error) {
+func (unit *HelmExecUnit) upsertOnlyContainer(containers *[]corev1.Container, cfg config.ExecutionUnit) (config.KubernetesTypeParams, string, error) {
 	if len(*containers) > 1 {
-		return "", errors.New("too many containers in pod spec, don't know which to replace")
+		var zero config.KubernetesTypeParams
+		return zero, "", errors.New("too many containers in pod spec, don't know which to replace")
 	}
 	if len(*containers) == 0 {
 		*containers = append(*containers, corev1.Container{
@@ -453,14 +470,15 @@ func (unit *HelmExecUnit) upsertOnlyContainer(containers *[]corev1.Container, cf
 	value := GenerateImagePlaceholder(unit.Name)
 	container.Image = fmt.Sprintf("{{ .Values.%s }}", value)
 
-	if err := unit.configureContainer(container, cfg); err != nil {
-		return "", err
+	k8config, err := unit.configureContainer(container, cfg)
+	if err != nil {
+		return k8config, "", err
 	}
 
-	return value, nil
+	return k8config, value, nil
 }
 
-func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg config.ExecutionUnit) error {
+func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg config.ExecutionUnit) (config.KubernetesTypeParams, error) {
 	k8sCfg := cfg.GetExecutionUnitParamsAsKubernetes()
 
 	limits := make(map[corev1.ResourceName]any)
@@ -472,11 +490,11 @@ func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg co
 	}
 	limitsYaml, err := yaml.Marshal(map[string]any{"limits": limits})
 	if err != nil {
-		return err
+		return k8sCfg, err
 	}
 	resourceReqs := corev1.ResourceRequirements{}
 	if err = yaml.Unmarshal(limitsYaml, &resourceReqs); err != nil {
-		return err
+		return k8sCfg, err
 	}
 	for name, quantity := range resourceReqs.Limits {
 		// We infer both limits and requestes from the k8sCfg limits. In order to get full utilization without overloading
@@ -491,5 +509,22 @@ func (unit *HelmExecUnit) configureContainer(container *corev1.Container, cfg co
 		container.Resources.Requests[name] = quantity
 	}
 
-	return nil
+	return k8sCfg, nil
+}
+
+type kubernetesLabels map[string]string
+
+func (k kubernetesLabels) addTo(other map[string]string) {
+	for k, v := range k {
+		_, inOther := other[k]
+		if !inOther {
+			other[k] = v
+		}
+	}
+}
+
+func generateLabels(cfg config.KubernetesTypeParams) kubernetesLabels {
+	return map[string]string{
+		"klotho-fargate-enabled": fmt.Sprintf(`%v`, cfg.NodeType == "fargate"),
+	}
 }

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -172,7 +172,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 			values = append(values, serviceAccountValues...)
 		}
 	}
-	upstreamValues, err := chart.handleUpstreamUnitDependencies(unit, constructGraph)
+	upstreamValues, err := chart.handleUpstreamUnitDependencies(unit, constructGraph, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 	return values, nil
 }
 
-func (chart *HelmChart) handleUpstreamUnitDependencies(unit *HelmExecUnit, constructGraph *core.ConstructGraph) (values []HelmChartValue, err error) {
+func (chart *HelmChart) handleUpstreamUnitDependencies(unit *HelmExecUnit, constructGraph *core.ConstructGraph, cfg config.ExecutionUnit) (values []HelmChartValue, err error) {
 	sources := constructGraph.GetUpstreamConstructs(&core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: unit.Name, Capability: annotation.ExecutionUnitCapability}})
 	needService := false
 	needsTargetGroupBinding := false
@@ -204,13 +204,13 @@ func (chart *HelmChart) handleUpstreamUnitDependencies(unit *HelmExecUnit, const
 	}
 	if needService {
 		if unit.Service != nil {
-			serviceValues, err := unit.transformService()
+			serviceValues, err := unit.transformService(cfg)
 			if err != nil {
 				return nil, err
 			}
 			values = append(values, serviceValues...)
 		} else {
-			serviceValues, err := chart.addService(unit)
+			serviceValues, err := chart.addService(unit, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -263,7 +263,7 @@ func (chart *HelmChart) addServiceAccount(unit *HelmExecUnit) ([]HelmChartValue,
 	return values, nil
 }
 
-func (chart *HelmChart) addService(unit *HelmExecUnit) ([]HelmChartValue, error) {
+func (chart *HelmChart) addService(unit *HelmExecUnit, cfg config.ExecutionUnit) ([]HelmChartValue, error) {
 	log := zap.L().Sugar().With(zap.String("unit", unit.Name))
 	log.Info("Adding Service manifest for exec unit")
 	err := addServiceManifest(chart, unit)
@@ -271,7 +271,7 @@ func (chart *HelmChart) addService(unit *HelmExecUnit) ([]HelmChartValue, error)
 		return nil, err
 	}
 
-	values, err := unit.transformService()
+	values, err := unit.transformService(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .ExecUnitName }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .ExecUnitName }}
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 70


### PR DESCRIPTION
The rest of the k8s configs, including Horizontal Pod Autoscaling (HPA).

If the user supplies an HPA manifest attached to this unit (per the usual rules), we use that. Otherwise, we'll create one only if there's (a) a deployment, and (b) the user has specified HPA configs in their klotho.yaml.

The intent is that this resolves #419, so if you don't think it does, please let me know. :)

> **Warning**
> I'm using the `autoscaling/v2beta2` autoscaler, because it looks like it's the latest? I don't know how much the k8s world like cutting-edge. I think it should be pretty easy to go to the standard `v2` (not beta), if we prefer — it should basically just be some yaml changes, mostly in tests.

### Standard checks

- **Unit tests**: I think I added the appropriate unit tests, but please do check (if you can do it without your eyes glazing over...mine would 😩 )
- **Docs**: not added; please lmk if there's anywhere you'd like comments
- **Backwards compatibility**: n/a
