### PR TITLE
Adds EKS VPC CNI addon and NVIDIA device plugin

### DIFF
--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -67,6 +67,7 @@ func TestKnownTemplates(t *testing.T) {
 		&resources.EksCluster{},
 		&resources.EksNodeGroup{},
 		&resources.EksFargateProfile{},
+		&resources.EksAddon{},
 		&resources.NatGateway{},
 		&resources.Subnet{},
 		&resources.InternetGateway{},

--- a/pkg/infra/iac2/templates/eks_addon/factory.ts
+++ b/pkg/infra/iac2/templates/eks_addon/factory.ts
@@ -1,0 +1,16 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+
+interface Args {
+    Name: string
+    AddonName: string
+    ClusterName: pulumi.Input<string>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.eks.Addon {
+    return new aws.eks.Addon(args.Name, {
+        clusterName: args.ClusterName,
+        addonName: args.AddonName,
+    })
+}

--- a/pkg/infra/iac2/templates/eks_addon/package.json
+++ b/pkg/infra/iac2/templates/eks_addon/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "eks_addon",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0",
+        "@pulumi/pulumi": "^3.40.2"
+    }
+}


### PR DESCRIPTION
This PR is associated with #507.

It adds support for the following:
- Installing the NVIDIA Device k8s plugin when any of an EKS cluster's node groups use a gpu-enabled AMI type.
- Installing the EKS VPC CNI addon on all EKS clusters

Fixes:
- Added  missing `ClustersProvider` reference for fluentbit