### PR TITLE
add validation back and make provider validation specific to the prov…

### DIFF
--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -30,11 +30,6 @@ type Kubernetes struct {
 
 func (p Kubernetes) Name() string { return "kubernetes" }
 
-// Right now we dont do any validation to ensure kubernetes configuration is correct up front. Instead we only do it within our translate function
-func (p Kubernetes) Validate(config *config.Application, constructGraph *core.ConstructGraph) error {
-	return nil
-}
-
 func (p Kubernetes) Translate(constructGraph *core.ConstructGraph, dag *core.ResourceGraph) (links []core.CloudResourceLink, err error) {
 	var errs multierr.Error
 	p.log = zap.L().Sugar()

--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -30,6 +30,11 @@ type Kubernetes struct {
 
 func (p Kubernetes) Name() string { return "kubernetes" }
 
+// Right now we dont do any validation to ensure kubernetes configuration is correct up front. Instead we only do it within our translate function
+func (p Kubernetes) Validate(config *config.Application, constructGraph *core.ConstructGraph) error {
+	return nil
+}
+
 func (p Kubernetes) Translate(constructGraph *core.ConstructGraph, dag *core.ResourceGraph) (links []core.CloudResourceLink, err error) {
 	var errs multierr.Error
 	p.log = zap.L().Sugar()

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -15,6 +15,10 @@ type (
 
 func (a *AWS) Name() string { return "aws" }
 
+func (a *AWS) Validate(config *config.Application, constructGraph *core.ConstructGraph) error {
+	return provider.HandleProviderValidation(a, config, constructGraph)
+}
+
 // Enums for the types we allow in the aws provider so that we can reuse the same string within the provider
 const (
 	Ecs                    = "ecs"
@@ -119,30 +123,30 @@ func (a *AWS) GetDefaultConfig() config.Defaults {
 }
 
 // GetKindTypeMappings returns a list of valid types for the aws provider based on the kind passed in
-func (a *AWS) GetKindTypeMappings(construct core.Construct) ([]string, bool) {
+func (a *AWS) GetKindTypeMappings(construct core.Construct) []string {
 	switch construct.(type) {
 	case *core.ExecutionUnit:
-		return []string{kubernetes.KubernetesType, Ecs, Lambda}, true
+		return []string{kubernetes.KubernetesType, Ecs, Lambda}
 	case *core.Gateway:
-		return []string{string(ApiGateway), string(Alb)}, true
+		return []string{string(ApiGateway), string(Alb)}
 	case *core.StaticUnit:
-		return []string{S3}, true
+		return []string{S3}
 	case *core.Fs:
-		return []string{S3}, true
+		return []string{S3}
 	case *core.Kv:
-		return []string{Dynamodb}, true
+		return []string{Dynamodb}
 	case *core.Orm:
-		return []string{Rds_postgres}, true
+		return []string{Rds_postgres}
 	case *core.RedisNode:
-		return []string{Elasticache}, true
+		return []string{Elasticache}
 	case *core.RedisCluster:
-		return []string{Memorydb}, true
+		return []string{Memorydb}
 	case *core.Secrets:
-		return []string{S3}, true
+		return []string{S3}
 	case *core.PubSub:
-		return []string{Sns}, true
+		return []string{Sns}
 	case *core.Config:
-		return []string{S3, Secrets_manager}, true
+		return []string{S3, Secrets_manager}
 	}
-	return nil, false
+	return nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -20,15 +20,21 @@
 package provider
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/klothoplatform/klotho/pkg/compiler"
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/multierr"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 type (
 	Provider interface {
 		compiler.ProviderPlugin
-		GetKindTypeMappings(construct core.Construct) ([]string, bool)
+		GetKindTypeMappings(construct core.Construct) []string
 		GetDefaultConfig() config.Defaults
 	}
 
@@ -38,3 +44,36 @@ type (
 		AppName string
 	}
 )
+
+// HandleProviderValidation ensures that the klotho configuration and construct graph are valid for the provider
+//
+// The current checks consist of:
+//   - types defined in klotho configuration for each construct is valid for the provider
+func HandleProviderValidation(p Provider, config *config.Application, constructGraph *core.ConstructGraph) error {
+
+	var errs multierr.Error
+	log := zap.L().Sugar()
+	for _, resource := range constructGraph.ListConstructs() {
+		if _, ok := resource.(*core.InternalResource); ok {
+			continue
+		}
+		resourceValid := false
+		mapping := p.GetKindTypeMappings(resource)
+		if len(mapping) == 0 {
+			errs.Append(errors.Errorf("Provider, %s, Does not support %s ", p.Name(), reflect.ValueOf(resource).Kind()))
+			continue
+		}
+		resourceType := config.GetResourceType(resource)
+		log.Debugf("Checking if provider, %s, supports %s and type, %s, pair.", p.Name(), resource.Provenance().Capability, resourceType)
+		for _, validType := range mapping {
+			if validType == resourceType {
+				resourceValid = true
+			}
+		}
+		if !resourceValid {
+			errs.Append(errors.Errorf("Provider, %s, Does not support %s and type, %s, pair.\nValid resource types are: %s", p.Name(), resource, resourceType, strings.Join(mapping, ", ")))
+		}
+	}
+
+	return errs.ErrOrNil()
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -36,6 +36,7 @@ type (
 		compiler.ProviderPlugin
 		GetKindTypeMappings(construct core.Construct) []string
 		GetDefaultConfig() config.Defaults
+		compiler.ValidatingPlugin
 	}
 
 	TemplateConfig struct {
@@ -60,7 +61,7 @@ func HandleProviderValidation(p Provider, config *config.Application, constructG
 		resourceValid := false
 		mapping := p.GetKindTypeMappings(resource)
 		if len(mapping) == 0 {
-			errs.Append(errors.Errorf("Provider, %s, Does not support %s ", p.Name(), reflect.ValueOf(resource).Kind()))
+			errs.Append(errors.Errorf("Provider, %s, Does not support %s ", p.Name(), reflect.ValueOf(resource).Type()))
 			continue
 		}
 		resourceType := config.GetResourceType(resource)
@@ -71,7 +72,7 @@ func HandleProviderValidation(p Provider, config *config.Application, constructG
 			}
 		}
 		if !resourceValid {
-			errs.Append(errors.Errorf("Provider, %s, Does not support %s and type, %s, pair.\nValid resource types are: %s", p.Name(), resource, resourceType, strings.Join(mapping, ", ")))
+			errs.Append(errors.Errorf("Provider, %s, Does not support %s and type, %s, pair.\nValid resource types are: %s", p.Name(), reflect.ValueOf(resource).Type(), resourceType, strings.Join(mapping, ", ")))
 		}
 	}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/annotation"
+	"github.com/klothoplatform/klotho/pkg/config"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validation_handleProviderValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  []core.Construct
+		cfg     config.Application
+		wantErr bool
+	}{
+		{
+			name: "exec unit match",
+			result: []core.Construct{&core.ExecutionUnit{
+				AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability},
+			}},
+			cfg: config.Application{
+				Provider: "aws",
+				ExecutionUnits: map[string]*config.ExecutionUnit{
+					"test": {
+						Type: "lambda",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exec unit mismatch",
+			result: []core.Construct{&core.ExecutionUnit{
+				AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability},
+			}},
+			cfg: config.Application{
+				Provider: "aws",
+				ExecutionUnits: map[string]*config.ExecutionUnit{
+					"test": {
+						Type: "wrong",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			provider := TestProvider{}
+			result := core.NewConstructGraph()
+			for _, c := range tt.result {
+				result.AddConstruct(c)
+			}
+
+			err := HandleProviderValidation(provider, &tt.cfg, result)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			} else {
+				assert.NoError(err)
+				return
+			}
+		})
+	}
+}
+
+type TestProvider struct {
+}
+
+func (p TestProvider) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (links []core.CloudResourceLink, err error) {
+	return nil, nil
+}
+func (p TestProvider) Name() string { return "test" }
+func (p TestProvider) Validate(config *config.Application, constructGraph *core.ConstructGraph) error {
+	return HandleProviderValidation(p, config, constructGraph)
+}
+func (p TestProvider) GetDefaultConfig() config.Defaults {
+	return config.Defaults{}
+
+}
+func (a TestProvider) GetKindTypeMappings(construct core.Construct) []string {
+	switch construct.(type) {
+	case *core.ExecutionUnit:
+		return []string{"lambda"}
+	}
+	return nil
+}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
-	"github.com/klothoplatform/klotho/pkg/provider/providers"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -156,7 +155,7 @@ func Test_validation_checkAnnotationForResource(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			p := Plugin{}
+			p := ConstructValidation{}
 			result := core.NewConstructGraph()
 			for _, c := range tt.result {
 				result.AddConstruct(c)
@@ -166,70 +165,6 @@ func Test_validation_checkAnnotationForResource(t *testing.T) {
 			resource := p.checkAnnotationForResource(&tt.annot, result, log)
 			assert.Equal(tt.want, resource)
 
-		})
-	}
-}
-
-func Test_validation_handleProviderValidation(t *testing.T) {
-	tests := []struct {
-		name    string
-		result  []core.Construct
-		cfg     config.Application
-		wantErr bool
-	}{
-		{
-			name: "exec unit match",
-			result: []core.Construct{&core.ExecutionUnit{
-				AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability},
-			}},
-			cfg: config.Application{
-				Provider: "aws",
-				ExecutionUnits: map[string]*config.ExecutionUnit{
-					"test": {
-						Type: "lambda",
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "exec unit mismatch",
-			result: []core.Construct{&core.ExecutionUnit{
-				AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability},
-			}},
-			cfg: config.Application{
-				Provider: "aws",
-				ExecutionUnits: map[string]*config.ExecutionUnit{
-					"test": {
-						Type: "wrong",
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			provider, _ := providers.GetProvider(&tt.cfg)
-			p := Plugin{
-				Provider: provider,
-				Config:   &tt.cfg,
-			}
-			result := core.NewConstructGraph()
-			for _, c := range tt.result {
-				result.AddConstruct(c)
-			}
-
-			err := p.handleProviderValidation(result)
-			if tt.wantErr {
-				assert.Error(err)
-				return
-			} else {
-				assert.NoError(err)
-				return
-			}
 		})
 	}
 }
@@ -281,7 +216,7 @@ func Test_validation_handleResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			p := Plugin{}
+			p := ConstructValidation{}
 			result := core.NewConstructGraph()
 			for _, c := range tt.result {
 				result.AddConstruct(c)
@@ -461,9 +396,7 @@ func Test_validateConfigOverrideResourcesExist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			provider, _ := providers.GetProvider(&tt.cfg)
-			p := Plugin{
-				Provider:            provider,
+			p := ConstructValidation{
 				UserConfigOverrides: tt.cfg,
 			}
 			result := core.NewConstructGraph()


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #470 

Split up validation into 2 parts
- Core validation - This is validation around the annotations/ids/config overrides themselves and has nothing to do with provider specific knowledge
- Provider validtion - This is very much provider specific and i added it as a part of the plugin interface so we can run it for every provider

The provider validation step has a common utility for handling provider validation so that as long as we map types to our constructs, we can have the same reusable logic

The kubernetes plugin really shouldnt be a part of the provider plugin interface as it stands today and is really a analysis and transform. Weve had this discussion before, but dont have the time to do a complete refactor there so for now we just return nil in validation since there is nothing to validate.

### Standard checks

- **Unit tests**: Any special considerations? made sure our unit tests still covered what we are doing
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
