### PR TITLE
Don't use the greedy marker for intergration URIs

### DIFF
--- a/pkg/infra/iac2/templates/package-lock.json
+++ b/pkg/infra/iac2/templates/package-lock.json
@@ -1,0 +1,3976 @@
+{
+    "name": "pulumi-templates",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "pulumi-templates",
+            "workspaces": [
+                "*"
+            ]
+        },
+        "account_id": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "api_deployment": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "api_integration": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "api_method": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "api_resource": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "api_stage": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "availability_zones": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "dynamodb_table": {
+            "name": "iac-fragment",
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "ecr_image": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/docker": "^v4.1.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "ecr_repository": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "eks_cluster": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0"
+            }
+        },
+        "eks_fargate_profile": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "eks_node_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0"
+            }
+        },
+        "elastic_ip": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "elasticache": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "elasticache_subnetgroup": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "helm_chart": {
+            "dependencies": {
+                "@pulumi/kubernetes": "^3.21.4"
+            }
+        },
+        "iam_policy": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "iam_role": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "internet_gateway": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "lambda_function": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/docker": "^v4.1.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "lambda_permission": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "log_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "nat_gateway": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.8.13",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.7.0",
+                "@types/node": ">=12.12.47"
+            },
+            "engines": {
+                "node": "^8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.7.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/long": "^4.0.1",
+                "lodash.camelcase": "^4.3.0",
+                "long": "^4.0.0",
+                "protobufjs": "^7.0.0",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@logdna/tail-file": {
+            "version": "2.2.0",
+            "license": "SEE LICENSE IN LICENSE",
+            "engines": {
+                "node": ">=10.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.4.1",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-metrics": {
+            "version": "0.32.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/resources": "1.10.1",
+                "@opentelemetry/sdk-trace-base": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.32.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "require-in-the-middle": "^5.0.3",
+                "semver": "^7.3.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc": {
+            "version": "0.32.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "@opentelemetry/instrumentation": "0.32.0",
+                "@opentelemetry/semantic-conventions": "1.6.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.6.0",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
+            "version": "7.3.8",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/resources": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.10.1",
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/propagator-b3": "1.10.1",
+                "@opentelemetry/propagator-jaeger": "1.10.1",
+                "@opentelemetry/sdk-trace-base": "1.10.1",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.5.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
+            "version": "7.3.8",
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.10.1",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@pulumi/aws": {
+            "version": "v5.33.0",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "aws-sdk": "^2.0.0",
+                "builtin-modules": "3.0.0",
+                "mime": "^2.0.0",
+                "read-package-tree": "^5.2.1",
+                "resolve": "^1.7.1"
+            }
+        },
+        "node_modules/@pulumi/aws-native": {
+            "version": "0.56.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws-native/-/aws-native-0.56.0.tgz",
+            "integrity": "sha512-0HgdAXcsCVBzzfe85KApDOvWXVMRCaAJC722dIJ/av4klJADzMpR03auKYvb4iQDIvG0tF+w8nArxKH6Q7uYKQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/@pulumi/docker": {
+            "version": "v4.1.0",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "semver": "^5.4.0"
+            }
+        },
+        "node_modules/@pulumi/kubernetes": {
+            "version": "3.24.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-3.24.2.tgz",
+            "integrity": "sha512-9TJoYt4RltTRX447zn9gCbQj+1lwV2XUBKkBM/GLhoKi75mzOh0RMFomqa70ITeVkPCAGEDqm/a6T5fGpMlDPw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.25.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/@pulumi/pulumi": {
+            "version": "3.60.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.3.8",
+                "@logdna/tail-file": "^2.0.6",
+                "@opentelemetry/api": "^1.2.0",
+                "@opentelemetry/exporter-zipkin": "^1.6.0",
+                "@opentelemetry/instrumentation-grpc": "^0.32.0",
+                "@opentelemetry/resources": "^1.6.0",
+                "@opentelemetry/sdk-trace-base": "^1.6.0",
+                "@opentelemetry/sdk-trace-node": "^1.6.0",
+                "@opentelemetry/semantic-conventions": "^1.6.0",
+                "@pulumi/query": "^0.3.0",
+                "execa": "^5.1.0",
+                "google-protobuf": "^3.5.0",
+                "ini": "^2.0.0",
+                "js-yaml": "^3.14.0",
+                "minimist": "^1.2.6",
+                "normalize-package-data": "^2.4.0",
+                "read-package-tree": "^5.3.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^6.1.0",
+                "source-map-support": "^0.5.6",
+                "ts-node": "^7.0.1",
+                "typescript": "~3.8.3",
+                "upath": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/semver": {
+            "version": "6.3.0",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@pulumi/query": {
+            "version": "v0.3.0",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@types/glob": {
+            "version": "5.0.38",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.38.tgz",
+            "integrity": "sha512-rTtf75rwyP9G2qO5yRpYtdJ6aU1QqEhWbtW55qEgquEDa6bXW0s2TWZfDm02GuppjEozOWG/F2UnPq5hAQb+gw==",
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/long": {
+            "version": "4.0.2",
+            "license": "MIT"
+        },
+        "node_modules/@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
+        },
+        "node_modules/@types/node": {
+            "version": "18.15.11",
+            "license": "MIT"
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            }
+        },
+        "node_modules/@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ=="
+        },
+        "node_modules/account_id": {
+            "resolved": "account_id",
+            "link": true
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/api_deployment": {
+            "resolved": "api_deployment",
+            "link": true
+        },
+        "node_modules/api_integration": {
+            "resolved": "api_integration",
+            "link": true
+        },
+        "node_modules/api_method": {
+            "resolved": "api_method",
+            "link": true
+        },
+        "node_modules/api_resource": {
+            "resolved": "api_resource",
+            "link": true
+        },
+        "node_modules/api_stage": {
+            "resolved": "api_stage",
+            "link": true
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/array.prototype.reduce": {
+            "version": "1.0.5",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "1.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "license": "MIT"
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/availability_zones": {
+            "resolved": "availability_zones",
+            "link": true
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.5",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1346.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "util": "^0.12.4",
+                "uuid": "8.0.0",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "license": "MIT"
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "license": "MIT"
+        },
+        "node_modules/builtin-modules": {
+            "version": "3.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/debuglog": {
+            "version": "1.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.0",
+            "license": "MIT",
+            "dependencies": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dezalgo": {
+            "version": "1.0.4",
+            "license": "ISC",
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/diff": {
+            "version": "3.5.0",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/ecr_image": {
+            "resolved": "ecr_image",
+            "link": true
+        },
+        "node_modules/ecr_repository": {
+            "resolved": "ecr_repository",
+            "link": true
+        },
+        "node_modules/eks_cluster": {
+            "resolved": "eks_cluster",
+            "link": true
+        },
+        "node_modules/eks_fargate_profile": {
+            "resolved": "eks_fargate_profile",
+            "link": true
+        },
+        "node_modules/eks_node_group": {
+            "resolved": "eks_node_group",
+            "link": true
+        },
+        "node_modules/elastic_ip": {
+            "resolved": "elastic_ip",
+            "link": true
+        },
+        "node_modules/elasticache": {
+            "resolved": "elasticache",
+            "link": true
+        },
+        "node_modules/elasticache_subnetgroup": {
+            "resolved": "elasticache_subnetgroup",
+            "link": true
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "license": "MIT"
+        },
+        "node_modules/es-abstract": {
+            "version": "1.21.2",
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
+                "es-to-primitive": "^1.2.1",
+                "function.prototype.name": "^1.1.5",
+                "get-intrinsic": "^1.2.0",
+                "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.10",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.4.3",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
+                "string.prototype.trimend": "^1.0.6",
+                "string.prototype.trimstart": "^1.0.6",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "license": "MIT"
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-secret": {
+            "resolved": "secret",
+            "link": true
+        },
+        "node_modules/fs-secret-version": {
+            "resolved": "secret_version",
+            "link": true
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "license": "ISC"
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "license": "MIT"
+        },
+        "node_modules/function.prototype.name": {
+            "version": "1.1.5",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.0",
+                "functions-have-names": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.2.0",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-symbol-description": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.3",
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/google-protobuf": {
+            "version": "3.21.2",
+            "license": "(BSD-3-Clause AND Apache-2.0)"
+        },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "license": "ISC"
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/helm_chart": {
+            "resolved": "helm_chart",
+            "link": true
+        },
+        "node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "license": "ISC"
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iac-fragment": {
+            "resolved": "dynamodb_table",
+            "link": true
+        },
+        "node_modules/iam_policy": {
+            "resolved": "iam_policy",
+            "link": true
+        },
+        "node_modules/iam_role": {
+            "resolved": "iam_role",
+            "link": true
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "2.0.0",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/internal-slot": {
+            "version": "1.0.5",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/internet_gateway": {
+            "resolved": "internet_gateway",
+            "link": true
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.4",
+            "license": "MIT",
+            "dependencies": {
+                "has-bigints": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.2",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.11.0",
+            "license": "MIT",
+            "dependencies": {
+                "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.5",
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.10",
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.2",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.7",
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.4",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-shared-array-buffer": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.0.7",
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.10",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakref": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "license": "ISC"
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "3.14.1",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "license": "MIT"
+        },
+        "node_modules/lambda_function": {
+            "resolved": "lambda_function",
+            "link": true
+        },
+        "node_modules/lambda_permission": {
+            "resolved": "lambda_permission",
+            "link": true
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "license": "MIT"
+        },
+        "node_modules/log_group": {
+            "resolved": "log_group",
+            "link": true
+        },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "license": "Apache-2.0"
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "license": "ISC"
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "license": "MIT"
+        },
+        "node_modules/mime": {
+            "version": "2.6.0",
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.6",
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.3",
+            "license": "MIT"
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "license": "MIT"
+        },
+        "node_modules/nat_gateway": {
+            "resolved": "nat_gateway",
+            "link": true
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/npm-normalize-package-bin": {
+            "version": "1.0.1",
+            "license": "ISC"
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.12.3",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.4",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object.getownpropertydescriptors": {
+            "version": "2.1.5",
+            "license": "MIT",
+            "dependencies": {
+                "array.prototype.reduce": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "license": "MIT"
+        },
+        "node_modules/protobufjs": {
+            "version": "7.2.3",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/protobufjs/node_modules/long": {
+            "version": "5.2.1",
+            "license": "Apache-2.0"
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "license": "MIT"
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/read-package-json": {
+            "version": "2.1.2",
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "normalize-package-data": "^2.0.0",
+                "npm-normalize-package-bin": "^1.0.0"
+            }
+        },
+        "node_modules/read-package-tree": {
+            "version": "5.3.1",
+            "license": "ISC",
+            "dependencies": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+            }
+        },
+        "node_modules/readdir-scoped-modules": {
+            "version": "1.1.0",
+            "license": "ISC",
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.4.3",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/region": {
+            "resolved": "region",
+            "link": true
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-in-the-middle": {
+            "version": "5.2.0",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.1",
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/rest_api": {
+            "resolved": "rest_api",
+            "link": true
+        },
+        "node_modules/s3_bucket": {
+            "resolved": "s3_bucket",
+            "link": true
+        },
+        "node_modules/s3_object": {
+            "resolved": "s3_object",
+            "link": true
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "license": "ISC"
+        },
+        "node_modules/security_group": {
+            "resolved": "security_group",
+            "link": true
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+            "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/side-channel": {
+            "version": "1.0.4",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "license": "ISC"
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.3.0",
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.13",
+            "license": "CC0-1.0"
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.7",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.6",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.6",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/subnet": {
+            "resolved": "subnet",
+            "link": true
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/ts-node": {
+            "version": "7.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/typed-array-length": {
+            "version": "1.0.4",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "3.8.3",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/upath": {
+            "version": "1.2.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/util": {
+            "version": "0.12.5",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "node_modules/util-promisify": {
+            "version": "2.1.0",
+            "license": "MIT",
+            "dependencies": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "8.0.0",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/vpc": {
+            "resolved": "vpc",
+            "link": true
+        },
+        "node_modules/vpc_endpoint": {
+            "resolved": "vpc_endpoint",
+            "link": true
+        },
+        "node_modules/vpc_link": {
+            "resolved": "vpc_link",
+            "link": true
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.9",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "license": "ISC"
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "license": "ISC"
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yn": {
+            "version": "2.0.0",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "region": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "rest_api": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "s3_bucket": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "s3_object": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2",
+                "mime": "^2.0.0"
+            }
+        },
+        "secret": {
+            "name": "fs-secret",
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "secret_version": {
+            "name": "fs-secret-version",
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "security_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "subnet": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "vpc": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "vpc_endpoint": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "vpc_link": {
+            "dependencies": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@grpc/grpc-js": {
+            "version": "1.8.13",
+            "requires": {
+                "@grpc/proto-loader": "^0.7.0",
+                "@types/node": ">=12.12.47"
+            }
+        },
+        "@grpc/proto-loader": {
+            "version": "0.7.6",
+            "requires": {
+                "@types/long": "^4.0.1",
+                "lodash.camelcase": "^4.3.0",
+                "long": "^4.0.0",
+                "protobufjs": "^7.0.0",
+                "yargs": "^16.2.0"
+            }
+        },
+        "@logdna/tail-file": {
+            "version": "2.2.0"
+        },
+        "@opentelemetry/api": {
+            "version": "1.4.1"
+        },
+        "@opentelemetry/api-metrics": {
+            "version": "0.32.0",
+            "requires": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "@opentelemetry/context-async-hooks": {
+            "version": "1.10.1",
+            "requires": {}
+        },
+        "@opentelemetry/core": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            }
+        },
+        "@opentelemetry/exporter-zipkin": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/resources": "1.10.1",
+                "@opentelemetry/sdk-trace-base": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            }
+        },
+        "@opentelemetry/instrumentation": {
+            "version": "0.32.0",
+            "requires": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "require-in-the-middle": "^5.0.3",
+                "semver": "^7.3.2",
+                "shimmer": "^1.2.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.8",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@opentelemetry/instrumentation-grpc": {
+            "version": "0.32.0",
+            "requires": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "@opentelemetry/instrumentation": "0.32.0",
+                "@opentelemetry/semantic-conventions": "1.6.0"
+            },
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": {
+                    "version": "1.6.0"
+                }
+            }
+        },
+        "@opentelemetry/propagator-b3": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/core": "1.10.1"
+            }
+        },
+        "@opentelemetry/propagator-jaeger": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/core": "1.10.1"
+            }
+        },
+        "@opentelemetry/resources": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            }
+        },
+        "@opentelemetry/sdk-trace-base": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/resources": "1.10.1",
+                "@opentelemetry/semantic-conventions": "1.10.1"
+            }
+        },
+        "@opentelemetry/sdk-trace-node": {
+            "version": "1.10.1",
+            "requires": {
+                "@opentelemetry/context-async-hooks": "1.10.1",
+                "@opentelemetry/core": "1.10.1",
+                "@opentelemetry/propagator-b3": "1.10.1",
+                "@opentelemetry/propagator-jaeger": "1.10.1",
+                "@opentelemetry/sdk-trace-base": "1.10.1",
+                "semver": "^7.3.5"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.8",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@opentelemetry/semantic-conventions": {
+            "version": "1.10.1"
+        },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2"
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2"
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4"
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0"
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2"
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0"
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2"
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0"
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0"
+        },
+        "@pulumi/aws": {
+            "version": "v5.33.0",
+            "requires": {
+                "@pulumi/pulumi": "^3.0.0",
+                "aws-sdk": "^2.0.0",
+                "builtin-modules": "3.0.0",
+                "mime": "^2.0.0",
+                "read-package-tree": "^5.2.1",
+                "resolve": "^1.7.1"
+            }
+        },
+        "@pulumi/aws-native": {
+            "version": "0.56.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws-native/-/aws-native-0.56.0.tgz",
+            "integrity": "sha512-0HgdAXcsCVBzzfe85KApDOvWXVMRCaAJC722dIJ/av4klJADzMpR03auKYvb4iQDIvG0tF+w8nArxKH6Q7uYKQ==",
+            "requires": {
+                "@pulumi/pulumi": "^3.0.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "@pulumi/docker": {
+            "version": "v4.1.0",
+            "requires": {
+                "@pulumi/pulumi": "^3.0.0",
+                "semver": "^5.4.0"
+            }
+        },
+        "@pulumi/kubernetes": {
+            "version": "3.24.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-3.24.2.tgz",
+            "integrity": "sha512-9TJoYt4RltTRX447zn9gCbQj+1lwV2XUBKkBM/GLhoKi75mzOh0RMFomqa70ITeVkPCAGEDqm/a6T5fGpMlDPw==",
+            "requires": {
+                "@pulumi/pulumi": "^3.25.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "@pulumi/pulumi": {
+            "version": "3.60.0",
+            "requires": {
+                "@grpc/grpc-js": "^1.3.8",
+                "@logdna/tail-file": "^2.0.6",
+                "@opentelemetry/api": "^1.2.0",
+                "@opentelemetry/exporter-zipkin": "^1.6.0",
+                "@opentelemetry/instrumentation-grpc": "^0.32.0",
+                "@opentelemetry/resources": "^1.6.0",
+                "@opentelemetry/sdk-trace-base": "^1.6.0",
+                "@opentelemetry/sdk-trace-node": "^1.6.0",
+                "@opentelemetry/semantic-conventions": "^1.6.0",
+                "@pulumi/query": "^0.3.0",
+                "execa": "^5.1.0",
+                "google-protobuf": "^3.5.0",
+                "ini": "^2.0.0",
+                "js-yaml": "^3.14.0",
+                "minimist": "^1.2.6",
+                "normalize-package-data": "^2.4.0",
+                "read-package-tree": "^5.3.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^6.1.0",
+                "source-map-support": "^0.5.6",
+                "ts-node": "^7.0.1",
+                "typescript": "~3.8.3",
+                "upath": "^1.1.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0"
+                }
+            }
+        },
+        "@pulumi/query": {
+            "version": "v0.3.0"
+        },
+        "@types/glob": {
+            "version": "5.0.38",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.38.tgz",
+            "integrity": "sha512-rTtf75rwyP9G2qO5yRpYtdJ6aU1QqEhWbtW55qEgquEDa6bXW0s2TWZfDm02GuppjEozOWG/F2UnPq5hAQb+gw==",
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/long": {
+            "version": "4.0.2"
+        },
+        "@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
+        },
+        "@types/node": {
+            "version": "18.15.11"
+        },
+        "@types/node-fetch": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+            "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            }
+        },
+        "@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ=="
+        },
+        "account_id": {
+            "version": "file:account_id",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "ansi-regex": {
+            "version": "5.0.1"
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "api_deployment": {
+            "version": "file:api_deployment",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "api_integration": {
+            "version": "file:api_integration",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "api_method": {
+            "version": "file:api_method",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "api_resource": {
+            "version": "file:api_resource",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "api_stage": {
+            "version": "file:api_stage",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "array-buffer-byte-length": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            }
+        },
+        "array.prototype.reduce": {
+            "version": "1.0.5",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            }
+        },
+        "arrify": {
+            "version": "1.0.1"
+        },
+        "asap": {
+            "version": "2.0.6"
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "availability_zones": {
+            "version": "file:availability_zones",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5"
+        },
+        "aws-sdk": {
+            "version": "2.1346.0",
+            "requires": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "util": "^0.12.4",
+                "uuid": "8.0.0",
+                "xml2js": "0.4.19"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.2"
+        },
+        "base64-js": {
+            "version": "1.5.1"
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer": {
+            "version": "4.9.2",
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.2"
+        },
+        "builtin-modules": {
+            "version": "3.0.0"
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "cliui": {
+            "version": "7.0.4",
+            "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4"
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1"
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            }
+        },
+        "debug": {
+            "version": "4.3.4",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "debuglog": {
+            "version": "1.0.1"
+        },
+        "define-properties": {
+            "version": "1.2.0",
+            "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "dezalgo": {
+            "version": "1.0.4",
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "diff": {
+            "version": "3.5.0"
+        },
+        "ecr_image": {
+            "version": "file:ecr_image",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/docker": "^v4.1.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "ecr_repository": {
+            "version": "file:ecr_repository",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "eks_cluster": {
+            "version": "file:eks_cluster",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0"
+            }
+        },
+        "eks_fargate_profile": {
+            "version": "file:eks_fargate_profile",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "eks_node_group": {
+            "version": "file:eks_node_group",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/aws-native": "^0.56.0"
+            }
+        },
+        "elastic_ip": {
+            "version": "file:elastic_ip",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "elasticache": {
+            "version": "file:elasticache",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "elasticache_subnetgroup": {
+            "version": "file:elasticache_subnetgroup",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "8.0.0"
+        },
+        "es-abstract": {
+            "version": "1.21.2",
+            "requires": {
+                "array-buffer-byte-length": "^1.0.0",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
+                "es-to-primitive": "^1.2.1",
+                "function.prototype.name": "^1.1.5",
+                "get-intrinsic": "^1.2.0",
+                "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has": "^1.0.3",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.10",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.4.3",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
+                "string.prototype.trimend": "^1.0.6",
+                "string.prototype.trimstart": "^1.0.6",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.9"
+            }
+        },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0"
+        },
+        "es-set-tostringtag": {
+            "version": "2.0.1",
+            "requires": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "escalade": {
+            "version": "3.1.1"
+        },
+        "esprima": {
+            "version": "4.0.1"
+        },
+        "events": {
+            "version": "1.1.1"
+        },
+        "execa": {
+            "version": "5.1.1",
+            "requires": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            }
+        },
+        "for-each": {
+            "version": "0.3.3",
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "form-data": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "fs-secret": {
+            "version": "file:secret",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "fs-secret-version": {
+            "version": "file:secret_version",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0"
+        },
+        "function-bind": {
+            "version": "1.1.1"
+        },
+        "function.prototype.name": {
+            "version": "1.1.5",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.19.0",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "functions-have-names": {
+            "version": "1.2.3"
+        },
+        "get-caller-file": {
+            "version": "2.0.5"
+        },
+        "get-intrinsic": {
+            "version": "1.2.0",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "get-stream": {
+            "version": "6.0.1"
+        },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "glob": {
+            "version": "7.2.3",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globalthis": {
+            "version": "1.0.3",
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
+        },
+        "google-protobuf": {
+            "version": "3.21.2"
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.11"
+        },
+        "has": {
+            "version": "1.0.3",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.2"
+        },
+        "has-property-descriptors": {
+            "version": "1.0.0",
+            "requires": {
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "has-proto": {
+            "version": "1.0.1"
+        },
+        "has-symbols": {
+            "version": "1.0.3"
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "helm_chart": {
+            "version": "file:helm_chart",
+            "requires": {
+                "@pulumi/kubernetes": "^3.21.4"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.8.9"
+        },
+        "human-signals": {
+            "version": "2.1.0"
+        },
+        "iac-fragment": {
+            "version": "file:dynamodb_table",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "iam_policy": {
+            "version": "file:iam_policy",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "iam_role": {
+            "version": "file:iam_role",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "ieee754": {
+            "version": "1.1.13"
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4"
+        },
+        "ini": {
+            "version": "2.0.0"
+        },
+        "internal-slot": {
+            "version": "1.0.5",
+            "requires": {
+                "get-intrinsic": "^1.2.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
+        "internet_gateway": {
+            "version": "file:internet_gateway",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "is-arguments": {
+            "version": "1.1.1",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-array-buffer": {
+            "version": "3.0.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "is-bigint": {
+            "version": "1.0.4",
+            "requires": {
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-callable": {
+            "version": "1.2.7"
+        },
+        "is-core-module": {
+            "version": "2.11.0",
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.5",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "3.0.0"
+        },
+        "is-generator-function": {
+            "version": "1.0.10",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-negative-zero": {
+            "version": "2.0.2"
+        },
+        "is-number-object": {
+            "version": "1.0.7",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-regex": {
+            "version": "1.1.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-shared-array-buffer": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-stream": {
+            "version": "2.0.1"
+        },
+        "is-string": {
+            "version": "1.0.7",
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.10",
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-weakref": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "isarray": {
+            "version": "1.0.0"
+        },
+        "isexe": {
+            "version": "2.0.0"
+        },
+        "jmespath": {
+            "version": "0.16.0"
+        },
+        "js-yaml": {
+            "version": "3.14.1",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1"
+        },
+        "lambda_function": {
+            "version": "file:lambda_function",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/docker": "^v4.1.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "lambda_permission": {
+            "version": "file:lambda_permission",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "lodash.camelcase": {
+            "version": "4.3.0"
+        },
+        "log_group": {
+            "version": "file:log_group",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "long": {
+            "version": "4.0.0"
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.6"
+        },
+        "merge-stream": {
+            "version": "2.0.0"
+        },
+        "mime": {
+            "version": "2.6.0"
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "2.1.0"
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.8"
+        },
+        "mkdirp": {
+            "version": "0.5.6",
+            "requires": {
+                "minimist": "^1.2.6"
+            }
+        },
+        "module-details-from-path": {
+            "version": "1.0.3"
+        },
+        "ms": {
+            "version": "2.1.2"
+        },
+        "nat_gateway": {
+            "version": "file:nat_gateway",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "node-fetch": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "npm-normalize-package-bin": {
+            "version": "1.0.1"
+        },
+        "npm-run-path": {
+            "version": "4.0.1",
+            "requires": {
+                "path-key": "^3.0.0"
+            }
+        },
+        "object-inspect": {
+            "version": "1.12.3"
+        },
+        "object-keys": {
+            "version": "1.1.1"
+        },
+        "object.assign": {
+            "version": "4.1.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.5",
+            "requires": {
+                "array.prototype.reduce": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "5.1.2",
+            "requires": {
+                "mimic-fn": "^2.1.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1"
+        },
+        "path-key": {
+            "version": "3.1.1"
+        },
+        "path-parse": {
+            "version": "1.0.7"
+        },
+        "protobufjs": {
+            "version": "7.2.3",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "dependencies": {
+                "long": {
+                    "version": "5.2.1"
+                }
+            }
+        },
+        "punycode": {
+            "version": "1.3.2"
+        },
+        "querystring": {
+            "version": "0.2.0"
+        },
+        "read-package-json": {
+            "version": "2.1.2",
+            "requires": {
+                "glob": "^7.1.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "normalize-package-data": "^2.0.0",
+                "npm-normalize-package-bin": "^1.0.0"
+            }
+        },
+        "read-package-tree": {
+            "version": "5.3.1",
+            "requires": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+            }
+        },
+        "readdir-scoped-modules": {
+            "version": "1.1.0",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.4.3",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "functions-have-names": "^1.2.2"
+            }
+        },
+        "region": {
+            "version": "file:region",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1"
+        },
+        "require-from-string": {
+            "version": "2.0.2"
+        },
+        "require-in-the-middle": {
+            "version": "5.2.0",
+            "requires": {
+                "debug": "^4.1.1",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.1"
+            }
+        },
+        "resolve": {
+            "version": "1.22.1",
+            "requires": {
+                "is-core-module": "^2.9.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
+        "rest_api": {
+            "version": "file:rest_api",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "s3_bucket": {
+            "version": "file:s3_bucket",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "s3_object": {
+            "version": "file:s3_object",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2",
+                "mime": "^2.0.0"
+            }
+        },
+        "safe-regex-test": {
+            "version": "1.0.0",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            }
+        },
+        "sax": {
+            "version": "1.2.1"
+        },
+        "security_group": {
+            "version": "file:security_group",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "semver": {
+            "version": "5.7.1"
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0"
+        },
+        "shell-quote": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.0.tgz",
+            "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ=="
+        },
+        "shimmer": {
+            "version": "1.2.1"
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
+        "signal-exit": {
+            "version": "3.0.7"
+        },
+        "source-map": {
+            "version": "0.6.1"
+        },
+        "source-map-support": {
+            "version": "0.5.21",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.2.0",
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0"
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.13"
+        },
+        "sprintf-js": {
+            "version": "1.0.3"
+        },
+        "string-width": {
+            "version": "4.2.3",
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.2.7",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.6",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.6",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "strip-ansi": {
+            "version": "6.0.1",
+            "requires": {
+                "ansi-regex": "^5.0.1"
+            }
+        },
+        "strip-final-newline": {
+            "version": "2.0.0"
+        },
+        "subnet": {
+            "version": "file:subnet",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0"
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "ts-node": {
+            "version": "7.0.1",
+            "requires": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            }
+        },
+        "typed-array-length": {
+            "version": "1.0.4",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            }
+        },
+        "typescript": {
+            "version": "3.8.3"
+        },
+        "unbox-primitive": {
+            "version": "1.0.2",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "upath": {
+            "version": "1.2.0"
+        },
+        "url": {
+            "version": "0.10.3",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "util": {
+            "version": "0.12.5",
+            "requires": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "util-promisify": {
+            "version": "2.1.0",
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
+        "uuid": {
+            "version": "8.0.0"
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "vpc": {
+            "version": "file:vpc",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "vpc_endpoint": {
+            "version": "file:vpc_endpoint",
+            "requires": {
+                "@pulumi/aws": "^5.16.0",
+                "@pulumi/pulumi": "^3.40.2"
+            }
+        },
+        "vpc_link": {
+            "version": "file:vpc_link",
+            "requires": {
+                "@pulumi/aws": "^5.16.0"
+            }
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "which": {
+            "version": "2.0.2",
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.9",
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.10"
+            }
+        },
+        "wrap-ansi": {
+            "version": "7.0.0",
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2"
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7"
+        },
+        "y18n": {
+            "version": "5.0.8"
+        },
+        "yallist": {
+            "version": "4.0.0"
+        },
+        "yargs": {
+            "version": "16.2.0",
+            "requires": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "20.2.9"
+        },
+        "yn": {
+            "version": "2.0.0"
+        }
+    }
+}

--- a/pkg/infra/pulumi_aws/iac/api_gateway.ts
+++ b/pkg/infra/pulumi_aws/iac/api_gateway.ts
@@ -416,7 +416,7 @@ export class ApiGateway {
                             connectionId: vpcLink.id,
                             uri: pulumi.interpolate`http://${
                                 nlb.loadBalancer.dnsName
-                            }${this.convertPath(r.path)}`,
+                            }${this.convertPath(r.path).replace('+', '')}`,
                             requestParameters:
                                 Object.keys(integrationRequestParams).length == 0
                                     ? undefined
@@ -444,7 +444,7 @@ export class ApiGateway {
                             connectionId: vpcLink.id,
                             uri: pulumi.interpolate`http://${nlb.dnsName}${this.convertPath(
                                 r.path
-                            )}`,
+                            ).replace('+', '')}`,
                             requestParameters:
                                 Object.keys(integrationRequestParams).length == 0
                                     ? undefined


### PR DESCRIPTION
Having `{rest+}` on the endpoint url causes "illegal character". 

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
