### PR TITLE
upgrade to go 1.20.3

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/checkout@v3
       - name: List files to check
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
 
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - name: pre-build
         if: ${{ inputs.pre-build-script }}
         run: ${{ inputs.pre-build-script }}

--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.3'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/klothoplatform/klotho
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
Basically like it says on the tin.

This should fix our govulncheck errors

### Standard checks

- **Unit tests**: none
- **Docs**: n/a
- **Backwards compatibility**: no issues
