### PR TITLE
remove applied outputs and k8s related fixes

### DIFF
--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -109,6 +109,7 @@ func TestKnownTemplates(t *testing.T) {
 		&RolePolicyAttachment{},
 		&resources.PrivateDnsNamespace{},
 		&kubernetes.KustomizeDirectory{},
+		&resources.OpenIdConnectProvider{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/inputs_outputs_test.go
+++ b/pkg/infra/iac2/inputs_outputs_test.go
@@ -110,6 +110,7 @@ func TestKnownTemplates(t *testing.T) {
 		&resources.PrivateDnsNamespace{},
 		&kubernetes.KustomizeDirectory{},
 		&resources.OpenIdConnectProvider{},
+		&SecurityGroupRule{},
 	}
 
 	tp := standardTemplatesProvider()

--- a/pkg/infra/iac2/resource_creation_template.go
+++ b/pkg/infra/iac2/resource_creation_template.go
@@ -36,11 +36,6 @@ type (
 		// ExpressionTemplate is a Go-[text/template] for a TypeScript expression to generate a piece of infrastructure.
 		ExpressionTemplate string
 	}
-
-	AppliedOutput struct {
-		appliedName string
-		varName     string
-	}
 )
 
 var (
@@ -181,47 +176,6 @@ func parseTS(val reflect.Value) (string, error) {
 		return out, nil
 	}
 	return "", fmt.Errorf("invalid template value detected: %s: %v: template values must implement the templateValue interface", val.Kind().String(), val.Interface())
-}
-
-func appliedOutputsToString(outputs []AppliedOutput) string {
-	out := strings.Builder{}
-	if len(outputs) == 0 {
-		return ""
-	}
-	out.WriteString("pulumi.all([")
-	for i := 0; i < len(outputs); i++ {
-		out.WriteString(outputs[i].appliedName)
-		if i < len(outputs)-1 {
-			out.WriteString(", ")
-		}
-	}
-	out.WriteString("]).apply(([")
-	for i := 0; i < len(outputs); i++ {
-		out.WriteString(outputs[i].varName)
-		if i < len(outputs)-1 {
-			out.WriteString(", ")
-		}
-	}
-	out.WriteString("]) => { return ")
-	return out.String()
-}
-
-func deduplicateAppliedOutputs(outputs []AppliedOutput) ([]AppliedOutput, error) {
-	uniqueList := []AppliedOutput{}
-	for _, output := range outputs {
-		unique := true
-		for _, u := range uniqueList {
-			if u.appliedName == output.appliedName && u.varName == output.varName {
-				unique = false
-			} else if u.varName == output.varName {
-				return nil, errors.Errorf("Found conflicting pulumi output var, %s", u.varName)
-			}
-		}
-		if unique {
-			uniqueList = append(uniqueList, output)
-		}
-	}
-	return uniqueList, nil
 }
 
 // bodyContents returns the contents of a 'statement_block' with the surrounding {}

--- a/pkg/infra/iac2/resource_creation_template_test.go
+++ b/pkg/infra/iac2/resource_creation_template_test.go
@@ -1,12 +1,8 @@
 package iac2
 
 import (
-<<<<<<< HEAD
 	"context"
 	_ "embed"
-	"fmt"
-=======
->>>>>>> 63e1235 (remove applied outputs)
 	"strings"
 	"testing"
 	"text/template"

--- a/pkg/infra/iac2/resource_creation_template_test.go
+++ b/pkg/infra/iac2/resource_creation_template_test.go
@@ -1,9 +1,12 @@
 package iac2
 
 import (
+<<<<<<< HEAD
 	"context"
 	_ "embed"
 	"fmt"
+=======
+>>>>>>> 63e1235 (remove applied outputs)
 	"strings"
 	"testing"
 	"text/template"
@@ -108,98 +111,6 @@ func TestParameterizeArgs(t *testing.T) {
 					}
 				})
 			}
-		})
-	}
-
-}
-
-func Test_appliedOutputsToString(t *testing.T) {
-	cases := []struct {
-		name  string
-		want  string
-		input []AppliedOutput
-	}{
-		{
-			name: "simple test",
-			input: []AppliedOutput{
-				{
-					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-				{
-					appliedName: fmt.Sprintf("%s.arn", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_arn",
-				},
-			},
-			want: "pulumi.all([awsEksClusterTestAppCluster1.openIdConnectIssuerUrl, awsEksClusterTestAppCluster1.arn]).apply(([cluster_oidc_url, cluster_arn]) => { return ",
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			result := appliedOutputsToString(tt.input)
-			assert := assert.New(t)
-			assert.Equal(tt.want, result)
-		})
-	}
-
-}
-
-func Test_dedupeAppliedOutputs(t *testing.T) {
-	cases := []struct {
-		name    string
-		want    []AppliedOutput
-		input   []AppliedOutput
-		wantErr bool
-	}{
-		{
-			name: "simple test",
-			input: []AppliedOutput{
-				{
-					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-				{
-					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-			},
-			want: []AppliedOutput{
-				{
-					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-			},
-		},
-		{
-			name: "var name conflict ",
-			input: []AppliedOutput{
-				{
-					appliedName: fmt.Sprintf("%s.should differ", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-				{
-					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
-					varName:     "cluster_oidc_url",
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			result, err := deduplicateAppliedOutputs(tt.input)
-
-			if tt.wantErr {
-				assert.Error(err)
-				return
-			}
-			if !assert.NoError(err) {
-				return
-			}
-
-			assert.Equal(tt.want, result)
 		})
 	}
 

--- a/pkg/infra/iac2/resources.go
+++ b/pkg/infra/iac2/resources.go
@@ -14,6 +14,17 @@ type (
 		Name                  string
 		EnableServerSideApply bool
 	}
+
+	SecurityGroupRule struct {
+		ConstructsRef []core.AnnotationKey
+		Name          string
+		FromPort      int
+		ToPort        int
+		Protocol      string
+		CidrBlocks    []string
+		Cluster       *resources.EksCluster
+		Type          string
+	}
 )
 
 func (e *KubernetesProvider) Provider() string {
@@ -26,6 +37,18 @@ func (e *KubernetesProvider) KlothoConstructRef() []core.AnnotationKey {
 
 func (e *KubernetesProvider) Id() string {
 	return fmt.Sprintf("%s:%s:%s", e.Provider(), "kubernetes_provider", e.Name)
+}
+
+func (e *SecurityGroupRule) Provider() string {
+	return "pulumi"
+}
+
+func (e *SecurityGroupRule) KlothoConstructRef() []core.AnnotationKey {
+	return e.ConstructsRef
+}
+
+func (e *SecurityGroupRule) Id() string {
+	return fmt.Sprintf("%s:%s:%s", e.Provider(), "security_group_rule", e.Name)
 }
 
 const (

--- a/pkg/infra/iac2/templates/eks_cluster/factory.ts
+++ b/pkg/infra/iac2/templates/eks_cluster/factory.ts
@@ -1,4 +1,3 @@
-import * as aws_native from '@pulumi/aws-native'
 import * as aws from '@pulumi/aws'
 
 interface Args {
@@ -9,9 +8,9 @@ interface Args {
 }
 
 // noinspection JSUnusedLocalSymbols
-function create(args: Args): aws_native.eks.Cluster {
-    return new aws_native.eks.Cluster(args.Name, {
-        resourcesVpcConfig: {
+function create(args: Args): aws.eks.Cluster {
+    return new aws.eks.Cluster(args.Name, {
+        vpcConfig: {
             subnetIds: args.Subnets.map((subnet) => subnet.id),
             //TMPL {{- if .SecurityGroups.Raw }}
             securityGroupIds: args.SecurityGroups.map((sg) => sg.id),

--- a/pkg/infra/iac2/templates/eks_cluster/package.json
+++ b/pkg/infra/iac2/templates/eks_cluster/package.json
@@ -1,7 +1,6 @@
 {
     "name": "eks_cluster",
     "dependencies": {
-        "@pulumi/aws-native": "^0.56.0",
         "@pulumi/aws": "^5.16.0"
     }
 }

--- a/pkg/infra/iac2/templates/eks_fargate_profile/factory.ts
+++ b/pkg/infra/iac2/templates/eks_fargate_profile/factory.ts
@@ -1,11 +1,10 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
-import * as aws_native from '@pulumi/aws-native'
 
 interface Args {
     Name: string
     Subnets: aws.ec2.Subnet[]
-    Cluster: aws_native.eks.Cluster
+    Cluster: aws.eks.Cluster
     PodExecutionRole: aws.iam.Role
     Selectors: pulumi.Input<pulumi.Input<aws.types.input.eks.FargateProfileSelector>[]>
 }
@@ -15,7 +14,7 @@ function create(args: Args): aws.eks.FargateProfile {
     return new aws.eks.FargateProfile(
         args.Name,
         {
-            clusterName: args.Cluster.name.apply((n) => n!),
+            clusterName: args.Cluster.name,
             podExecutionRoleArn: args.PodExecutionRole.arn,
             selectors: args.Selectors,
             subnetIds: args.Subnets.map((subnet) => subnet.id),

--- a/pkg/infra/iac2/templates/eks_fargate_profile/package.json
+++ b/pkg/infra/iac2/templates/eks_fargate_profile/package.json
@@ -2,7 +2,6 @@
     "name": "eks_fargate_profile",
     "dependencies": {
         "@pulumi/aws": "^5.16.0",
-        "@pulumi/aws-native": "^0.56.0",
         "@pulumi/pulumi": "^3.40.2"
     }
 }

--- a/pkg/infra/iac2/templates/helm_chart/factory.ts
+++ b/pkg/infra/iac2/templates/helm_chart/factory.ts
@@ -40,9 +40,7 @@ function create(args: Args): pulumi_k8s.helm.v3.Chart {
         },
         {
             provider: args.ClustersProvider,
-            //TMPL {{- if .dependsOn.Raw }}
             dependsOn: args.dependsOn,
-            //TMPL {{- end }}
         }
     )
 }

--- a/pkg/infra/iac2/templates/iam_role/factory.ts
+++ b/pkg/infra/iac2/templates/iam_role/factory.ts
@@ -12,7 +12,7 @@ interface Args {
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.iam.Role {
     return new aws.iam.Role(args.Name, {
-        assumeRolePolicy: JSON.stringify(args.AssumeRolePolicyDoc),
+        assumeRolePolicy: pulumi.jsonStringify(args.AssumeRolePolicyDoc),
         //TMPL {{ if .InlinePolicy.Raw }}
         inlinePolicies: [
             {

--- a/pkg/infra/iac2/templates/load_balancer/factory.ts
+++ b/pkg/infra/iac2/templates/load_balancer/factory.ts
@@ -18,6 +18,8 @@ function create(args: Args): aws.lb.LoadBalancer {
         loadBalancerType: args.Type,
         subnets: args.Subnets.map((subnet) => subnet.id),
         tags: args.Tags,
+        //TMPL {{- if .SecurityGroups.Raw }}
         securityGroups: args.SecurityGroups.map((sg) => sg.id),
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac2/templates/open_id_connect_provider/factory.ts
+++ b/pkg/infra/iac2/templates/open_id_connect_provider/factory.ts
@@ -1,0 +1,29 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import { getIssuerCAThumbprint } from '@pulumi/eks/cert-thumprint'
+import * as https from 'https'
+
+interface Args {
+    Name: string
+    ClientIdLists: string[]
+    Cluster: aws.eks.Cluster
+    Region: pulumi.Output<pulumi.UnwrappedObject<aws.GetRegionResult>>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.iam.OpenIdConnectProvider {
+    return new aws.iam.OpenIdConnectProvider(`oidcProvider`, {
+        clientIdLists: ['sts.amazonaws.com'],
+        url: args.Cluster.identities[0].oidcs[0].issuer,
+        thumbprintLists: [
+            getIssuerCAThumbprint(
+                pulumi.interpolate`https://oidc.eks.${args.Region.name}.amazonaws.com`,
+                new https.Agent({
+                    // Cached sessions can result in the certificate not being
+                    // available since its already been "accepted." Disable caching.
+                    maxCachedSessions: 0,
+                })
+            ),
+        ],
+    })
+}

--- a/pkg/infra/iac2/templates/open_id_connect_provider/package.json
+++ b/pkg/infra/iac2/templates/open_id_connect_provider/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "origin_access_identity",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0",
+        "@pulumi/pulumi": "^3.40.2",
+        "@pulumi/eks": "^0.42.0"
+    }
+}

--- a/pkg/infra/iac2/templates/open_id_connect_provider/package.json
+++ b/pkg/infra/iac2/templates/open_id_connect_provider/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "origin_access_identity",
+    "name": "open_id_connect_provider",
     "dependencies": {
         "@pulumi/aws": "^5.16.0",
         "@pulumi/pulumi": "^3.40.2",

--- a/pkg/infra/iac2/templates/rds_proxy_target_group/factory.ts
+++ b/pkg/infra/iac2/templates/rds_proxy_target_group/factory.ts
@@ -9,9 +9,13 @@ interface Args {
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.rds.ProxyTarget {
-    return new aws.rds.ProxyTarget('exampleProxyTarget', {
-        dbInstanceIdentifier: args.RdsInstance.id,
-        dbProxyName: args.RdsProxy.name,
-        targetGroupName: args.TargetGroupName,
-    })
+    return new aws.rds.ProxyTarget(
+        args.Name,
+        {
+            dbInstanceIdentifier: args.RdsInstance.id,
+            dbProxyName: args.RdsProxy.name,
+            targetGroupName: args.TargetGroupName,
+        },
+        { deleteBeforeReplace: true }
+    )
 }

--- a/pkg/infra/iac2/templates/security_group_rule/factory.ts
+++ b/pkg/infra/iac2/templates/security_group_rule/factory.ts
@@ -1,0 +1,22 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    FromPort: number
+    ToPort: number
+    Protocol: string
+    CidrBlocks: string[]
+    Cluster: aws.eks.Cluster
+    Type: string
+}
+
+function create(args: Args): aws.ec2.SecurityGroupRule {
+    return new aws.ec2.SecurityGroupRule(args.Name, {
+        type: args.Type,
+        cidrBlocks: args.CidrBlocks,
+        fromPort: args.FromPort,
+        protocol: args.Protocol,
+        toPort: args.ToPort,
+        securityGroupId: args.Cluster.vpcConfig.clusterSecurityGroupId,
+    })
+}

--- a/pkg/infra/iac2/templates/security_group_rule/package.json
+++ b/pkg/infra/iac2/templates/security_group_rule/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "security_group_rule",
+    "dependencies": {
+        "@pulumi/aws": "^5.16.0"
+    }
+}

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -55,7 +55,6 @@ type (
 	}
 	NestedCtx struct {
 		useDoubleQuotes bool
-		appliedOutputs  *[]AppliedOutput
 		rootVal         *reflect.Value
 	}
 )
@@ -213,31 +212,13 @@ func (tc TemplatesCompiler) renderResource(out io.Writer, resource core.Resource
 			}
 			childVal := resourceVal.FieldByName(fieldName)
 
-			var appliedoutputs []AppliedOutput
 			buf := strings.Builder{}
-			strValue, err := tc.resolveStructInput(&resourceVal, childVal, false, &appliedoutputs)
-			if err != nil {
-				errs.Append(err)
-				return
-			}
-			uniqueOutputs, err := deduplicateAppliedOutputs(appliedoutputs)
-			if err != nil {
-				errs.Append(err)
-				return
-			}
-			_, err = buf.WriteString(appliedOutputsToString(uniqueOutputs))
+			strValue, err := tc.resolveStructInput(&resourceVal, childVal, false)
 			if err != nil {
 				errs.Append(err)
 				return
 			}
 			buf.WriteString(strValue)
-			if len(uniqueOutputs) > 0 {
-				_, err = buf.WriteString("})")
-				if err != nil {
-					errs.Append(err)
-					return
-				}
-			}
 
 			var rawVal any
 			if childVal.IsValid() {
@@ -288,10 +269,9 @@ func (tc TemplatesCompiler) resolveDependencies(resource core.Resource) string {
 }
 
 // resolveStructInput translates a value to a form suitable to inject into the typescript as an input to a function.
-func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, childVal reflect.Value, useDoubleQuotedStrings bool, appliedOutputs *[]AppliedOutput) (string, error) {
+func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, childVal reflect.Value, useDoubleQuotedStrings bool) (string, error) {
 	tc.ctx = &NestedCtx{
 		useDoubleQuotes: useDoubleQuotedStrings,
-		appliedOutputs:  appliedOutputs,
 		rootVal:         resourceVal,
 	}
 	var zeroValue reflect.Value
@@ -313,7 +293,7 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 		if typedChild, ok := childVal.Interface().(core.Resource); ok {
 			return tc.getVarName(typedChild), nil
 		} else if typedChild, ok := childVal.Interface().(core.IaCValue); ok {
-			output, err := tc.handleIaCValue(typedChild, appliedOutputs, resourceVal)
+			output, err := tc.handleIaCValue(typedChild, resourceVal)
 			if err != nil {
 				return output, err
 			}
@@ -354,7 +334,7 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 					resourceVal = &correspondingStruct
 				}
 
-				resolvedValue, err := tc.resolveStructInput(resourceVal, childVal, false, appliedOutputs)
+				resolvedValue, err := tc.resolveStructInput(resourceVal, childVal, false)
 
 				if err != nil {
 					return output.String(), err
@@ -379,7 +359,7 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 		buf := strings.Builder{}
 		buf.WriteRune('[')
 		for i := 0; i < sliceLen; i++ {
-			output, err := tc.resolveStructInput(resourceVal, childVal.Index(i), false, appliedOutputs)
+			output, err := tc.resolveStructInput(resourceVal, childVal.Index(i), false)
 			if err != nil {
 				return output, err
 			}
@@ -396,7 +376,7 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 		buf := strings.Builder{}
 		buf.WriteRune('{')
 		for i, key := range childVal.MapKeys() {
-			output, err := tc.resolveStructInput(resourceVal, key, true, appliedOutputs)
+			output, err := tc.resolveStructInput(resourceVal, key, true)
 			if err != nil {
 				return output, nil
 			}
@@ -409,7 +389,7 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 				buf.WriteString(output)
 			}
 			buf.WriteRune(':')
-			output, err = tc.resolveStructInput(resourceVal, childVal.MapIndex(key), false, appliedOutputs)
+			output, err = tc.resolveStructInput(resourceVal, childVal.MapIndex(key), false)
 			if err != nil {
 				return output, err
 			}
@@ -425,18 +405,18 @@ func (tc TemplatesCompiler) resolveStructInput(resourceVal *reflect.Value, child
 		// instead of being the actual type. So, we basically pull the item out of the collection, and then reflect on
 		// it directly.
 		underlyingVal := childVal.Interface()
-		return tc.resolveStructInput(resourceVal, reflect.ValueOf(underlyingVal), false, appliedOutputs)
+		return tc.resolveStructInput(resourceVal, reflect.ValueOf(underlyingVal), false)
 	}
 	return "", nil
 }
 
 // handleIaCValue determines how to retrieve values from a resource given a specific value identifier.
-func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]AppliedOutput, resourceVal *reflect.Value) (string, error) {
+func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, resourceVal *reflect.Value) (string, error) {
 	resource := v.Resource
 	property := v.Property
 
 	if resource == nil {
-		output, err := tc.resolveStructInput(nil, reflect.ValueOf(property), false, appliedOutputs)
+		output, err := tc.resolveStructInput(nil, reflect.ValueOf(property), false)
 		if err != nil {
 			return output, err
 		}
@@ -504,28 +484,12 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 			return "", errors.Errorf("unsupported resource type %T for '%s'", v.Resource, v.Property)
 		}
 
-	case resources.CLUSTER_OIDC_ARN_IAC_VALUE:
-		varName := "cluster_oidc_url"
-		*appliedOutputs = append(*appliedOutputs, AppliedOutput{
-			appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", tc.getVarName(v.Resource)),
-			varName:     varName,
-		})
-
-		arnVarName := "cluster_arn"
-		*appliedOutputs = append(*appliedOutputs, AppliedOutput{
-			appliedName: fmt.Sprintf("%s.arn", tc.getVarName(v.Resource)),
-			varName:     arnVarName,
-		})
-		return fmt.Sprintf("`arn:aws:iam::${%s.split(':')[4]}:oidc-provider/${%s}`", arnVarName, varName), nil
-	case resources.CLUSTER_OIDC_URL_IAC_VALUE:
-		varName := "cluster_oidc_url"
-		*appliedOutputs = append(*appliedOutputs, AppliedOutput{
-			appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", tc.getVarName(v.Resource)),
-			varName:     varName,
-		})
-		return fmt.Sprintf("`${%s}:sub`", varName), nil
+	case resources.OIDC_URL_IAC_VALUE:
+		return fmt.Sprintf("`${%s.url}:sub`", tc.getVarName(v.Resource)), nil
+	case resources.OIDC_AUD_IAC_VALUE:
+		return fmt.Sprintf("`${%s.url}:aud`", tc.getVarName(v.Resource)), nil
 	case resources.CLUSTER_CA_DATA_IAC_VALUE:
-		return fmt.Sprintf("%s.certificateAuthorityData", tc.getVarName(v.Resource)), nil
+		return fmt.Sprintf("%s.certificateAuthorities[0].data", tc.getVarName(v.Resource)), nil
 	case resources.CLUSTER_ENDPOINT_IAC_VALUE:
 		return fmt.Sprintf("%s.endpoint", tc.getVarName(v.Resource)), nil
 	case resources.CLUSTER_PROVIDER_IAC_VALUE:
@@ -578,7 +542,7 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 }
 
 func (tc TemplatesCompiler) handleSingleIaCValue(v core.IaCValue) (string, error) {
-	return tc.handleIaCValue(v, nil, nil)
+	return tc.handleIaCValue(v, nil)
 }
 
 // getVarName gets a unique but nice-looking variable for the given item.
@@ -615,7 +579,7 @@ func (tc TemplatesCompiler) getVarNameByResourceId(id string) string {
 
 // parseVal parses the supplied value for nested tempaltes
 func (tc TemplatesCompiler) parseVal(val reflect.Value) (string, error) {
-	return tc.resolveStructInput(tc.ctx.rootVal, val, tc.ctx.useDoubleQuotes, tc.ctx.appliedOutputs)
+	return tc.resolveStructInput(tc.ctx.rootVal, val, tc.ctx.useDoubleQuotes)
 }
 
 func (tp templatesProvider) getTemplate(v core.Resource) (ResourceCreationTemplate, error) {

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -259,9 +259,14 @@ func (tc TemplatesCompiler) resolveDependencies(resource core.Resource) string {
 	numDeps := len(upstreamResources)
 	for i := 0; i < numDeps; i++ {
 		res := upstreamResources[i]
-		buf.WriteString(tc.getVarName(res))
-		if i < (numDeps - 1) {
-			buf.WriteRune(',')
+		switch res.(type) {
+		case *resources.Region, *resources.AvailabilityZones, *resources.AccountId:
+			continue
+		default:
+			buf.WriteString(tc.getVarName(res))
+			if i < (numDeps - 1) {
+				buf.WriteRune(',')
+			}
 		}
 	}
 	buf.WriteRune(']')

--- a/pkg/infra/kubernetes/kubeconfig.go
+++ b/pkg/infra/kubernetes/kubeconfig.go
@@ -24,9 +24,8 @@ type (
 	}
 
 	KubeconfigCluster struct {
-		Name                     core.IaCValue
-		CertificateAuthorityData core.IaCValue
-		Server                   core.IaCValue
+		Name    core.IaCValue
+		Cluster map[string]core.IaCValue
 	}
 
 	KubeconfigContext struct {

--- a/pkg/infra/kubernetes/kubeconfig.go
+++ b/pkg/infra/kubernetes/kubeconfig.go
@@ -19,8 +19,8 @@ type (
 		CurrentContext string
 
 		Clusters []KubeconfigCluster
-		Contexts []KubeconfigContext
-		Users    []KubeconfigUser
+		Contexts []KubeconfigContexts
+		Users    []KubeconfigUsers
 	}
 
 	KubeconfigCluster struct {
@@ -28,9 +28,18 @@ type (
 		Cluster map[string]core.IaCValue
 	}
 
+	KubeconfigContexts struct {
+		Context KubeconfigContext
+		Name    core.IaCValue
+	}
 	KubeconfigContext struct {
 		Cluster core.IaCValue
 		User    string
+	}
+
+	KubeconfigUsers struct {
+		Name string
+		User KubeconfigUser
 	}
 
 	KubeconfigUser struct {

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -119,6 +119,9 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 									Property: resources.ARN_IAC_VALUE,
 								}
 								dag.AddDependency(khChart, targetGroup)
+								for _, nodeGroup := range cluster.GetClustersNodeGroups(dag) {
+									dag.AddDependency(khChart, nodeGroup)
+								}
 							}
 						}
 					}

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -73,7 +73,10 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 		if cluster == nil {
 			return errors.Errorf("Expected to have cluster created for unit, %s, but did not find cluster in graph", unit.ID)
 		}
-		role.AssumeRolePolicyDoc = cluster.GetServiceAccountAssumeRolePolicy(unit.ID)
+		role.AssumeRolePolicyDoc, err = cluster.GetServiceAccountAssumeRolePolicy(unit.ID, dag)
+		if err != nil {
+			return err
+		}
 		// transform kubernetes resources for EKS
 		for _, res := range dag.ListResources() {
 			if khChart, ok := res.(*kubernetes.HelmChart); ok {
@@ -340,8 +343,7 @@ func (a *AWS) createEksLoadBalancer(result *core.ConstructGraph, dag *core.Resou
 	}
 	vpc := resources.GetVpc(a.Config, dag)
 	subnets := vpc.GetPrivateSubnets(dag)
-	securityGroups := []*resources.SecurityGroup{resources.GetSecurityGroup(a.Config, dag)}
-	lb := resources.NewLoadBalancer(a.Config.AppName, unit.ID, refs, "internal", "network", subnets, securityGroups)
+	lb := resources.NewLoadBalancer(a.Config.AppName, unit.ID, refs, "internal", "network", subnets, nil)
 	unitsPort := unit.Port
 	if unitsPort == 0 {
 		unitsPort = 3000

--- a/pkg/provider/aws/expose.go
+++ b/pkg/provider/aws/expose.go
@@ -163,8 +163,9 @@ func (a *AWS) createIntegration(method *resources.ApiMethod, unit *core.Executio
 			return nil, errors.Errorf("No nlb created for unit %s", unit.ID)
 		}
 		vpcLink := resources.NewVpcLink(nlb, refs)
-		integration := resources.NewApiIntegration(method, refs, method.HttpMethod, "VPC_LINK", vpcLink, core.IaCValue{Resource: nlb, Property: resources.NLB_INTEGRATION_URI_IAC_VALUE})
+		integration := resources.NewApiIntegration(method, refs, method.HttpMethod, "HTTP_PROXY", vpcLink, core.IaCValue{Resource: nlb, Property: resources.NLB_INTEGRATION_URI_IAC_VALUE})
 		integration.Route = convertPath(route.Path)
+		integration.ConnectionType = "VPC_LINK"
 		dag.AddDependency(integration, nlb)
 		dag.AddDependenciesReflect(vpcLink)
 		dag.AddDependenciesReflect(integration)

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -156,7 +156,7 @@ func (a *AWS) createEksClusters(result *core.ConstructGraph, dag *core.ResourceG
 
 	var merr multierr.Error
 	for clusterId, units := range clusterIdToUnit {
-		merr.Append(resources.CreateEksCluster(a.Config, clusterId, subnets, nil, units, dag))
+		merr.Append(resources.CreateEksCluster(a.Config, clusterId, subnets, vpc.GetSecurityGroups(dag), units, dag))
 	}
 	return merr.ErrOrNil()
 }

--- a/pkg/provider/aws/resources/eks.go
+++ b/pkg/provider/aws/resources/eks.go
@@ -597,13 +597,15 @@ func createEKSKubeconfig(cluster *EksCluster, region *Region) *kubernetes.Kubeco
 		Clusters: []kubernetes.KubeconfigCluster{
 			{
 				Name: clusterNameIaCValue,
-				CertificateAuthorityData: core.IaCValue{
-					Resource: cluster,
-					Property: CLUSTER_CA_DATA_IAC_VALUE,
-				},
-				Server: core.IaCValue{
-					Resource: cluster,
-					Property: CLUSTER_ENDPOINT_IAC_VALUE,
+				Cluster: map[string]core.IaCValue{
+					"certificate-authority-data": {
+						Resource: cluster,
+						Property: CLUSTER_CA_DATA_IAC_VALUE,
+					},
+					"server": {
+						Resource: cluster,
+						Property: CLUSTER_ENDPOINT_IAC_VALUE,
+					},
 				},
 			},
 		},

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -61,6 +61,7 @@ func Test_CreateEksCluster(t *testing.T) {
 					"kubernetes:manifest:test-app-test-cluster-fluent-bit-cluster-info-config-map",
 					"kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin",
 					"aws:eks_addon:test-app-test-cluster-addon-vpc-cni",
+					"aws:iam_oidc_provider:test-app-test-cluster",
 				},
 				Deps: []coretesting.StringDep{
 					{Source: "aws:vpc:test_app", Destination: "aws:region:region"},
@@ -92,6 +93,8 @@ func Test_CreateEksCluster(t *testing.T) {
 					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:private_g2"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:private_t3_medium"},
+					{Source: "aws:iam_oidc_provider:test-app-test-cluster", Destination: "aws:eks_cluster:test-app-test-cluster"},
+					{Source: "aws:iam_oidc_provider:test-app-test-cluster", Destination: "aws:region:region"},
 				},
 			},
 		},

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -186,7 +186,7 @@ func Test_getClustersNodeGroups(t *testing.T) {
 	dag.AddDependenciesReflect(nodeGroup1)
 	dag.AddDependenciesReflect(nodeGroup2)
 	dag.AddDependenciesReflect(nodeGroup3)
-	assert.ElementsMatch(cluster.getClustersNodeGroups(dag), []*EksNodeGroup{nodeGroup1, nodeGroup2})
+	assert.ElementsMatch(cluster.GetClustersNodeGroups(dag), []*EksNodeGroup{nodeGroup1, nodeGroup2})
 }
 
 func Test_createClusterAdminRole(t *testing.T) {

--- a/pkg/provider/aws/resources/iam.go
+++ b/pkg/provider/aws/resources/iam.go
@@ -127,6 +127,14 @@ type (
 		StringEquals map[core.IaCValue]string
 		Null         map[core.IaCValue]string
 	}
+
+	OpenIdConnectProvider struct {
+		Name          string
+		ConstructsRef []core.AnnotationKey
+		ClientIdLists []string
+		Cluster       *EksCluster
+		Region        *Region
+	}
 )
 
 func NewPolicyGenerator() *PolicyGenerator {
@@ -231,6 +239,21 @@ func (policy *IamPolicy) KlothoConstructRef() []core.AnnotationKey {
 // ID returns the id of the cloud resource
 func (policy *IamPolicy) Id() string {
 	return fmt.Sprintf("%s:%s:%s", policy.Provider(), IAM_POLICY_TYPE, policy.Name)
+}
+
+// Provider returns name of the provider the resource is correlated to
+func (oidc *OpenIdConnectProvider) Provider() string {
+	return AWS_PROVIDER
+}
+
+// KlothoResource returns AnnotationKey of the klotho resource the cloud resource is correlated to
+func (oidc *OpenIdConnectProvider) KlothoConstructRef() []core.AnnotationKey {
+	return oidc.ConstructsRef
+}
+
+// ID returns the id of the cloud resource
+func (oidc *OpenIdConnectProvider) Id() string {
+	return fmt.Sprintf("%s:%s:%s", oidc.Provider(), OIDC_PROVIDER_TYPE, oidc.Name)
 }
 
 func (s StatementEntry) Id() string {


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

lots of fixes from deploying a k8s mega app

- Fixes the addition of the openIdConnectProvider
- removes using aws-native for now to prevent the need to set region
- removed the appliedOutputs since it doesnt work anyways when set on a field. using pulumi.Jsonstringify instead
- other small fixes to api integration/other resources

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
