### PR TITLE
make security group rules dynamic

### DIFF
--- a/pkg/infra/iac2/templates/security_group/factory.ts
+++ b/pkg/infra/iac2/templates/security_group/factory.ts
@@ -3,44 +3,15 @@ import * as aws from '@pulumi/aws'
 interface Args {
     Name: string
     Vpc: aws.ec2.Vpc
+    IngressRules: aws.types.input.ec2.SecurityGroupIngress[]
+    EgressRules: aws.types.input.ec2.SecurityGroupEgress[]
 }
 
 function create(args: Args): aws.ec2.SecurityGroup {
     return new aws.ec2.SecurityGroup(args.Name, {
         name: args.Name,
         vpcId: args.Vpc.id,
-        egress: [
-            {
-                cidrBlocks: ['0.0.0.0/0'],
-                description: 'Allows all outbound IPv4 traffic.',
-                fromPort: 0,
-                protocol: '-1',
-                toPort: 0,
-            },
-        ],
-        ingress: [
-            {
-                description:
-                    'Allows inbound traffic from network interfaces and instances that are assigned to the same security group.',
-                fromPort: 0,
-                protocol: '-1',
-                self: true,
-                toPort: 0,
-            },
-            {
-                description: 'For EKS control plane',
-                cidrBlocks: ['0.0.0.0/0'],
-                fromPort: 9443,
-                protocol: 'TCP',
-                toPort: 9443,
-            },
-            {
-                description: 'For private subnets internally',
-                cidrBlocks: [args.Vpc.cidrBlock],
-                fromPort: 0,
-                protocol: '-1',
-                toPort: 0,
-            },
-        ],
+        egress: args.EgressRules,
+        ingress: args.IngressRules,
     })
 }

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -511,6 +511,8 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 			return "", errors.Errorf("Unable to handle iac value for %s on type %s", resources.NLB_INTEGRATION_URI_IAC_VALUE, resourceVal.Type().Name())
 		}
 		return fmt.Sprintf("pulumi.interpolate`http://${%s.dnsName}%s`", tc.getVarName(resource), integration.Route), nil
+	case resources.CIDR_BLOCK_IAC_VALUE:
+		return fmt.Sprintf(`%s.cidrBlock`, tc.getVarName(resource)), nil
 	}
 
 	return "", errors.Errorf("unsupported IaC Value Property, %s", property)

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -109,6 +109,16 @@ func (a *AWS) createEksClusters(result *core.ConstructGraph, dag *core.ResourceG
 	}
 
 	vpc := resources.CreateNetwork(a.Config, dag)
+	sg := resources.GetSecurityGroup(a.Config, dag)
+	sg.IngressRules = append(sg.IngressRules, resources.SecurityGroupRule{
+		Description: "Allows ingress traffic from the EKS control plane",
+		FromPort:    9443,
+		Protocol:    "TCP",
+		ToPort:      9443,
+		CidrBlocks: []core.IaCValue{
+			{Property: "0.0.0.0/0"},
+		},
+	})
 	subnets := vpc.GetVpcSubnets(dag)
 	for clusterId, units := range clusterIdToUnit {
 		resources.CreateEksCluster(a.Config.AppName, clusterId, subnets, nil, units, dag)

--- a/pkg/provider/aws/plugin_test.go
+++ b/pkg/provider/aws/plugin_test.go
@@ -20,6 +20,18 @@ func Test_createEksClusters(t *testing.T) {
 		want   []*resources.EksCluster
 	}{
 		{
+			name: `no clusters created`,
+			units: []*core.ExecutionUnit{
+				{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}},
+			},
+			config: &config.Application{
+				AppName: "test",
+				ExecutionUnits: map[string]*config.ExecutionUnit{
+					"test": {Type: Lambda},
+				},
+			},
+		},
+		{
 			name: `one exec unit, no cluster id`,
 			units: []*core.ExecutionUnit{
 				{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}},
@@ -139,6 +151,19 @@ func Test_createEksClusters(t *testing.T) {
 					return
 				}
 				assert.ElementsMatch(resource.KlothoConstructRef(), cluster.ConstructsRef)
+			}
+
+			if len(tt.want) > 0 {
+				sg := resources.GetSecurityGroup(aws.Config, dag)
+				assert.Contains(sg.IngressRules, resources.SecurityGroupRule{
+					Description: "Allows ingress traffic from the EKS control plane",
+					FromPort:    9443,
+					Protocol:    "TCP",
+					ToPort:      9443,
+					CidrBlocks: []core.IaCValue{
+						{Property: "0.0.0.0/0"},
+					},
+				})
 			}
 		})
 

--- a/pkg/provider/aws/resources/securitygroup_test.go
+++ b/pkg/provider/aws/resources/securitygroup_test.go
@@ -1,0 +1,81 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetSecurityGroup(t *testing.T) {
+	vpc := NewVpc("test")
+	type result struct {
+		ingressRules []SecurityGroupRule
+		egressRules  []SecurityGroupRule
+	}
+	cases := []struct {
+		name       string
+		existingSG *SecurityGroup
+		want       result
+	}{
+		{
+			name: "new SG is created",
+			want: result{
+				ingressRules: []SecurityGroupRule{
+					{
+						Description: "Allow ingress traffic from ip addresses within the vpc",
+						CidrBlocks: []core.IaCValue{
+							{Resource: vpc, Property: CIDR_BLOCK_IAC_VALUE},
+						},
+						FromPort: 0,
+						Protocol: "-1",
+						ToPort:   0,
+					},
+					{
+						Description: "Allow ingress traffic from within the same security group",
+						FromPort:    0,
+						Protocol:    "-1",
+						ToPort:      0,
+						Self:        true,
+					},
+				},
+				egressRules: []SecurityGroupRule{
+					{
+						Description: "Allows all outbound IPv4 traffic.",
+						FromPort:    0,
+						Protocol:    "-1",
+						ToPort:      0,
+						CidrBlocks: []core.IaCValue{
+							{Property: "0.0.0.0/0"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "existing sg",
+			existingSG: &SecurityGroup{},
+			want: result{
+				ingressRules: []SecurityGroupRule{},
+				egressRules:  []SecurityGroupRule{},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			dag := core.NewResourceGraph()
+			cfg := &config.Application{}
+
+			dag.AddResource(vpc)
+			if tt.existingSG != nil {
+				dag.AddResource(tt.existingSG)
+			}
+
+			result := GetSecurityGroup(cfg, dag)
+			assert.ElementsMatch(result.IngressRules, tt.want.ingressRules)
+			assert.ElementsMatch(result.EgressRules, tt.want.egressRules)
+		})
+	}
+}

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -25,6 +25,8 @@ const (
 	VPC_SUBNET_TYPE       = "vpc_subnet"
 	VPC_ENDPOINT_TYPE     = "vpc_endpoint"
 	VPC_TYPE              = "vpc"
+
+	CIDR_BLOCK_IAC_VALUE = "cidr_block"
 )
 
 type (


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #465 

Makes our rules dynamic so we can manipulate them in the provider. This makes it so we only include ones that are necessary, where as previously we would always input the eks rule


```
const awsSecurityGroupDemoKube = new aws.ec2.SecurityGroup(`demo-kube`, {
        name: `demo-kube`,
        vpcId: awsVpcDemoKube.id,
        egress: [{description: `Allows all outbound IPv4 traffic.`,
cidrBlocks: [`0.0.0.0/0`],
protocol: `-1`,
}],
        ingress: [{description: `Allow ingress traffic from ip addresses within the vpc`,
cidrBlocks: [awsVpcDemoKube.cidrBlock],
protocol: `-1`,
},{description: `Allow ingress traffic from within the same security group`,
protocol: `-1`,
self: true,
},{description: `Allows ingress traffic from the EKS control plane`,
cidrBlocks: [`0.0.0.0/0`],
fromPort: 9443,
protocol: `TCP`,
toPort: 9443,
}],
    });
```

### Standard checks

- **Unit tests**: Any special considerations? added new and missing unit tests.
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
