### PR TITLE
add cloudmap controller for eks service discovery

### DIFF
--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -107,6 +107,7 @@ func TestKnownTemplates(t *testing.T) {
 		&KubernetesProvider{},
 		&RolePolicyAttachment{},
 		&resources.PrivateDnsNamespace{},
+		&kubernetes.KustomizeDirectory{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/templates/eks_cluster/factory.ts
+++ b/pkg/infra/iac2/templates/eks_cluster/factory.ts
@@ -4,6 +4,7 @@ import * as aws from '@pulumi/aws'
 interface Args {
     Name: string
     Subnets: aws.ec2.Subnet[]
+    SecurityGroups: aws.ec2.SecurityGroup[]
     ClusterRole: aws.iam.Role
 }
 
@@ -12,6 +13,9 @@ function create(args: Args): aws_native.eks.Cluster {
     return new aws_native.eks.Cluster(args.Name, {
         resourcesVpcConfig: {
             subnetIds: args.Subnets.map((subnet) => subnet.id),
+            //TMPL {{- if .SecurityGroups.Raw }}
+            securityGroupIds: args.SecurityGroups.map((sg) => sg.id),
+            //TMPL {{- end }}
         },
         roleArn: args.ClusterRole.arn,
     })

--- a/pkg/infra/iac2/templates/kustomize_directory/factory.ts
+++ b/pkg/infra/iac2/templates/kustomize_directory/factory.ts
@@ -1,0 +1,23 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as pulumi_k8s from '@pulumi/kubernetes'
+
+interface Args {
+    Name: string
+    Directory: string
+    ClustersProvider: pulumi_k8s.Provider
+    dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): pulumi_k8s.kustomize.Directory {
+    return new pulumi_k8s.kustomize.Directory(
+        args.Name,
+        {
+            directory: args.Directory,
+        },
+        {
+            dependsOn: args.dependsOn,
+            provider: args.ClustersProvider,
+        }
+    )
+}

--- a/pkg/infra/iac2/templates/kustomize_directory/package.json
+++ b/pkg/infra/iac2/templates/kustomize_directory/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "kustomize_directory",
+    "dependencies": {
+        "@pulumi/kubernetes": "^3.21.4"
+    }
+}

--- a/pkg/infra/iac2/templates/kustomize_directory/package.json
+++ b/pkg/infra/iac2/templates/kustomize_directory/package.json
@@ -1,6 +1,7 @@
 {
     "name": "kustomize_directory",
     "dependencies": {
+        "@pulumi/pulumi": "^3.40.2",
         "@pulumi/kubernetes": "^3.21.4"
     }
 }

--- a/pkg/infra/iac2/templates/manifest/factory.ts
+++ b/pkg/infra/iac2/templates/manifest/factory.ts
@@ -4,6 +4,7 @@ import * as pulumi_k8s from '@pulumi/kubernetes'
 interface Args {
     Name: string
     FilePath: string
+    ClustersProvider: pulumi_k8s.Provider
     Transformations?: Record<string, pulumi.Output<string>>
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
 }
@@ -24,6 +25,9 @@ function create(args: Args): pulumi_k8s.yaml.ConfigFile {
             ],
             //TMPL {{- end }}
         },
-        { dependsOn: args.dependsOn }
+        {
+            dependsOn: args.dependsOn,
+            provider: args.ClustersProvider,
+        }
     )
 }

--- a/pkg/infra/kubernetes/kustomize.go
+++ b/pkg/infra/kubernetes/kustomize.go
@@ -1,0 +1,30 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+)
+
+const (
+	KUSTOMIZE_DIRECTORY_TYPE = "kustomize_directory"
+)
+
+type (
+	KustomizeDirectory struct {
+		Name             string
+		ConstructRefs    []core.AnnotationKey
+		Directory        string
+		ClustersProvider core.IaCValue
+	}
+)
+
+// Provider returns name of the provider the resource is correlated to
+func (dir *KustomizeDirectory) Provider() string { return "kubernetes" }
+
+// KlothoConstructRef returns a slice containing the ids of any Klotho constructs is correlated to
+func (dir *KustomizeDirectory) KlothoConstructRef() []core.AnnotationKey { return dir.ConstructRefs }
+
+func (dir *KustomizeDirectory) Id() string {
+	return fmt.Sprintf("%s:%s:%s", dir.Provider(), KUSTOMIZE_DIRECTORY_TYPE, dir.Name)
+}

--- a/pkg/infra/kubernetes/manifest.go
+++ b/pkg/infra/kubernetes/manifest.go
@@ -26,10 +26,11 @@ const (
 
 type (
 	Manifest struct {
-		Name            string
-		ConstructRefs   []core.AnnotationKey
-		FilePath        string
-		Transformations map[string]core.IaCValue
+		Name             string
+		ConstructRefs    []core.AnnotationKey
+		FilePath         string
+		Transformations  map[string]core.IaCValue
+		ClustersProvider core.IaCValue
 	}
 
 	DeploymentManifestData struct {

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -37,7 +36,6 @@ func (a *AWS) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (l
 	for _, id := range constructIds {
 		construct := result.GetConstruct(id)
 		log.Debugf("Converting construct with id, %s, to aws resources", construct.Id())
-		fmt.Println(construct.Id())
 		switch construct := construct.(type) {
 		case *core.ExecutionUnit:
 			merr.Append(a.GenerateExecUnitResources(construct, result, dag))

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -1,11 +1,15 @@
 package resources
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/core/coretesting"
+	"github.com/klothoplatform/klotho/pkg/infra/kubernetes"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,6 +100,72 @@ func Test_CreateEksCluster(t *testing.T) {
 			tt.want.Assert(t, dag)
 		})
 	}
+}
+
+func Test_InstallCloudMapController(t *testing.T) {
+	assert := assert.New(t)
+	dag := core.NewResourceGraph()
+	cluster := NewEksCluster("test", "cluster", nil, nil, nil)
+	nodeGroup1 := &EksNodeGroup{
+		Name:    "nodegroup1",
+		Cluster: cluster,
+	}
+	dag.AddDependenciesReflect(nodeGroup1)
+
+	unit1 := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "1"}}
+	err := cluster.InstallCloudMapController(unit1.AnnotationKey, dag)
+	if !assert.NoError(err) {
+		return
+	}
+
+	cloudMapController := &kubernetes.KustomizeDirectory{
+		Name: fmt.Sprintf("%s-cloudmap-controller", cluster.Name),
+	}
+
+	if controller := dag.GetResource(cloudMapController.Id()); controller != nil {
+		if cm, ok := controller.(*kubernetes.KustomizeDirectory); ok {
+			assert.Equal(cm.ClustersProvider, core.IaCValue{
+				Resource: cluster,
+				Property: CLUSTER_PROVIDER_IAC_VALUE,
+			})
+			assert.Equal(cm.Directory, "https://github.com/aws/aws-cloud-map-mcs-controller-for-k8s/config/controller_install_release")
+		} else {
+			assert.NoError(errors.Errorf("Expected resource with id, %s, to be of type HelmChart, but was %s",
+				controller.Id(), reflect.ValueOf(controller).Type().Name()))
+		}
+	}
+
+	unit2 := &core.ExecutionUnit{AnnotationKey: core.AnnotationKey{ID: "2"}}
+	err = cluster.InstallCloudMapController(unit2.AnnotationKey, dag)
+	if !assert.NoError(err) {
+		return
+	}
+
+	if controller := dag.GetResource(cloudMapController.Id()); controller != nil {
+		assert.ElementsMatch(controller.KlothoConstructRef(), []core.AnnotationKey{unit1.AnnotationKey, unit2.AnnotationKey})
+	}
+
+}
+
+func Test_getClustersNodeGroups(t *testing.T) {
+	assert := assert.New(t)
+	dag := core.NewResourceGraph()
+	cluster := NewEksCluster("test", "cluster", nil, nil, nil)
+	nodeGroup1 := &EksNodeGroup{
+		Name:    "nodegroup1",
+		Cluster: cluster,
+	}
+	nodeGroup2 := &EksNodeGroup{
+		Name:    "nodegroup2",
+		Cluster: cluster,
+	}
+	nodeGroup3 := &EksNodeGroup{
+		Name: "nodegroup3",
+	}
+	dag.AddDependenciesReflect(nodeGroup1)
+	dag.AddDependenciesReflect(nodeGroup2)
+	dag.AddDependenciesReflect(nodeGroup3)
+	assert.ElementsMatch(cluster.getClustersNodeGroups(dag), []*EksNodeGroup{nodeGroup1, nodeGroup2})
 }
 
 func Test_createClusterAdminRole(t *testing.T) {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? Adds code to satisfy the cloud map controller instillation

adds an IR and template for a kustomize directory.

Adds code to ensure if we have a k8s proxy, we install the cloud map controller so we can properly proxy

### Standard checks

- **Unit tests**: Any special considerations? added
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
