### PR TITLE
setting up eks logging for fargate and fluent bit

### DIFF
--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -254,7 +254,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 			cmd.SilenceUsage = true
 		},
 	}
-	// defer analyticsClient.PanicHandler(&err, errHandler)
+	defer analyticsClient.PanicHandler(&err, errHandler)
 
 	updateStream := options.Update.Stream.OrDefault(km.DefaultUpdateStream)
 	analyticsClient.AppendProperty("updateStream", updateStream)

--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -103,6 +103,7 @@ func TestKnownTemplates(t *testing.T) {
 		&resources.RdsProxy{},
 		&resources.RdsSubnetGroup{},
 		&resources.RdsProxyTargetGroup{},
+		&kubernetes.Manifest{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/resource_creation_template.go
+++ b/pkg/infra/iac2/resource_creation_template.go
@@ -147,9 +147,10 @@ func parseFile(contents []byte) *sitter.Node {
 	return tree.RootNode()
 }
 
-func (t ResourceCreationTemplate) RenderCreate(out io.Writer, inputs map[string]templateValue) error {
+func (t ResourceCreationTemplate) RenderCreate(out io.Writer, inputs map[string]templateValue, tc TemplatesCompiler) error {
 	tmpl, err := template.New(t.name).Funcs(template.FuncMap{
-		"parseTS": parseTS,
+		"parseTS":        parseTS,
+		"handleIaCValue": tc.handleSingleIaCValue,
 	}).Parse(t.ExpressionTemplate)
 	if err != nil {
 		return errors.Wrapf(err, `while writing template for %s`, t.name)

--- a/pkg/infra/iac2/templates/manifest/factory.ts
+++ b/pkg/infra/iac2/templates/manifest/factory.ts
@@ -1,0 +1,29 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as pulumi_k8s from '@pulumi/kubernetes'
+
+interface Args {
+    Name: string
+    FilePath: string
+    Transformations?: Record<string, pulumi.Output<string>>
+    dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): pulumi_k8s.yaml.ConfigFile {
+    return new pulumi_k8s.yaml.ConfigFile(
+        args.Name,
+        {
+            file: args.FilePath,
+            //TMPL {{- if .Transformations.Raw }}
+            transformations: [
+                (obj: any, opts: pulumi.CustomResourceOptions) => {
+                    //TMPL {{- range $key, $value := .Transformations.Raw }}
+                    //TMPL obj.{{ $key }} = {{ handleIaCValue $value }}
+                    //TMPL {{- end }}
+                },
+            ],
+            //TMPL {{- end }}
+        },
+        { dependsOn: args.dependsOn }
+    )
+}

--- a/pkg/infra/iac2/templates/manifest/package.json
+++ b/pkg/infra/iac2/templates/manifest/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "helm_chart",
+    "name": "manifest",
     "dependencies": {
         "@pulumi/kubernetes": "^3.21.4",
         "@pulumi/pulumi": "^3.40.2"

--- a/pkg/infra/iac2/templates/manifest/package.json
+++ b/pkg/infra/iac2/templates/manifest/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "helm_chart",
+    "dependencies": {
+        "@pulumi/kubernetes": "^3.21.4",
+        "@pulumi/pulumi": "^3.40.2"
+    }
+}

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -232,7 +232,7 @@ func (tc TemplatesCompiler) renderResource(out io.Writer, resource core.Resource
 		varName := tc.getVarName(resource)
 		fmt.Fprintf(out, `const %s = `, varName)
 	}
-	errs.Append(tmpl.RenderCreate(out, inputArgs))
+	errs.Append(tmpl.RenderCreate(out, inputArgs, tc))
 	_, err = out.Write([]byte(";"))
 	if err != nil {
 		return err
@@ -413,6 +413,8 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		return fmt.Sprintf("%s.bucket", tc.getVarName(resource)), nil
 	case string(resources.ARN_IAC_VALUE):
 		return fmt.Sprintf("%s.arn", tc.getVarName(v.Resource)), nil
+	case string(resources.NAME_IAC_VALUE):
+		return fmt.Sprintf("%s.name", tc.getVarName(v.Resource)), nil
 	case string(resources.ALL_BUCKET_DIRECTORY_IAC_VALUE):
 		return fmt.Sprintf("pulumi.interpolate`${%s.arn}/*`", tc.getVarName(v.Resource)), nil
 	case resources.DYNAMODB_TABLE_BACKUP_IAC_VALUE,
@@ -523,6 +525,10 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 	}
 
 	return "", errors.Errorf("unsupported IaC Value Property, %s", property)
+}
+
+func (tc TemplatesCompiler) handleSingleIaCValue(v core.IaCValue) (string, error) {
+	return tc.handleIaCValue(v, nil, nil)
 }
 
 // getVarName gets a unique but nice-looking variable for the given item.

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -2,10 +2,11 @@ package kubernetes
 
 import (
 	"fmt"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"path/filepath"
+
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/config"
@@ -44,8 +45,6 @@ func (chart *HelmChart) KlothoConstructRef() []core.AnnotationKey { return chart
 func (chart *HelmChart) Id() string {
 	return fmt.Sprintf("%s:%s:%s", chart.Provider(), HELM_CHART_TYPE, chart.Name)
 }
-
-var HelmChartKind = "helm_chart"
 
 func (t *HelmChart) OutputTo(dest string) error {
 	errs := make(chan error)

--- a/pkg/infra/kubernetes/manifest.go
+++ b/pkg/infra/kubernetes/manifest.go
@@ -20,13 +20,36 @@ var service = templateutils.MustTemplate(files, "manifests/service.yaml.tmpl")
 var serviceExport = templateutils.MustTemplate(files, "manifests/service_export.yaml.tmpl")
 var targetGroupBinding = templateutils.MustTemplate(files, "manifests/target_group_binding.yaml.tmpl")
 
-type DeploymentManifestData struct {
-	ExecUnitName       string
-	FargateEnabled     string
-	ReplicaCount       string
-	ServiceAccountName string
-	Image              string
-	Namespace          string
+const (
+	MANIFEST_TYPE = "manifest"
+)
+
+type (
+	Manifest struct {
+		Name            string
+		ConstructRefs   []core.AnnotationKey
+		FilePath        string
+		Transformations map[string]core.IaCValue
+	}
+
+	DeploymentManifestData struct {
+		ExecUnitName       string
+		FargateEnabled     string
+		ReplicaCount       string
+		ServiceAccountName string
+		Image              string
+		Namespace          string
+	}
+)
+
+// Provider returns name of the provider the resource is correlated to
+func (manifest *Manifest) Provider() string { return "kubernetes" }
+
+// KlothoConstructRef returns a slice containing the ids of any Klotho constructs is correlated to
+func (manifest *Manifest) KlothoConstructRef() []core.AnnotationKey { return manifest.ConstructRefs }
+
+func (manifest *Manifest) Id() string {
+	return fmt.Sprintf("%s:%s:%s", manifest.Provider(), MANIFEST_TYPE, manifest.Name)
 }
 
 func addDeploymentManifest(kch *HelmChart, unit *HelmExecUnit) error {

--- a/pkg/provider/aws/resources/eks.go
+++ b/pkg/provider/aws/resources/eks.go
@@ -1,10 +1,15 @@
 package resources
 
 import (
+	"embed"
 	"fmt"
+	"io/fs"
+	"path"
+
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/infra/kubernetes"
 	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
+	"go.uber.org/zap"
 )
 
 const (
@@ -15,11 +20,21 @@ const (
 
 	CLUSTER_OIDC_URL_IAC_VALUE = "cluster_oidc_url"
 	CLUSTER_OIDC_ARN_IAC_VALUE = "cluster_oidc_arn"
+	NAME_IAC_VALUE             = "name"
+
+	AWS_OBSERVABILITY_NS_PATH         = "aws_observability_namespace.yaml"
+	AWS_OBSERVABILITY_CONFIG_MAP_PATH = "aws_observability_configmap.yaml"
+	AMAZON_CLOUDWATCH_NS_PATH         = "amazon_cloudwatch_namespace.yaml"
+	FLUENT_BIT_CLUSTER_INFO           = "fluent_bit_cluster_info.yaml"
+	MANIFEST_PATH_PREFIX              = "manifests"
 )
 
 var nodeGroupSanitizer = aws.EksNodeGroupSanitizer
 var profileSanitizer = aws.EksFargateProfileSanitizer
 var clusterSanitizer = aws.EksClusterSanitizer
+
+//go:embed manifests/*
+var eksManifests embed.FS
 
 type (
 	//Todo: Add SecurityGroups when they are available
@@ -28,6 +43,7 @@ type (
 		ConstructsRef []core.AnnotationKey
 		ClusterRole   *IamRole
 		Subnets       []*Subnet
+		Manifests     []core.File
 	}
 
 	EksFargateProfile struct {
@@ -78,6 +94,15 @@ func CreateEksCluster(appName string, clusterName string, subnets []*Subnet, sec
 	cluster.ConstructsRef = references
 	dag.AddResource(cluster)
 	dag.AddDependency(cluster, clusterRole)
+
+	err := cluster.createFargateLogging(references, dag)
+	if err != nil {
+		zap.S().Warnf("Unable to set up Fargate logging manifests for cluster %s: %s", clusterName, err.Error())
+	}
+	err = cluster.installFluentBit(references, dag)
+	if err != nil {
+		zap.S().Warnf("Unable to set up fluent bit manifests for cluster %s: %s", clusterName, err.Error())
+	}
 
 	fargateRole := createPodExecutionRole(appName, clusterName+"-FargateExecutionRole", references)
 	dag.AddResource(fargateRole)
@@ -132,6 +157,89 @@ func createAddOns(clusterName string, provenance []core.AnnotationKey) []*kubern
 			},
 		},
 	}
+}
+
+func (cluster *EksCluster) GetOutputFiles() []core.File {
+	return cluster.Manifests
+}
+
+func (cluster *EksCluster) createFargateLogging(references []core.AnnotationKey, dag *core.ResourceGraph) error {
+	namespaceOutputPath := path.Join(MANIFEST_PATH_PREFIX, AWS_OBSERVABILITY_NS_PATH)
+	content, err := fs.ReadFile(eksManifests, namespaceOutputPath)
+	if err != nil {
+		return err
+	}
+	namespace := &kubernetes.Manifest{
+		Name:          fmt.Sprintf("%s-%s", cluster.Name, "aws-observability-ns"),
+		ConstructRefs: references,
+		FilePath:      namespaceOutputPath,
+	}
+	dag.AddResource(namespace)
+	dag.AddDependency(namespace, cluster)
+	cluster.Manifests = append(cluster.Manifests, &core.RawFile{FPath: namespaceOutputPath, Content: content})
+
+	configMapOutputPath := path.Join(MANIFEST_PATH_PREFIX, AWS_OBSERVABILITY_CONFIG_MAP_PATH)
+	content, err = fs.ReadFile(eksManifests, configMapOutputPath)
+	if err != nil {
+		return err
+	}
+	configMap := &kubernetes.Manifest{
+		Name:          fmt.Sprintf("%s-%s", cluster.Name, "aws-observability-config-map"),
+		ConstructRefs: references,
+		FilePath:      configMapOutputPath,
+	}
+	dag.AddResource(configMap)
+	dag.AddDependency(configMap, cluster)
+	dag.AddDependency(configMap, namespace)
+	cluster.Manifests = append(cluster.Manifests, &core.RawFile{FPath: configMapOutputPath, Content: content})
+	return nil
+}
+
+func (cluster *EksCluster) installFluentBit(references []core.AnnotationKey, dag *core.ResourceGraph) error {
+	namespaceOutputPath := path.Join(MANIFEST_PATH_PREFIX, AMAZON_CLOUDWATCH_NS_PATH)
+	content, err := fs.ReadFile(eksManifests, namespaceOutputPath)
+	if err != nil {
+		return err
+	}
+	namespace := &kubernetes.Manifest{
+		Name:          fmt.Sprintf("%s-%s", cluster.Name, "awmazon-cloudwatch-ns"),
+		ConstructRefs: references,
+		FilePath:      namespaceOutputPath,
+	}
+	dag.AddResource(namespace)
+	dag.AddDependency(namespace, cluster)
+	cluster.Manifests = append(cluster.Manifests, &core.RawFile{FPath: namespaceOutputPath, Content: content})
+
+	configMapOutputPath := path.Join(MANIFEST_PATH_PREFIX, FLUENT_BIT_CLUSTER_INFO)
+	content, err = fs.ReadFile(eksManifests, configMapOutputPath)
+	if err != nil {
+		return err
+	}
+	region := NewRegion()
+	configMap := &kubernetes.Manifest{
+		Name:          fmt.Sprintf("%s-%s", cluster.Name, "fluent-bit-cluster-info-config-map"),
+		ConstructRefs: references,
+		FilePath:      configMapOutputPath,
+		Transformations: map[string]core.IaCValue{
+			"data.cluster.name": {Resource: cluster, Property: NAME_IAC_VALUE},
+			"data.logs.region":  {Resource: region, Property: NAME_IAC_VALUE},
+		},
+	}
+	dag.AddResource(configMap)
+	dag.AddDependency(configMap, cluster)
+	dag.AddDependency(configMap, namespace)
+	dag.AddDependency(configMap, region)
+	cluster.Manifests = append(cluster.Manifests, &core.RawFile{FPath: configMapOutputPath, Content: content})
+
+	fluentBitOptimized := &kubernetes.Manifest{
+		Name:          fmt.Sprintf("%s-%s", cluster.Name, "fluent-bit"),
+		ConstructRefs: references,
+		FilePath:      "https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml",
+	}
+	dag.AddResource(configMap)
+	dag.AddDependency(fluentBitOptimized, cluster)
+	dag.AddDependency(fluentBitOptimized, configMap)
+	return nil
 }
 
 // GetEksCluster will return the resource with the name corresponding to the appName and ClusterId

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -76,7 +75,6 @@ func Test_CreateEksCluster(t *testing.T) {
 					assert.ElementsMatch(sources, r.KlothoConstructRef(), "not matching refs in %s", r.Id())
 				}
 			}
-			fmt.Println(coretesting.ResoucesFromDAG(dag).GoString())
 			tt.want.Assert(t, dag)
 
 		})

--- a/pkg/provider/aws/resources/manifests/amazon_cloudwatch_namespace.yaml
+++ b/pkg/provider/aws/resources/manifests/amazon_cloudwatch_namespace.yaml
@@ -1,0 +1,7 @@
+# create amazon-cloudwatch namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: amazon-cloudwatch
+  labels:
+    name: amazon-cloudwatch

--- a/pkg/provider/aws/resources/manifests/aws_observability_configmap.yaml
+++ b/pkg/provider/aws/resources/manifests/aws_observability_configmap.yaml
@@ -1,0 +1,36 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: aws-logging
+  namespace: aws-observability
+data:
+  flb_log_cw: 'false' # Set to true to ship Fluent Bit process logs to CloudWatch.
+  filters.conf: |
+    [FILTER]
+        Name parser
+        Match *
+        Key_name log
+        Parser crio
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        Buffer_Size 0
+        Kube_Meta_Cache_TTL 300s
+  output.conf: |
+    [OUTPUT]
+        Name cloudwatch_logs
+        Match   kube.*
+        region region-code
+        log_group_name my-logs
+        log_stream_prefix from-fluent-bit-
+        log_retention_days 60
+        auto_create_group true
+  parsers.conf: |
+    [PARSER]
+        Name crio
+        Format Regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/pkg/provider/aws/resources/manifests/aws_observability_namespace.yaml
+++ b/pkg/provider/aws/resources/manifests/aws_observability_namespace.yaml
@@ -1,0 +1,8 @@
+# create aws-observability namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-observability
+  labels:
+    name: aws-observability
+    aws-observability: enabled

--- a/pkg/provider/aws/resources/manifests/fluent_bit_cluster_info.yaml
+++ b/pkg/provider/aws/resources/manifests/fluent_bit_cluster_info.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  cluster.name: REPLACE_ME
+  logs.region: REPLACE_ME
+  http.server: On
+  http.port: 2020
+  read.head: Off
+  read.tail: On


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #444 

sets up fargate logging and fluent bit for container insights.

We now can install manifests via ConfigFile in pulumi.

We also output our manifests to the `compiled/manifests` directory

### Standard checks

- **Unit tests**: Any special considerations? added test case
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
