### PR TITLE
remove all render tags and add parsVal function back for security gro…

### DIFF
--- a/pkg/infra/iac2/iac2.go
+++ b/pkg/infra/iac2/iac2.go
@@ -62,11 +62,8 @@
 //
 // Within a Resource struct, the default TemplatesCompiler rendering behavior allows only fields of primitive types,
 // slices, maps, and structs implementing the Resource or IacValue interfaces.
-// This behavior can be modified with the following using the following tas on struct fields:
-//   - `render:"document"` - tells TemplatesCompiler to render a field as a TypeScript object
-//   - `render:"template"` - tells TemplatesCompiler to render a field using a standard Go-[text/template]
-//     with a filename matching the nested struct's name in lower-snake-case format
-//     in the same directory as the parent resource's factory.ts file.
+// This behavior can be extendend using nested templates, if there is a filename matching the nested struct's name in lower-snake-case format in the same directory as the parent resource's factory.ts file.
+// Any other field will be rendered as a document, recursively.
 //
 // # TemplatesCompiler
 //

--- a/pkg/infra/iac2/templates/security_group/security_group_rule.ts.tmpl
+++ b/pkg/infra/iac2/templates/security_group/security_group_rule.ts.tmpl
@@ -1,0 +1,12 @@
+{
+    {{- if .CidrBlocks }}
+    cidrBlocks: {{ parseVal .CidrBlocks }},
+    {{- end }}
+    description: "{{ .Description }}",
+    fromPort: {{ .FromPort }},
+    protocol: "{{ .Protocol }}",
+    {{- if .Self }}
+    self: {{ .Self }},
+    {{- end }}
+    toPort: {{ .ToPort }},
+}

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -22,13 +22,6 @@ import (
 )
 
 type (
-	nestedTemplateValue struct {
-		parentValue            reflect.Value
-		childValue             reflect.Value
-		tc                     *TemplatesCompiler
-		useDoubleQuotedStrings bool
-	}
-
 	stringTemplateValue struct {
 		raw   interface{}
 		value string
@@ -78,15 +71,6 @@ func (s stringTemplateValue) Parse() (string, error) {
 
 func (s stringTemplateValue) Raw() interface{} {
 	return s.raw
-}
-
-func (v nestedTemplateValue) Parse() (string, error) {
-	childVal := v.childValue
-	return v.tc.resolveStructInput(&v.parentValue, childVal, v.useDoubleQuotedStrings, nil)
-}
-
-func (v nestedTemplateValue) Raw() interface{} {
-	return v.childValue.Interface()
 }
 
 func CreateTemplatesCompiler(resources *core.ResourceGraph) *TemplatesCompiler {
@@ -216,6 +200,9 @@ func (tc TemplatesCompiler) renderResource(out io.Writer, resource core.Resource
 		var appliedoutputs []AppliedOutput
 		buf := strings.Builder{}
 		strValue, err = tc.resolveStructInput(&resourceVal, childVal, false, &appliedoutputs)
+		if err != nil {
+			return err
+		}
 		uniqueOutputs, err := deduplicateAppliedOutputs(appliedoutputs)
 		if err != nil {
 			return err

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -280,8 +280,8 @@ type (
 		id             string
 		Fizz           *DummyFizz
 		Buzz           DummyBuzz
-		NestedDoc      *NestedResource `render:"document"`
-		NestedTemplate *NestedTemplate `render:"template"`
+		NestedDoc      *NestedResource
+		NestedTemplate *NestedTemplate
 	}
 
 	NestedResource struct {

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -166,7 +166,7 @@ func TestResolveStructInput(t *testing.T) {
 			}
 			resourceVal := reflect.ValueOf(tt.parentResource)
 			val := reflect.ValueOf(tt.value)
-			actual, err := tc.resolveStructInput(&resourceVal, val, tt.useDoubleQuotedStrings, "", nil)
+			actual, err := tc.resolveStructInput(&resourceVal, val, tt.useDoubleQuotedStrings, nil)
 			assert.NoError(err)
 			assert.Equal(tt.want, actual)
 		})

--- a/pkg/provider/aws/resources/cloudfront.go
+++ b/pkg/provider/aws/resources/cloudfront.go
@@ -18,11 +18,11 @@ type (
 	CloudfrontDistribution struct {
 		Name                         string
 		ConstructsRef                []core.AnnotationKey
-		Origins                      []*CloudfrontOrigin `render:"document"`
+		Origins                      []*CloudfrontOrigin
 		CloudfrontDefaultCertificate bool
 		Enabled                      bool
-		DefaultCacheBehavior         *DefaultCacheBehavior `render:"document"`
-		Restrictions                 *Restrictions         `render:"document"`
+		DefaultCacheBehavior         *DefaultCacheBehavior
+		Restrictions                 *Restrictions
 		DefaultRootObject            string
 	}
 
@@ -30,7 +30,7 @@ type (
 		AllowedMethods       []string
 		CachedMethods        []string
 		TargetOriginId       string
-		ForwardedValues      ForwardedValues `render:"document"`
+		ForwardedValues      ForwardedValues
 		MinTtl               int
 		DefaultTtl           int
 		MaxTtl               int
@@ -39,7 +39,7 @@ type (
 
 	ForwardedValues struct {
 		QueryString bool
-		Cookies     Cookies `render:"document"`
+		Cookies     Cookies
 	}
 
 	Cookies struct {
@@ -47,7 +47,7 @@ type (
 	}
 
 	Restrictions struct {
-		GeoRestriction GeoRestriction `render:"document"`
+		GeoRestriction GeoRestriction
 	}
 
 	GeoRestriction struct {
@@ -58,8 +58,8 @@ type (
 		DomainName         core.IaCValue
 		OriginId           string
 		OriginPath         string
-		S3OriginConfig     S3OriginConfig     `render:"document"`
-		CustomOriginConfig CustomOriginConfig `render:"document"`
+		S3OriginConfig     S3OriginConfig
+		CustomOriginConfig CustomOriginConfig
 	}
 
 	S3OriginConfig struct {

--- a/pkg/provider/aws/resources/dynamodb.go
+++ b/pkg/provider/aws/resources/dynamodb.go
@@ -15,7 +15,7 @@ type (
 	DynamodbTable struct {
 		Name          string
 		ConstructsRef []core.AnnotationKey
-		Attributes    []DynamodbTableAttribute `render:"template"`
+		Attributes    []DynamodbTableAttribute
 		BillingMode   string
 		HashKey       string
 		RangeKey      string

--- a/pkg/provider/aws/resources/eks.go
+++ b/pkg/provider/aws/resources/eks.go
@@ -35,7 +35,7 @@ type (
 		ConstructsRef    []core.AnnotationKey
 		Cluster          *EksCluster
 		PodExecutionRole *IamRole
-		Selectors        []*FargateProfileSelector `render:"template"`
+		Selectors        []*FargateProfileSelector
 		Subnets          []*Subnet
 	}
 

--- a/pkg/provider/aws/resources/iam.go
+++ b/pkg/provider/aws/resources/iam.go
@@ -87,16 +87,16 @@ type (
 	IamRole struct {
 		Name                string
 		ConstructsRef       []core.AnnotationKey
-		AssumeRolePolicyDoc *PolicyDocument `render:"document"`
+		AssumeRolePolicyDoc *PolicyDocument
 		ManagedPolicies     []core.IaCValue
 		AwsManagedPolicies  []string
-		InlinePolicy        *PolicyDocument `render:"document"`
+		InlinePolicy        *PolicyDocument
 	}
 
 	IamPolicy struct {
 		Name          string
 		ConstructsRef []core.AnnotationKey
-		Policy        *PolicyDocument `render:"document"`
+		Policy        *PolicyDocument
 	}
 
 	PolicyGenerator struct {
@@ -106,15 +106,15 @@ type (
 
 	PolicyDocument struct {
 		Version   string
-		Statement []StatementEntry `render:"document"`
+		Statement []StatementEntry
 	}
 
 	StatementEntry struct {
 		Effect    string
 		Action    []string
 		Resource  []core.IaCValue
-		Principal *Principal `render:"document"`
-		Condition *Condition `render:"document"`
+		Principal *Principal
+		Condition *Condition
 	}
 
 	Principal struct {

--- a/pkg/provider/aws/resources/lb.go
+++ b/pkg/provider/aws/resources/lb.go
@@ -48,7 +48,7 @@ type (
 		Port           int
 		Protocol       string
 		LoadBalancer   *LoadBalancer
-		DefaultActions []*LBAction `render:"document"`
+		DefaultActions []*LBAction
 	}
 	LBAction struct {
 		TargetGroupArn core.IaCValue

--- a/pkg/provider/aws/resources/s3.go
+++ b/pkg/provider/aws/resources/s3.go
@@ -39,7 +39,7 @@ type (
 		Name          string
 		ConstructsRef []core.AnnotationKey
 		Bucket        *S3Bucket
-		Policy        *PolicyDocument `render:"document"`
+		Policy        *PolicyDocument
 	}
 )
 

--- a/pkg/provider/aws/resources/securitygroup.go
+++ b/pkg/provider/aws/resources/securitygroup.go
@@ -12,8 +12,8 @@ type (
 		Name          string
 		Vpc           *Vpc
 		ConstructsRef []core.AnnotationKey
-		IngressRules  []SecurityGroupRule `render:"document"`
-		EgressRules   []SecurityGroupRule `render:"document"`
+		IngressRules  []SecurityGroupRule
+		EgressRules   []SecurityGroupRule
 	}
 	SecurityGroupRule struct {
 		Description string

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -14,9 +14,6 @@
 //   - They are a native Go Type
 //   - They satisfy the core.Resource interface
 //   - They are a core.IaCValue
-//   - The struct field is tagged with `render: "document`
-//
-// The `render: "document` signals that the field within the struct contains other nested fields and needs to be rendered as an object, native to the language the IaCPlugin uses
 package provider
 
 import (


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #474 

We remove all tags from fields within Provider IR resources

our logic is now
- If core.Resource then handle
- if core.IaCValue then handle
- If there is a nested tempalte for the field, then render the nested tempalte
- If not, render as a document

A couple notes:
- When we render as a document, any zeroValue is not rendered, so if '' or 0 or nil is valid, you would need to create a nested tempalte
- added back the template function of parseVal so that we can render resources and iacValues within nested templates.

David pointed out the document version broke the security group, so added a nested template for that and heres the end result

```
const awsSecurityGroupMp = new aws.ec2.SecurityGroup(`mp`, {
        name: `mp`,
        vpcId: awsVpcMp.id,
        egress: [{
    cidrBlocks: [`0.0.0.0/0`],
    description: "Allows all outbound IPv4 traffic.",
    fromPort: 0,
    protocol: "-1",
    toPort: 0,
}
],
        ingress: [{
    cidrBlocks: [awsVpcMp.cidrBlock],
    description: "Allow ingress traffic from ip addresses within the vpc",
    fromPort: 0,
    protocol: "-1",
    toPort: 0,
}
,{
    description: "Allow ingress traffic from within the same security group",
    fromPort: 0,
    protocol: "-1",
    self: true,
    toPort: 0,
}
,{
    cidrBlocks: [`0.0.0.0/0`],
    description: "Allows ingress traffic from the EKS control plane",
    fromPort: 9443,
    protocol: "TCP",
    toPort: 9443,
}
],
    });
```
### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
