### PR TITLE
add the alb controller when exposed k8s units exist

### DIFF
--- a/pkg/infra/kubernetes/manifests/service_account.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/service_account.yaml.tmpl
@@ -2,5 +2,9 @@ apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
-  name: {{ .ExecUnitName }}
+  {{- if .IRSA }}
+  annotations:
+    eks.amazonaws.com/role-arn: REPLACE_ME
+  {{- end }}
+  name: {{ .Name }}
   namespace: {{ .Namespace }}

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -73,29 +73,7 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 		if cluster == nil {
 			return errors.Errorf("Expected to have cluster created for unit, %s, but did not find cluster in graph", unit.ID)
 		}
-		role.AssumeRolePolicyDoc = &resources.PolicyDocument{
-			Version: resources.VERSION,
-			Statement: []resources.StatementEntry{
-				{
-					Effect: "Allow",
-					Principal: &resources.Principal{
-						Federated: core.IaCValue{
-							Resource: cluster,
-							Property: resources.CLUSTER_OIDC_ARN_IAC_VALUE,
-						},
-					},
-					Action: []string{"sts:AssumeRoleWithWebIdentity"},
-					Condition: &resources.Condition{
-						StringEquals: map[core.IaCValue]string{
-							{
-								Resource: cluster,
-								Property: resources.CLUSTER_OIDC_URL_IAC_VALUE,
-							}: fmt.Sprintf("system:serviceaccount:default:%s", unit.ID), // TODO: Replace default with the namespace when we expose via configuration
-						},
-					},
-				},
-			},
-		}
+		role.AssumeRolePolicyDoc = cluster.GetServiceAccountAssumeRolePolicy(unit.ID)
 		// transform kubernetes resources for EKS
 		for _, res := range dag.ListResources() {
 			if khChart, ok := res.(*kubernetes.HelmChart); ok {

--- a/pkg/provider/aws/expose.go
+++ b/pkg/provider/aws/expose.go
@@ -149,6 +149,15 @@ func (a *AWS) createIntegration(method *resources.ApiMethod, unit *core.Executio
 		dag.AddDependenciesReflect(integration)
 		return integration, nil
 	case kubernetes.KubernetesType:
+
+		cluster, err := findUnitsCluster(unit, dag)
+		if err != nil {
+			return nil, err
+		}
+		err = cluster.InstallAlbController([]core.AnnotationKey{unit.AnnotationKey}, dag)
+		if err != nil {
+			return nil, err
+		}
 		nlb := dag.GetResource(resources.NewLoadBalancer(a.Config.AppName, unit.ID, nil, "internal", "network", nil, nil).Id())
 		if nlb == nil {
 			return nil, errors.Errorf("No nlb created for unit %s", unit.ID)

--- a/pkg/provider/aws/expose_test.go
+++ b/pkg/provider/aws/expose_test.go
@@ -26,6 +26,7 @@ func Test_CreateRestApi(t *testing.T) {
 		gw                     *core.Gateway
 		units                  []*core.ExecutionUnit
 		constructIdToResources map[string][]core.Resource
+		existingResources      []core.Resource
 		cfg                    config.Application
 		want                   coretesting.ResourcesExpectation
 		wantErr                bool
@@ -240,6 +241,13 @@ func Test_CreateRestApi(t *testing.T) {
 					resources.NewLoadBalancer(appName, unit2.ID, nil, "internal", "network", nil, nil),
 				},
 			},
+			existingResources: []core.Resource{
+				&resources.EksCluster{
+					Name:          "Cluster",
+					ConstructsRef: []core.AnnotationKey{unit1.AnnotationKey, unit2.AnnotationKey},
+					Subnets:       []*resources.Subnet{resources.NewSubnet("1", resources.NewVpc("test"), "", "", core.IaCValue{})},
+				},
+			},
 			cfg: config.Application{
 				AppName: appName,
 				Defaults: config.Defaults{
@@ -265,6 +273,13 @@ func Test_CreateRestApi(t *testing.T) {
 					"aws:rest_api:test-test",
 					"aws:vpc_link:aws:load_balancer:test-test",
 					"aws:vpc_link:aws:load_balancer:test-test2",
+					"aws:eks_cluster:Cluster",
+					"aws:iam_policy:Cluster-alb-controller",
+					"aws:iam_role:Cluster-alb-controller",
+					"aws:region:region",
+					"aws:vpc:test",
+					"kubernetes:helm_chart:Cluster-alb-controller",
+					"kubernetes:manifest:Cluster-alb-controller-service-account",
 				},
 				Deps: []graph.Edge[string]{
 					{Source: "aws:api_deployment:test-test", Destination: "aws:api_integration:test-test-GET"},
@@ -309,6 +324,13 @@ func Test_CreateRestApi(t *testing.T) {
 					{Source: "aws:api_stage:test-test-stage", Destination: "aws:rest_api:test-test"},
 					{Source: "aws:vpc_link:aws:load_balancer:test-test", Destination: "aws:load_balancer:test-test"},
 					{Source: "aws:vpc_link:aws:load_balancer:test-test2", Destination: "aws:load_balancer:test-test2"},
+					{Source: "aws:iam_role:Cluster-alb-controller", Destination: "aws:eks_cluster:Cluster"},
+					{Source: "aws:iam_role:Cluster-alb-controller", Destination: "aws:iam_policy:Cluster-alb-controller"},
+					{Source: "kubernetes:helm_chart:Cluster-alb-controller", Destination: "aws:eks_cluster:Cluster"},
+					{Source: "kubernetes:helm_chart:Cluster-alb-controller", Destination: "aws:region:region"},
+					{Source: "kubernetes:helm_chart:Cluster-alb-controller", Destination: "aws:vpc:test"},
+					{Source: "kubernetes:manifest:Cluster-alb-controller-service-account", Destination: "aws:eks_cluster:Cluster"},
+					{Source: "kubernetes:manifest:Cluster-alb-controller-service-account", Destination: "aws:iam_role:Cluster-alb-controller"},
 				},
 			},
 		},
@@ -326,6 +348,9 @@ func Test_CreateRestApi(t *testing.T) {
 				for _, res := range resources {
 					dag.AddResource(res)
 				}
+			}
+			for _, res := range tt.existingResources {
+				dag.AddResource(res)
 			}
 			result := core.NewConstructGraph()
 			result.AddConstruct(tt.gw)

--- a/pkg/provider/aws/resources/iam.go
+++ b/pkg/provider/aws/resources/iam.go
@@ -125,6 +125,7 @@ type (
 
 	Condition struct {
 		StringEquals map[core.IaCValue]string
+		Null         map[core.IaCValue]string
 	}
 )
 


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

The following PR
- Adds the alb controller including, its service account manifest, and its iam role with the necessary iam policy to give it permissions to ec2, etc
- Modifies how we output the key in maps for the condition fields within the policy in the iac2 plugin, due to pulumis expected input
- Adds a general generation for service account manifests that can be used outside of klotho helm charts


### Standard checks

- **Unit tests**: Any special considerations? added/modified
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
