### PR TITLE
(optional) refactor exec unit transformation functions

### DIFF
--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -55,11 +55,8 @@ func (transformer manifestTransformer[K]) apply(unit *HelmExecUnit, cfg config.E
 	}
 	transformObj, ok := obj.(K)
 	if !ok {
-		t := reflect.TypeOf((*K)(nil))
-		for t.Kind() == reflect.Pointer {
-			t = t.Elem()
-		}
-		err = fmt.Errorf("expected file %s to contain %s Kind", source.Path(), t.Name())
+		var k K
+		err = fmt.Errorf("expected file %s to contain %T Kind", source.Path(), t)
 		return nil, err
 	}
 

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -3,11 +3,12 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/runtime"
 	"regexp"
 
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/yaml"
@@ -28,6 +29,49 @@ type HelmExecUnit struct {
 	TargetGroupBinding      *core.SourceFile
 	ServiceExport           *core.SourceFile
 	HorizontalPodAutoscaler *core.SourceFile
+}
+
+type manifestTransformer[K runtime.Object] struct {
+	manifestKind     string
+	fieldToTransform func(unit *HelmExecUnit) *core.SourceFile
+	transform        func(unit *HelmExecUnit, cfg config.ExecutionUnit, target K, log *zap.SugaredLogger) ([]HelmChartValue, error)
+	// readF is the function to read a given file to the runtime.Object that we will then cast down to K. You may leave
+	// it blank, in which case the transformer will assume readFile.
+	readF func(f *core.SourceFile) (runtime.Object, error)
+}
+
+func (transformer manifestTransformer[K]) apply(unit *HelmExecUnit, cfg config.ExecutionUnit) ([]HelmChartValue, error) {
+	source := transformer.fieldToTransform(unit)
+	log := zap.L().Sugar().With(logging.FileField(source), zap.String("unit", unit.Name))
+	log.Debugf("Transforming file, %s, for exec unit, %s", source.Path(), unit.Name)
+	readF := transformer.readF
+	if readF == nil {
+		readF = readFile
+	}
+	obj, err := readF(source)
+	if err != nil {
+		return nil, err
+	}
+	transformObj, ok := obj.(K)
+	if !ok {
+		err = fmt.Errorf("expected file %s to contain %s Kind", source.Path(), transformer.manifestKind)
+		return nil, err
+	}
+
+	newValues, err := transformer.transform(unit, cfg, transformObj, log)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := yaml.Marshal(transformObj)
+	if err != nil {
+		return nil, err
+	}
+	err = source.Reparse([]byte(output))
+	if err != nil {
+		return nil, err
+	}
+	return newValues, nil
 }
 
 var (
@@ -76,197 +120,171 @@ func shouldTransformServiceAccount(unit *core.ExecutionUnit) bool {
 	return shouldTransformImage(unit)
 }
 
-func (unit *HelmExecUnit) transformPod(cfg config.ExecutionUnit) (values []HelmChartValue, err error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.Pod), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.Pod.Path(), unit.Name)
-	obj, err := readFile(unit.Pod)
-	if err != nil {
-		return
-	}
-	pod, ok := obj.(*corev1.Pod)
-	if !ok {
-		err = fmt.Errorf("expected file %s to contain Pod Kind", unit.Pod.Path())
-		return
-	}
+var podTransformer = manifestTransformer[*corev1.Pod]{
+	manifestKind: "Pod",
 
-	_, imagePlaceholder, err := unit.upsertOnlyContainer(&pod.Spec.Containers, cfg)
-	if err != nil {
-		return nil, err
-	}
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.Pod
+	},
 
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
-	pod.Labels["execUnit"] = unit.Name
-	pod.Spec.ServiceAccountName = unit.getServiceAccountName()
-
-	output, err := yaml.Marshal(pod)
-	if err != nil {
-		return
-	}
-	err = unit.Pod.Reparse([]byte(output))
-	if err != nil {
-		return
-	}
-	values = append(values, HelmChartValue{
-		ExecUnitName: unit.Name,
-		Kind:         pod.Kind,
-		Type:         string(ImageTransformation),
-		Key:          imagePlaceholder,
-	})
-	return
-}
-
-func (unit *HelmExecUnit) transformDeployment(cfg config.ExecutionUnit) (values []HelmChartValue, err error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.Deployment), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.Deployment.Path(), unit.Name)
-	obj, err := readFile(unit.Deployment)
-	if err != nil {
-		return nil, err
-	}
-	deployment, ok := obj.(*apps.Deployment)
-	if !ok {
-		err = fmt.Errorf("expected file %s to contain Deployment Kind", unit.Deployment.Path())
-		return nil, err
-	}
-
-	k8sCfg, imagePlaceholder, err := unit.upsertOnlyContainer(&deployment.Spec.Template.Spec.Containers, cfg)
-	if err != nil {
-		return nil, err
-	}
-	values = append(values, HelmChartValue{
-		ExecUnitName: unit.Name,
-		Kind:         deployment.Kind,
-		Type:         string(ImageTransformation),
-		Key:          imagePlaceholder,
-	})
-
-	extraLabels := generateLabels(k8sCfg)
-
-	if deployment.Labels == nil {
-		deployment.Labels = make(map[string]string)
-	}
-	deployment.Labels["execUnit"] = unit.Name
-	extraLabels.addTo(deployment.Labels)
-
-	if k8sCfg.Replicas != 0 {
-		*deployment.Spec.Replicas = int32(k8sCfg.Replicas)
-	}
-
-	if deployment.Spec.Template.Labels == nil {
-		deployment.Spec.Template.Labels = make(map[string]string)
-	}
-	deployment.Spec.Template.Labels["execUnit"] = unit.Name
-	deployment.Spec.Template.Spec.ServiceAccountName = unit.getServiceAccountName()
-	extraLabels.addTo(deployment.Spec.Template.Labels)
-
-	if deployment.Spec.Selector.MatchLabels == nil {
-		deployment.Spec.Selector.MatchLabels = make(map[string]string)
-	}
-	deployment.Spec.Selector.MatchLabels["execUnit"] = unit.Name
-	extraLabels.addTo(deployment.Spec.Selector.MatchLabels)
-
-	if deployment.Spec.Template.Spec.NodeSelector == nil {
-		deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
-	}
-
-	if cfg.NetworkPlacement != "" {
-		deployment.Spec.Template.Spec.NodeSelector["network_placement"] = cfg.NetworkPlacement
-	}
-	if kconfig := cfg.GetExecutionUnitParamsAsKubernetes(); kconfig.InstanceType != "" {
-		instanceTypeKey := unit.Name + "InstanceTypeKey"
-		instanceTypeValue := unit.Name + "InstanceTypeValue"
-		deployment.Spec.Template.Spec.NodeSelector[fmt.Sprintf("{{ .Values.%s }}", instanceTypeKey)] = fmt.Sprintf("{{ .Values.%s }}", instanceTypeValue)
-		values = append(values,
-			HelmChartValue{
-				ExecUnitName: unit.Name,
-				Kind:         deployment.Kind,
-				Type:         string(InstanceTypeKey),
-				Key:          instanceTypeKey,
-			},
-			HelmChartValue{
-				ExecUnitName: unit.Name,
-				Kind:         deployment.Kind,
-				Type:         string(InstanceTypeValue),
-				Key:          instanceTypeValue,
-			},
-		)
-	} else if kconfig.DiskSizeGiB > 0 {
-		log.Warnf("Unimplemented: disk size configured of %d ignored due to missing instance type", kconfig.DiskSizeGiB)
-	}
-
-	output, err := yaml.Marshal(deployment)
-	if err != nil {
-		return nil, err
-	}
-	err = unit.Deployment.Reparse([]byte(output))
-	if err != nil {
-		return nil, err
-	}
-
-	return values, nil
-}
-
-func (unit *HelmExecUnit) transformHorizontalPodAutoscaler(cfg config.ExecutionUnit) ([]HelmChartValue, error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.HorizontalPodAutoscaler), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.HorizontalPodAutoscaler.Path(), unit.Name)
-	obj, err := readFile(unit.HorizontalPodAutoscaler)
-	if err != nil {
-		return nil, nil
-	}
-	hpa, ok := obj.(*autoscaling.HorizontalPodAutoscaler)
-	if !ok {
-		return nil, fmt.Errorf("expected file %s to contain HorizontalPodAutoscaler Kind", unit.HorizontalPodAutoscaler.Path())
-	}
-	k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
-	hpaCfg := k8Cfg.HorizontalPodAutoScalingConfig
-
-	if k8Cfg.Replicas != 0 {
-		minReplicas := int32(k8Cfg.Replicas)
-		hpa.Spec.MinReplicas = &minReplicas
-		if hpaCfg.MaxReplicas == 0 {
-			hpaCfg.MaxReplicas = int(minReplicas) * 2
+	transform: func(unit *HelmExecUnit, cfg config.ExecutionUnit, pod *corev1.Pod, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		_, imagePlaceholder, err := unit.upsertOnlyContainer(&pod.Spec.Containers, cfg)
+		if err != nil {
+			return nil, err
 		}
-	}
 
-	if hpaCfg.MaxReplicas != 0 {
-		maxReplicas := int32(hpaCfg.MaxReplicas)
-		if maxReplicas < *hpa.Spec.MinReplicas {
-			log.Errorf(`cannot set maxReplicas to %v because that's less than minReplicas (%v)`,
-				hpaCfg.MaxReplicas,
-				*hpa.Spec.MinReplicas,
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		pod.Labels["execUnit"] = unit.Name
+		pod.Spec.ServiceAccountName = unit.getServiceAccountName()
+
+		output, err := yaml.Marshal(pod)
+		if err != nil {
+			return nil, err
+		}
+		err = unit.Pod.Reparse([]byte(output))
+		if err != nil {
+			return nil, err
+		}
+		return []HelmChartValue{
+			HelmChartValue{
+				ExecUnitName: unit.Name,
+				Kind:         pod.Kind,
+				Type:         string(ImageTransformation),
+				Key:          imagePlaceholder,
+			},
+		}, nil
+	},
+}
+
+var deploymentTransformer = manifestTransformer[*apps.Deployment]{
+	manifestKind: "Deployment",
+
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.Deployment
+	},
+
+	transform: func(unit *HelmExecUnit, cfg config.ExecutionUnit, deployment *apps.Deployment, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		k8sCfg, imagePlaceholder, err := unit.upsertOnlyContainer(&deployment.Spec.Template.Spec.Containers, cfg)
+		if err != nil {
+			return nil, err
+		}
+		var values []HelmChartValue
+		values = []HelmChartValue{
+			HelmChartValue{
+				ExecUnitName: unit.Name,
+				Kind:         deployment.Kind,
+				Type:         string(ImageTransformation),
+				Key:          imagePlaceholder,
+			},
+		}
+
+		extraLabels := generateLabels(k8sCfg)
+
+		if deployment.Labels == nil {
+			deployment.Labels = make(map[string]string)
+		}
+		deployment.Labels["execUnit"] = unit.Name
+		extraLabels.addTo(deployment.Labels)
+
+		if k8sCfg.Replicas != 0 {
+			*deployment.Spec.Replicas = int32(k8sCfg.Replicas)
+		}
+
+		if deployment.Spec.Template.Labels == nil {
+			deployment.Spec.Template.Labels = make(map[string]string)
+		}
+		deployment.Spec.Template.Labels["execUnit"] = unit.Name
+		deployment.Spec.Template.Spec.ServiceAccountName = unit.getServiceAccountName()
+		extraLabels.addTo(deployment.Spec.Template.Labels)
+
+		if deployment.Spec.Selector.MatchLabels == nil {
+			deployment.Spec.Selector.MatchLabels = make(map[string]string)
+		}
+		deployment.Spec.Selector.MatchLabels["execUnit"] = unit.Name
+		extraLabels.addTo(deployment.Spec.Selector.MatchLabels)
+
+		if deployment.Spec.Template.Spec.NodeSelector == nil {
+			deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
+		}
+
+		if cfg.NetworkPlacement != "" {
+			deployment.Spec.Template.Spec.NodeSelector["network_placement"] = cfg.NetworkPlacement
+		}
+		if kconfig := cfg.GetExecutionUnitParamsAsKubernetes(); kconfig.InstanceType != "" {
+			instanceTypeKey := unit.Name + "InstanceTypeKey"
+			instanceTypeValue := unit.Name + "InstanceTypeValue"
+			deployment.Spec.Template.Spec.NodeSelector[fmt.Sprintf("{{ .Values.%s }}", instanceTypeKey)] = fmt.Sprintf("{{ .Values.%s }}", instanceTypeValue)
+			values = append(values,
+				HelmChartValue{
+					ExecUnitName: unit.Name,
+					Kind:         deployment.Kind,
+					Type:         string(InstanceTypeKey),
+					Key:          instanceTypeKey,
+				},
+				HelmChartValue{
+					ExecUnitName: unit.Name,
+					Kind:         deployment.Kind,
+					Type:         string(InstanceTypeValue),
+					Key:          instanceTypeValue,
+				},
 			)
-		} else {
-			hpa.Spec.MaxReplicas = maxReplicas
+		} else if kconfig.DiskSizeGiB > 0 {
+			log.Warnf("Unimplemented: disk size configured of %d ignored due to missing instance type", kconfig.DiskSizeGiB)
 		}
-	}
-	if hpaCfg.CpuUtilization != 0 {
-		cpu := int32(hpaCfg.CpuUtilization)
-		res := getOrCreateMetricResource(&hpa.Spec.Metrics, corev1.ResourceCPU)
-		res.Target = autoscaling.MetricTarget{
-			Type:               autoscaling.UtilizationMetricType,
-			AverageUtilization: &cpu,
-		}
-	}
-	if hpaCfg.MemoryUtilization != 0 {
-		mem := int32(hpaCfg.MemoryUtilization)
-		res := getOrCreateMetricResource(&hpa.Spec.Metrics, corev1.ResourceMemory)
-		res.Target = autoscaling.MetricTarget{
-			Type:               autoscaling.UtilizationMetricType,
-			AverageUtilization: &mem,
-		}
-	}
+		return values, nil
+	},
+}
 
-	output, err := yaml.Marshal(hpa)
-	if err != nil {
-		return nil, err
-	}
-	manifest := string(output)
-	err = unit.HorizontalPodAutoscaler.Reparse([]byte(manifest))
-	if err != nil {
-		return nil, err
-	}
-	return nil, nil
+var horizontalPodAutoscalerTransformer = manifestTransformer[*autoscaling.HorizontalPodAutoscaler]{
+	manifestKind: "HorizontalPodAutoscaler",
+
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.HorizontalPodAutoscaler
+	},
+
+	transform: func(unit *HelmExecUnit, cfg config.ExecutionUnit, hpa *autoscaling.HorizontalPodAutoscaler, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
+		hpaCfg := k8Cfg.HorizontalPodAutoScalingConfig
+
+		if k8Cfg.Replicas != 0 {
+			minReplicas := int32(k8Cfg.Replicas)
+			hpa.Spec.MinReplicas = &minReplicas
+			if hpaCfg.MaxReplicas == 0 {
+				hpaCfg.MaxReplicas = int(minReplicas) * 2
+			}
+		}
+
+		if hpaCfg.MaxReplicas != 0 {
+			maxReplicas := int32(hpaCfg.MaxReplicas)
+			if maxReplicas < *hpa.Spec.MinReplicas {
+				log.Errorf(`cannot set maxReplicas to %v because that's less than minReplicas (%v)`,
+					hpaCfg.MaxReplicas,
+					*hpa.Spec.MinReplicas,
+				)
+			} else {
+				hpa.Spec.MaxReplicas = maxReplicas
+			}
+		}
+		if hpaCfg.CpuUtilization != 0 {
+			cpu := int32(hpaCfg.CpuUtilization)
+			res := getOrCreateMetricResource(&hpa.Spec.Metrics, corev1.ResourceCPU)
+			res.Target = autoscaling.MetricTarget{
+				Type:               autoscaling.UtilizationMetricType,
+				AverageUtilization: &cpu,
+			}
+		}
+		if hpaCfg.MemoryUtilization != 0 {
+			mem := int32(hpaCfg.MemoryUtilization)
+			res := getOrCreateMetricResource(&hpa.Spec.Metrics, corev1.ResourceMemory)
+			res.Target = autoscaling.MetricTarget{
+				Type:               autoscaling.UtilizationMetricType,
+				AverageUtilization: &mem,
+			}
+		}
+		return nil, nil
+	},
 }
 
 func getOrCreateMetricResource(metrics *[]autoscaling.MetricSpec, name corev1.ResourceName) *autoscaling.ResourceMetricSource {
@@ -290,120 +308,90 @@ func getOrCreateMetricResource(metrics *[]autoscaling.MetricSpec, name corev1.Re
 	return createdRes
 }
 
-func (unit *HelmExecUnit) transformService(cfg config.ExecutionUnit) (values []HelmChartValue, err error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.Service), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.Service.Path(), unit.Name)
-	obj, err := readFile(unit.Service)
-	if err != nil {
-		return
-	}
-	service, ok := obj.(*corev1.Service)
-	if !ok {
-		err = fmt.Errorf("expected file %s to contain ServiceAccount Kind", unit.ServiceAccount.Path())
-		return
-	}
+var serviceTransformer = manifestTransformer[*corev1.Service]{
+	manifestKind: "Service",
 
-	k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
-	extraLabels := generateLabels(k8Cfg)
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.Service
+	},
 
-	if service.Spec.Selector == nil {
-		service.Spec.Selector = make(map[string]string)
-	}
-	service.Spec.Selector["execUnit"] = unit.Name
-	extraLabels.addTo(service.Spec.Selector)
+	transform: func(unit *HelmExecUnit, cfg config.ExecutionUnit, service *corev1.Service, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		k8Cfg := cfg.GetExecutionUnitParamsAsKubernetes()
+		extraLabels := generateLabels(k8Cfg)
 
-	if service.Labels == nil {
-		service.Labels = make(map[string]string)
-	}
-	service.Labels["execUnit"] = unit.Name
-	extraLabels.addTo(service.Labels)
+		if service.Spec.Selector == nil {
+			service.Spec.Selector = make(map[string]string)
+		}
+		service.Spec.Selector["execUnit"] = unit.Name
+		extraLabels.addTo(service.Spec.Selector)
 
-	output, err := yaml.Marshal(service)
-	if err != nil {
-		return nil, err
-	}
-	manifest := string(output)
-	err = unit.Service.Reparse([]byte(manifest))
-	if err != nil {
-		return nil, err
-	}
-	return
+		if service.Labels == nil {
+			service.Labels = make(map[string]string)
+		}
+		service.Labels["execUnit"] = unit.Name
+		extraLabels.addTo(service.Labels)
+
+		return nil, nil
+	},
 }
 
-func (unit *HelmExecUnit) transformServiceAccount() (values []HelmChartValue, err error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.ServiceAccount), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.ServiceAccount.Path(), unit.Name)
-	obj, err := readFile(unit.ServiceAccount)
-	if err != nil {
-		return
-	}
-	serviceAccount, ok := obj.(*corev1.ServiceAccount)
-	if !ok {
-		err = fmt.Errorf("expected file %s to contain ServiceAccount Kind", unit.ServiceAccount.Path())
-		return
-	}
-	value := GenerateRoleArnPlaceholder(unit.Name)
-	if serviceAccount.Annotations == nil {
-		serviceAccount.Annotations = make(map[string]string)
-	}
-	serviceAccount.Annotations[EKS_ANNOTATION_KEY] = fmt.Sprintf("{{ .Values.%s }}", value)
-	if serviceAccount.Labels == nil {
-		serviceAccount.Labels = make(map[string]string)
-	}
-	serviceAccount.Labels["execUnit"] = unit.Name
+var serviceAccountTransformer = manifestTransformer[*corev1.ServiceAccount]{
+	manifestKind: "ServiceAccount",
 
-	output, err := yaml.Marshal(serviceAccount)
-	if err != nil {
-		return nil, err
-	}
-	err = unit.ServiceAccount.Reparse([]byte(output))
-	if err != nil {
-		return nil, err
-	}
-	values = append(values, HelmChartValue{
-		ExecUnitName: unit.Name,
-		Kind:         serviceAccount.Kind,
-		Type:         string(ServiceAccountAnnotationTransformation),
-		Key:          value,
-	})
-	return
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.ServiceAccount
+	},
+
+	transform: func(unit *HelmExecUnit, _cfg config.ExecutionUnit, serviceAccount *corev1.ServiceAccount, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		value := GenerateRoleArnPlaceholder(unit.Name)
+		if serviceAccount.Annotations == nil {
+			serviceAccount.Annotations = make(map[string]string)
+		}
+		serviceAccount.Annotations[EKS_ANNOTATION_KEY] = fmt.Sprintf("{{ .Values.%s }}", value)
+		if serviceAccount.Labels == nil {
+			serviceAccount.Labels = make(map[string]string)
+		}
+		serviceAccount.Labels["execUnit"] = unit.Name
+
+		return []HelmChartValue{
+			HelmChartValue{
+				ExecUnitName: unit.Name,
+				Kind:         serviceAccount.Kind,
+				Type:         string(ServiceAccountAnnotationTransformation),
+				Key:          value,
+			},
+		}, nil
+	},
 }
 
-func (unit *HelmExecUnit) transformTargetGroupBinding() (values []HelmChartValue, err error) {
-	log := zap.L().Sugar().With(logging.FileField(unit.TargetGroupBinding), zap.String("unit", unit.Name))
-	log.Debugf("Transforming file, %s, for exec unit, %s", unit.TargetGroupBinding.Path(), unit.Name)
-	obj, err := readElbv2ApiFiles(unit.TargetGroupBinding)
-	if err != nil {
-		return
-	}
-	targetGroupBinding, ok := obj.(*elbv2api.TargetGroupBinding)
-	if !ok {
-		err = fmt.Errorf("expected file %s to contain TargetGroupBinding Kind", unit.TargetGroupBinding.Path())
-		return
-	}
-	value := GenerateTargetGroupBindingPlaceholder(unit.Name)
+var targetGroupBindingTransformer = manifestTransformer[*elbv2api.TargetGroupBinding]{
+	manifestKind: "TargetGroupBinding",
 
-	targetGroupBinding.Spec.TargetGroupARN = fmt.Sprintf("{{ .Values.%s }}", value)
+	fieldToTransform: func(unit *HelmExecUnit) *core.SourceFile {
+		return unit.TargetGroupBinding
+	},
 
-	if targetGroupBinding.Labels == nil {
-		targetGroupBinding.Labels = make(map[string]string)
-	}
-	targetGroupBinding.Labels["execUnit"] = unit.Name
-	output, err := yaml.Marshal(targetGroupBinding)
-	if err != nil {
-		return nil, err
-	}
-	err = unit.TargetGroupBinding.Reparse([]byte(output))
-	if err != nil {
-		return nil, err
-	}
-	values = append(values, HelmChartValue{
-		ExecUnitName: unit.Name,
-		Kind:         targetGroupBinding.Kind,
-		Type:         string(TargetGroupTransformation),
-		Key:          value,
-	})
-	return
+	readF: readElbv2ApiFiles,
+
+	transform: func(unit *HelmExecUnit, cfg config.ExecutionUnit, targetGroupBinding *elbv2api.TargetGroupBinding, log *zap.SugaredLogger) ([]HelmChartValue, error) {
+		value := GenerateTargetGroupBindingPlaceholder(unit.Name)
+
+		targetGroupBinding.Spec.TargetGroupARN = fmt.Sprintf("{{ .Values.%s }}", value)
+
+		if targetGroupBinding.Labels == nil {
+			targetGroupBinding.Labels = make(map[string]string)
+		}
+		targetGroupBinding.Labels["execUnit"] = unit.Name
+
+		return []HelmChartValue{
+			HelmChartValue{
+				ExecUnitName: unit.Name,
+				Kind:         targetGroupBinding.Kind,
+				Type:         string(TargetGroupTransformation),
+				Key:          value,
+			},
+		}, nil
+	},
 }
 
 func (unit *HelmExecUnit) getServiceAccountName() string {

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -3,12 +3,13 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
-	"k8s.io/apimachinery/pkg/runtime"
 	"regexp"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/yaml"

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,7 +55,7 @@ func (transformer manifestTransformer[K]) apply(unit *HelmExecUnit, cfg config.E
 	transformObj, ok := obj.(K)
 	if !ok {
 		var k K
-		err = fmt.Errorf("expected file %s to contain %T Kind", source.Path(), t)
+		err = fmt.Errorf("expected file %s to contain %T Kind", source.Path(), k)
 		return nil, err
 	}
 
@@ -148,7 +147,7 @@ var podTransformer = manifestTransformer[*corev1.Pod]{
 			return nil, err
 		}
 		return []HelmChartValue{
-			HelmChartValue{
+			{
 				ExecUnitName: unit.Name,
 				Kind:         pod.Kind,
 				Type:         string(ImageTransformation),

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -348,7 +348,7 @@ func Test_transformPod(t *testing.T) {
 				testUnit.Pod = f
 			}
 
-			values, err := testUnit.transformPod(tt.cfg)
+			values, err := podTransformer.apply(&testUnit, tt.cfg)
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -626,7 +626,7 @@ status: {}
 				testUnit.Deployment = f
 			}
 
-			values, err := testUnit.transformDeployment(tt.cfg)
+			values, err := deploymentTransformer.apply(&testUnit, tt.cfg)
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -923,7 +923,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				testUnit.HorizontalPodAutoscaler = f
 			}
 
-			values, err := testUnit.transformHorizontalPodAutoscaler(tt.cfg)
+			values, err := horizontalPodAutoscalerTransformer.apply(&testUnit, tt.cfg)
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -1443,7 +1443,7 @@ metadata:
 				testUnit.ServiceAccount = f
 			}
 
-			values, err := testUnit.transformServiceAccount()
+			values, err := serviceAccountTransformer.apply(&testUnit, config.ExecutionUnit{})
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -1512,7 +1512,7 @@ status: {}
 				testUnit.TargetGroupBinding = f
 			}
 
-			values, err := testUnit.transformTargetGroupBinding()
+			values, err := targetGroupBindingTransformer.apply(&testUnit, config.ExecutionUnit{})
 			if tt.wantErr {
 				assert.Error(err)
 				return
@@ -1591,7 +1591,7 @@ status:
 				testUnit.Service = f
 			}
 
-			values, err := testUnit.transformService(config.ExecutionUnit{})
+			values, err := serviceTransformer.apply(&testUnit, config.ExecutionUnit{})
 			if tt.wantErr {
 				assert.Error(err)
 				return

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -138,13 +138,13 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 
 	if shouldTransformImage(eu) {
 		if unit.Deployment != nil {
-			deploymentValues, err := unit.transformDeployment(cfg)
+			deploymentValues, err := deploymentTransformer.apply(unit, cfg)
 			if err != nil {
 				return nil, err
 			}
 			values = append(values, deploymentValues...)
 		} else if unit.Pod != nil {
-			podValues, err := unit.transformPod(cfg)
+			podValues, err := podTransformer.apply(unit, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -158,7 +158,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 		}
 		if unit.Deployment != nil && cfg.GetExecutionUnitParamsAsKubernetes().HorizontalPodAutoScalingConfig.NotEmpty() {
 			if unit.HorizontalPodAutoscaler != nil {
-				hpaValues, err := unit.transformHorizontalPodAutoscaler(cfg)
+				hpaValues, err := horizontalPodAutoscalerTransformer.apply(unit, cfg)
 				if err != nil {
 					return nil, err
 				}
@@ -174,7 +174,7 @@ func (chart *HelmChart) handleExecutionUnit(unit *HelmExecUnit, eu *core.Executi
 	}
 	if shouldTransformServiceAccount(eu) {
 		if unit.ServiceAccount != nil {
-			serviceAccountValues, err := unit.transformServiceAccount()
+			serviceAccountValues, err := serviceAccountTransformer.apply(unit, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -219,7 +219,7 @@ func (chart *HelmChart) handleUpstreamUnitDependencies(unit *HelmExecUnit, const
 	}
 	if needService {
 		if unit.Service != nil {
-			serviceValues, err := unit.transformService(cfg)
+			serviceValues, err := serviceTransformer.apply(unit, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +257,7 @@ func (chart *HelmChart) addDeployment(unit *HelmExecUnit, cfg config.ExecutionUn
 	if err != nil {
 		return nil, err
 	}
-	values, err := unit.transformDeployment(cfg)
+	values, err := deploymentTransformer.apply(unit, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ func (chart *HelmChart) addHorizontalPodAutoscaler(unit *HelmExecUnit, cfg confi
 	if err != nil {
 		return nil, err
 	}
-	values, err := unit.transformHorizontalPodAutoscaler(cfg)
+	values, err := horizontalPodAutoscalerTransformer.apply(unit, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (chart *HelmChart) addServiceAccount(unit *HelmExecUnit) ([]HelmChartValue,
 	if err != nil {
 		return nil, err
 	}
-	values, err := unit.transformServiceAccount()
+	values, err := serviceAccountTransformer.apply(unit, config.ExecutionUnit{})
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (chart *HelmChart) addService(unit *HelmExecUnit, cfg config.ExecutionUnit)
 		return nil, err
 	}
 
-	values, err := unit.transformService(cfg)
+	values, err := serviceTransformer.apply(unit, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func (chart *HelmChart) addTargetGroupBinding(unit *HelmExecUnit) ([]HelmChartVa
 	if err != nil {
 		return nil, err
 	}
-	values, err := unit.transformTargetGroupBinding()
+	values, err := targetGroupBindingTransformer.apply(unit, config.ExecutionUnit{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is optional cleanup; we should only merge it if consensus is that it improves readability.

This pulls all the common code in the transformers (reading, writing, casting, error handling, etc.) to a single method, so that each transformer focuses on just the logic it needs to provide.

> **Note**
> A lot of this diff is indentation change, so I recommend viewing with "ignore whitespace"

### Standard checks

- **Unit tests**: passing
- **Docs**: n/a
- **Backwards compatibility**: no issues
