### PR TITLE
Klotho 420 prereqs

### DIFF
--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -267,14 +267,18 @@ func buildExpectedTsType(out *strings.Builder, tp *templatesProvider, t reflect.
 			return err
 		}
 		out.WriteRune('>')
-	case reflect.Pointer, reflect.Interface:
-		// Interface happens when the value is inside a map, slice, or array. Basically, the reflected type is
+	case reflect.Pointer:
+		// Pointer happens when the value is inside a map, slice, or array. Basically, the reflected type is
 		// interface{},instead of being the actual type. So, we basically pull the item out of the collection, and then
 		// reflect on it directly.
 		err := buildExpectedTsType(out, tp, t.Elem())
 		if err != nil {
 			return err
 		}
+	case reflect.Interface:
+		// Similar to Pointer above; but specifically when the map/slice's type is "any". For example,
+		// `map[string]int` will hit the `reflect.Pointer`case for the value type, but `map[string]any` will his here.
+		out.WriteString(`pulumi.Output<any>`)
 	}
 	return nil
 }

--- a/pkg/infra/iac2/templates/helm_chart/factory.ts
+++ b/pkg/infra/iac2/templates/helm_chart/factory.ts
@@ -5,7 +5,7 @@ interface Args {
     Name: string
     Chart?: string
     Repo?: string
-    Values?: Record<string, pulumi.Output<string>>
+    Values?: Record<string, pulumi.Output<any>>
     Version?: string
     Namespace?: string
     ClustersProvider: pulumi_k8s.Provider
@@ -20,7 +20,7 @@ function create(args: Args): pulumi_k8s.helm.v3.Chart {
             //TMPL {{- if .Chart.Raw }}
             chart: args.Chart,
             //TMPL {{- end }}
-            //TMPL {{- if and (.Chart.Raw) (.FetchOpts.Raw) }}
+            //TMPL {{- if .Repo.Raw }}
             fetchOpts: {
                 repo: args.Repo,
             },

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -32,7 +32,7 @@ type HelmChart struct {
 	Repo             string
 	Version          string
 	Namespace        string
-	Values           map[string]core.IaCValue
+	Values           map[string]any
 }
 
 // Provider returns name of the provider the resource is correlated to

--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -192,7 +192,7 @@ func (p *Kubernetes) getKlothoCharts(constructGraph *core.ConstructGraph) (map[s
 					ExecutionUnits: []*HelmExecUnit{{Name: unit.ID, Namespace: "default"}},
 					Directory:      chartDir,
 					ConstructRefs:  []core.AnnotationKey{unit.Provenance()},
-					Values:         make(map[string]core.IaCValue),
+					Values:         make(map[string]any),
 				}
 
 			} else {

--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -143,6 +143,12 @@ func (p *Kubernetes) setHelmChartDirectory(path string, cfg *config.ExecutionUni
 	return false, nil
 }
 
+// getKlothoCharts gets all the main Chart.yaml Helm charts for the compilation. It returns a map of Helm charts for
+// each execution unit, keyed by their directory (relative to the source root).
+//
+//   - Side effect: If the user has provided [config.HelmChartOptions] with an empty Directory for a given execution
+//     unit, this method will look for a Chart.yaml next to whatever file declares the execution unit, and set the
+//     Directory field on the exec unit's [config.HelmChartOptions] to that chart's directory.
 func (p *Kubernetes) getKlothoCharts(constructGraph *core.ConstructGraph) (map[string]HelmChart, error) {
 	var errs multierr.Error
 	klothoCharts := make(map[string]HelmChart)

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -41,7 +41,7 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 				Key:          "tgb",
 			},
 		},
-		Values: make(map[string]core.IaCValue),
+		Values: make(map[string]any),
 	}
 
 	cases := []struct {
@@ -288,7 +288,7 @@ func Test_convertExecUnitParams(t *testing.T) {
 						Key:                 "BUCKETBUCKETNAME",
 					},
 				},
-				Values: make(map[string]core.IaCValue),
+				Values: make(map[string]any),
 			},
 			wants: resources.EnvironmentVariables{
 				"BUCKETBUCKETNAME": core.IaCValue{Resource: s3Bucket, Property: "bucket_name"},
@@ -326,7 +326,7 @@ func Test_convertExecUnitParams(t *testing.T) {
 			case *resources.LambdaFunction:
 				assert.Equal(tt.wants, res.EnvironmentVariables)
 			case *kubernetes.HelmChart:
-				wantAsMap := map[string]core.IaCValue{}
+				wantAsMap := map[string]any{}
 				for key, val := range tt.wants {
 					wantAsMap[key] = val
 				}

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -28,6 +28,8 @@ func Test_CreateEksCluster(t *testing.T) {
 					"aws:iam_role:test-app-test-cluster-FargateExecutionRole",
 					"aws:iam_role:test-app-test-cluster-k8sAdmin",
 					"aws:iam_role:test-app-test-cluster-NodeGroupRole",
+					"kubernetes:helm_chart:test-cluster-cert-manager",
+					"kubernetes:helm_chart:test-cluster-metrics-server",
 					subnet.Id(),
 				},
 				Deps: []coretesting.StringDep{
@@ -38,6 +40,8 @@ func Test_CreateEksCluster(t *testing.T) {
 					{Source: "aws:eks_fargate_profile:test-app-test-cluster", Destination: subnet.Id()},
 					{Source: "aws:eks_node_group:test-app-test-cluster", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "aws:eks_node_group:test-app-test-cluster", Destination: "aws:iam_role:test-app-test-cluster-NodeGroupRole"},
+					{Source: "kubernetes:helm_chart:test-cluster-cert-manager", Destination: "aws:eks_node_group:test-app-test-cluster"},
+					{Source: "kubernetes:helm_chart:test-cluster-metrics-server", Destination: "aws:eks_node_group:test-app-test-cluster"},
 					{Source: "aws:eks_node_group:test-app-test-cluster", Destination: subnet.Id()},
 				},
 			},


### PR DESCRIPTION
As part of this, i'm also changing the helmchart.values map to have values of type `any`, instead of `iacvalue`. this because the cert-manager chart wants values that include a boolean (for `installcrds`) and a nested record/map (for `webhook`). in order to accomplish that, i also changed the helm_chart/factory.ts args to take `pulumi.output<any>` instead of `...<string>`. this is what the pulumi field is actually typed as, so we don't actually lose any checks by doing it this way.

also fix a typo in the factory.ts's handling of args.repo.

also also provider a prettier error in coretesting, because otherwise it's very hard to read the diff when two lists have different elements.

in service of #420


### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: no issues
