### PR TITLE
Config secrets

### DIFF
--- a/pkg/config/config_construct.go
+++ b/pkg/config/config_construct.go
@@ -4,6 +4,7 @@ type (
 	// Config is how config Klotho constructs and other related resources (or meta-resources) are represented in the klotho configuration
 	Config struct {
 		Type        string      `json:"type" yaml:"type" toml:"type"`
+		Path        string      `json:"path,omitempty" yaml:"path,omitempty" toml:"path,omitempty"`
 		InfraParams InfraParams `json:"infra_params,omitempty" yaml:"infra_params,omitempty" toml:"infra_params,omitempty"`
 	}
 )

--- a/pkg/infra/iac2/find_create_func.scm
+++ b/pkg/infra/iac2/find_create_func.scm
@@ -10,9 +10,7 @@
       .
     )
     return_type: (type_annotation (_) @return_type)
-    body: (statement_block
-      (return_statement (_) @return_body)
-    )
+    body: (statement_block) @body
   )
   (#eq? @function_name "create")
   (#eq? @input_type "Args")

--- a/pkg/infra/iac2/find_return.scm
+++ b/pkg/infra/iac2/find_return.scm
@@ -1,0 +1,1 @@
+(return_statement (_) @return_body)

--- a/pkg/infra/iac2/find_return.scm
+++ b/pkg/infra/iac2/find_return.scm
@@ -1,1 +1,5 @@
-(return_statement (_) @return_body)
+(statement_block
+  .
+  (return_statement (_) @return_body)
+  .
+)

--- a/pkg/infra/iac2/resource_creation_template.go
+++ b/pkg/infra/iac2/resource_creation_template.go
@@ -224,6 +224,9 @@ func deduplicateAppliedOutputs(outputs []AppliedOutput) ([]AppliedOutput, error)
 	return uniqueList, nil
 }
 
+// bodyContents returns the contents of a 'statement_block' with the surrounding {}
+// and indentation removed so that the contents of a void function
+// can be inlined with the rest of the index.ts.
 func bodyContents(node *sitter.Node) string {
 	if node.ChildCount() == 0 || node.Child(0).Content() != "{" {
 		return node.Content()
@@ -236,5 +239,5 @@ func bodyContents(node *sitter.Node) string {
 		}
 		buf.WriteString(node.NamedChild(i).Content())
 	}
-	return strings.TrimSuffix(buf.String(), ";")
+	return strings.TrimSuffix(buf.String(), ";") // Remove any trailing ';' since one is added later to prevent ';;'
 }

--- a/pkg/infra/iac2/resource_creation_template_test.go
+++ b/pkg/infra/iac2/resource_creation_template_test.go
@@ -63,6 +63,16 @@ func TestParameterizeArgs(t *testing.T) {
 			given: `new Foo(myargs.Foo)`,
 			want:  `new Foo(myargs.Foo)`,
 		},
+		{
+			given: `//TMPL test`,
+			want:  `test`,
+		},
+		{
+			given:  `//TMPL {{ .Param }}`,
+			want:   `{{ .Param }}`,
+			input:  map[string]any{"Param": "value"},
+			result: `value`,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.given, func(t *testing.T) {

--- a/pkg/infra/iac2/templates/package.json
+++ b/pkg/infra/iac2/templates/package.json
@@ -2,5 +2,8 @@
     "name": "pulumi-templates",
     "workspaces": [
         "*"
-    ]
+    ],
+    "devDependencies": {
+        "@types/node": "^18.15.11"
+    }
 }

--- a/pkg/infra/iac2/templates/secret_version/factory.ts
+++ b/pkg/infra/iac2/templates/secret_version/factory.ts
@@ -10,17 +10,19 @@ interface Args {
 }
 
 // noinspection JSUnusedLocalSymbols
-function create(args: Args): aws.secretsmanager.SecretVersion {
-    return new aws.secretsmanager.SecretVersion(
-        args.SecretName,
-        {
-            secretId: args.Secret.id,
-            //TMPL {{ if eq .Type.Raw "string" }}
-            //TMPL secretString: fs.readFileSync(args.Path, 'utf-8').toString()
-            //TMPL {{ else }}
-            secretBinary: fs.readFileSync(args.Path, 'base64').toString(),
-            //TMPL {{ end }}
-        },
-        { protect: args.protect }
-    )
+function create(args: Args): void {
+    if (fs.existsSync(args.Path)) {
+        new aws.secretsmanager.SecretVersion(
+            args.SecretName,
+            {
+                secretId: args.Secret.id,
+                //TMPL {{- if eq .Type.Raw "string" }}
+                secretString: fs.readFileSync(args.Path, 'utf-8').toString(),
+                //TMPL {{ else }}
+                //TMPL secretBinary: fs.readFileSync({{ .Path.Parse }}, 'base64').toString(),
+                //TMPL {{ end }}
+            },
+            { protect: args.protect }
+        )
+    }
 }

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -447,7 +447,7 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 	switch property {
 	case string(core.SECRET_NAME):
 		secret := resource.(*resources.Secret)
-		return secret.SecretName, nil
+		return quoteTsString(secret.SecretName, true), nil
 	case string(core.BUCKET_NAME):
 		return fmt.Sprintf("%s.bucket", tc.getVarName(resource)), nil
 	case resources.ARN_IAC_VALUE:

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -445,6 +445,9 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		return fmt.Sprintf("%s.names[%s]", tc.getVarName(v.Resource), v.Property), nil
 	}
 	switch property {
+	case string(core.SECRET_NAME):
+		secret := resource.(*resources.Secret)
+		return secret.SecretName, nil
 	case string(core.BUCKET_NAME):
 		return fmt.Sprintf("%s.bucket", tc.getVarName(resource)), nil
 	case resources.ARN_IAC_VALUE:
@@ -571,7 +574,7 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		return fmt.Sprintf(`%s.cidrBlock`, tc.getVarName(resource)), nil
 	}
 
-	return "", errors.Errorf("unsupported IaC Value Property, %s", property)
+	return "", errors.Errorf("unsupported IaC Value Property %T.%s", resource, property)
 }
 
 func (tc TemplatesCompiler) handleSingleIaCValue(v core.IaCValue) (string, error) {

--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -406,7 +406,7 @@ var dummyTemplateFiles = map[string]string{
 		interface Args {}
 
 		function create(args: Args): void {
-			return fs.ReadFile();
+			fs.ReadFile();
 		}`,
 
 	`dummy_big/nested_template.ts.tmpl`: `

--- a/pkg/provider/aws/config_resources.go
+++ b/pkg/provider/aws/config_resources.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"github.com/klothoplatform/klotho/pkg/core"
-	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 	"github.com/pkg/errors"
 )
 
@@ -12,42 +11,8 @@ func (a *AWS) GenerateConfigResources(construct *core.Config, result *core.Const
 		if cfg.Path == "" {
 			return errors.Errorf("'Path' required for config %s", construct.ID)
 		}
-		secret := resources.NewSecret(construct.Provenance(), cfg.Path, a.Config.AppName)
-		dag.AddResource(secret)
-		a.MapResourceDirectlyToConstruct(secret, construct)
-
-		secretVersion := resources.NewSecretVersion(secret, cfg.Path)
-		dag.AddResource(secretVersion)
-		dag.AddDependency(secretVersion, secret)
-
-		for _, upstreamCons := range result.GetUpstreamConstructs(construct) {
-			unit, isUnit := upstreamCons.(*core.ExecutionUnit)
-			if !isUnit {
-				continue
-			}
-
-			actions := []string{`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`}
-			policyResources := []core.IaCValue{{
-				Resource: secret,
-				Property: resources.ARN_IAC_VALUE,
-			}}
-			policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
-			policy := resources.NewIamPolicy(a.Config.AppName, construct.Id(), construct.Provenance(), policyDoc)
-			if res := dag.GetResource(policy.Id()); res != nil {
-				if existingPolicy, ok := res.(*resources.IamPolicy); ok {
-					existingPolicy.Policy.Statement = append(existingPolicy.Policy.Statement, policyDoc.Statement...)
-					dag.AddDependency(existingPolicy, secretVersion)
-				} else {
-					return errors.Errorf("expected resource with id, %s, to be an iam policy", res.Id())
-				}
-			} else {
-				dag.AddResource(policy)
-				dag.AddDependency(policy, secretVersion)
-				a.PolicyGenerator.AddAllowPolicyToUnit(unit.Id(), policy)
-			}
-		}
-		return nil
+		return a.generateSecret(construct, result, dag, cfg.Path)
 	}
 
-	return errors.New("unsupported")
+	return errors.Errorf("unsupported: non-secret config for annotation '%s'", construct.ID)
 }

--- a/pkg/provider/aws/config_resources.go
+++ b/pkg/provider/aws/config_resources.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+	"github.com/pkg/errors"
+)
+
+func (a *AWS) GenerateConfigResources(construct *core.Config, result *core.ConstructGraph, dag *core.ResourceGraph) error {
+	if construct.Secret {
+		cfg := a.Config.GetConfig(construct.ID)
+		if cfg.Path == "" {
+			return errors.Errorf("'Path' required for config %s", construct.ID)
+		}
+		secret := resources.NewSecret(construct.Provenance(), cfg.Path, a.Config.AppName)
+		dag.AddResource(secret)
+		a.MapResourceDirectlyToConstruct(secret, construct)
+
+		secretVersion := resources.NewSecretVersion(secret, cfg.Path)
+		dag.AddResource(secretVersion)
+		dag.AddDependency(secretVersion, secret)
+
+		for _, upstreamCons := range result.GetUpstreamConstructs(construct) {
+			unit, isUnit := upstreamCons.(*core.ExecutionUnit)
+			if !isUnit {
+				continue
+			}
+
+			actions := []string{`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`}
+			policyResources := []core.IaCValue{{
+				Resource: secret,
+				Property: resources.ARN_IAC_VALUE,
+			}}
+			policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
+			policy := resources.NewIamPolicy(a.Config.AppName, construct.Id(), construct.Provenance(), policyDoc)
+			if res := dag.GetResource(policy.Id()); res != nil {
+				if existingPolicy, ok := res.(*resources.IamPolicy); ok {
+					existingPolicy.Policy.Statement = append(existingPolicy.Policy.Statement, policyDoc.Statement...)
+					dag.AddDependency(existingPolicy, secretVersion)
+				} else {
+					return errors.Errorf("expected resource with id, %s, to be an iam policy", res.Id())
+				}
+			} else {
+				dag.AddResource(policy)
+				dag.AddDependency(policy, secretVersion)
+				a.PolicyGenerator.AddAllowPolicyToUnit(unit.Id(), policy)
+			}
+		}
+		return nil
+	}
+
+	return errors.New("unsupported")
+}

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -265,7 +265,6 @@ func (a *AWS) convertExecUnitParams(result *core.ConstructGraph, dag *core.Resou
 					}
 
 				}
-
 			} else {
 				resourceEnvVars[envVar.Name] = core.IaCValue{
 					Property: envVar.Value,

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -55,6 +55,8 @@ func (a *AWS) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) (l
 			merr.Append(a.GenerateOrmResources(construct, result, dag))
 		case *core.InternalResource:
 			merr.Append(a.GenerateFsResources(construct, result, dag))
+		case *core.Config:
+			merr.Append(a.GenerateConfigResources(construct, result, dag))
 		default:
 			// TODO convert to error once migration to ifc2 is complete
 			log.Warnf("Unsupported resource %s", construct.Id())

--- a/pkg/provider/aws/resources/secret.go
+++ b/pkg/provider/aws/resources/secret.go
@@ -28,7 +28,10 @@ const SECRET_TYPE = "secret"
 const SECRET_VERSION_TYPE = "secret_version"
 
 func NewSecret(annot core.AnnotationKey, secretName string, appName string) *Secret {
-	plainName := fmt.Sprintf("%s-%s-%s", appName, annot.ID, secretName)
+	plainName := fmt.Sprintf("%s-%s", appName, annot.ID)
+	if secretName != "" {
+		plainName += "-" + secretName
+	}
 	return &Secret{
 		Name:          plainName,
 		SecretName:    aws.SecretSanitizer.Apply(plainName),

--- a/pkg/provider/aws/secret.go
+++ b/pkg/provider/aws/secret.go
@@ -2,45 +2,50 @@ package aws
 
 import (
 	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/multierr"
 	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 	"github.com/pkg/errors"
 )
 
 func (a *AWS) GenerateSecretsResources(construct *core.Secrets, result *core.ConstructGraph, dag *core.ResourceGraph) error {
-	for _, single := range construct.Secrets {
-		secret := resources.NewSecret(construct.Provenance(), single, a.Config.AppName)
-		dag.AddResource(secret)
-		a.MapResourceDirectlyToConstruct(secret, construct)
+	var merr multierr.Error
+	for _, secretName := range construct.Secrets {
+		merr.Append(a.generateSecret(construct, result, dag, secretName))
+	}
+	return merr.ErrOrNil()
+}
 
-		secretVersion := resources.NewSecretVersion(secret, single)
-		dag.AddResource(secretVersion)
-		dag.AddDependency(secretVersion, secret)
+func (a *AWS) generateSecret(construct core.Construct, result *core.ConstructGraph, dag *core.ResourceGraph, secretName string) error {
+	secret := resources.NewSecret(construct.Provenance(), secretName, a.Config.AppName)
+	dag.AddResource(secret)
+	a.MapResourceDirectlyToConstruct(secret, construct)
 
-		for _, upstreamCons := range result.GetUpstreamConstructs(construct) {
-			unit, isUnit := upstreamCons.(*core.ExecutionUnit)
-			if !isUnit {
-				continue
-			}
+	secretVersion := resources.NewSecretVersion(secret, secretName)
+	dag.AddDependenciesReflect(secretVersion)
 
-			actions := []string{`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`}
-			policyResources := []core.IaCValue{{
-				Resource: secret,
-				Property: resources.ARN_IAC_VALUE,
-			}}
-			policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
-			policy := resources.NewIamPolicy(a.Config.AppName, construct.Id(), construct.Provenance(), policyDoc)
-			if res := dag.GetResource(policy.Id()); res != nil {
-				if existingPolicy, ok := res.(*resources.IamPolicy); ok {
-					existingPolicy.Policy.Statement = append(existingPolicy.Policy.Statement, policyDoc.Statement...)
-					dag.AddDependency(existingPolicy, secretVersion)
-				} else {
-					return errors.Errorf("expected resource with id, %s, to be an iam policy", res.Id())
-				}
+	for _, upstreamCons := range result.GetUpstreamConstructs(construct) {
+		unit, isUnit := upstreamCons.(*core.ExecutionUnit)
+		if !isUnit {
+			continue
+		}
+
+		actions := []string{`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`}
+		policyResources := []core.IaCValue{{
+			Resource: secret,
+			Property: resources.ARN_IAC_VALUE,
+		}}
+		policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)
+		policy := resources.NewIamPolicy(a.Config.AppName, construct.Id(), construct.Provenance(), policyDoc)
+		if res := dag.GetResource(policy.Id()); res != nil {
+			if existingPolicy, ok := res.(*resources.IamPolicy); ok {
+				existingPolicy.Policy.Statement = append(existingPolicy.Policy.Statement, policyDoc.Statement...)
+				dag.AddDependency(existingPolicy, secret)
 			} else {
-				dag.AddResource(policy)
-				dag.AddDependency(policy, secretVersion)
-				a.PolicyGenerator.AddAllowPolicyToUnit(unit.Id(), policy)
+				return errors.Errorf("expected resource with id, %s, to be an iam policy", res.Id())
 			}
+		} else {
+			dag.AddDependenciesReflect(policy)
+			a.PolicyGenerator.AddAllowPolicyToUnit(unit.Id(), policy)
 		}
 	}
 	return nil

--- a/pkg/provider/aws/secret.go
+++ b/pkg/provider/aws/secret.go
@@ -24,7 +24,7 @@ func (a *AWS) GenerateSecretsResources(construct *core.Secrets, result *core.Con
 
 			actions := []string{`secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`}
 			policyResources := []core.IaCValue{{
-				Resource: secretVersion,
+				Resource: secret,
 				Property: resources.ARN_IAC_VALUE,
 			}}
 			policyDoc := resources.CreateAllowPolicyDocument(actions, policyResources)

--- a/pkg/provider/aws/secret_test.go
+++ b/pkg/provider/aws/secret_test.go
@@ -40,8 +40,8 @@ func TestGenerateSecretsResources(t *testing.T) {
 					"aws:secret_version:AppName-MySecrets-secret2",
 				},
 				Deps: []coretesting.StringDep{
-					{Source: "aws:iam_policy:AppName-persist_MySecrets", Destination: "aws:secret_version:AppName-MySecrets-secret1"},
-					{Source: "aws:iam_policy:AppName-persist_MySecrets", Destination: "aws:secret_version:AppName-MySecrets-secret2"},
+					{Source: "aws:iam_policy:AppName-persist_MySecrets", Destination: "aws:secret:AppName-MySecrets-secret1"},
+					{Source: "aws:iam_policy:AppName-persist_MySecrets", Destination: "aws:secret:AppName-MySecrets-secret2"},
 					{Source: "aws:secret_version:AppName-MySecrets-secret1", Destination: "aws:secret:AppName-MySecrets-secret1"},
 					{Source: "aws:secret_version:AppName-MySecrets-secret2", Destination: "aws:secret:AppName-MySecrets-secret2"},
 				},


### PR DESCRIPTION
Support config secrets for https://github.com/klothoplatform/klotho/issues/502

from `go-secrets` sample app
```ts
const awsSecretGgDevMySecretMySecretKey = new aws.secretsmanager.Secret(
        `gg-dev-mySecret-my_secret.key`,
        {
            name: `gg-dev-mySecret-my_secret.key`,
            recoveryWindowInDays: 0,
        },
        { protect: protect }
    );

if (fs.existsSync(`my_secret.key`)) {
        new aws.secretsmanager.SecretVersion(
            `gg-dev-mySecret-my_secret.key`,
            {
                secretId: awsSecretGgDevMySecretMySecretKey.id,
                secretBinary: fs.readFileSync(`my_secret.key`, 'base64').toString(),
                
            },
            { protect: protect }
        )
    };

const awsIamPolicyGgDevConfigMySecret = new aws.iam.Policy(`gg-dev-config_mySecret`, {
        policy: {Version: `2012-10-17`,
Statement: [{Effect: `Allow`,
Action: [`secretsmanager:DescribeSecret`,`secretsmanager:GetSecretValue`],
Resource: [awsSecretGgDevMySecretMySecretKey.arn],
}],
},
    });
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
