### PR TITLE
Remove async function wrapping from pulumi index.ts

### DIFF
--- a/pkg/infra/iac2/plugin.go
+++ b/pkg/infra/iac2/plugin.go
@@ -42,7 +42,6 @@ func (p Plugin) Translate(cloudGraph *core.ResourceGraph) ([]core.File, error) {
 		return nil, err
 	}
 
-	buf.Write([]byte("export = async () => {\n"))
 	buf.Write([]byte("const kloConfig: pulumi.Config = new pulumi.Config('klo')\n"))
 	buf.Write([]byte("const protect = kloConfig.getBoolean('protect') ?? false"))
 	buf.Write([]byte(`
@@ -52,7 +51,6 @@ const awsProfile = awsConfig.get('profile')` + "\n\n"))
 	if err := tc.RenderBody(buf); err != nil {
 		return nil, err
 	}
-	buf.Write([]byte("}"))
 
 	indexTs := &core.RawFile{
 		FPath:   `index.ts`,


### PR DESCRIPTION
We don't need this anymore because we're using `pulumi.Input` anywhere this would've normally been needed.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
