### PR TITLE
don't use greedy vars in integration routes

### DIFF
--- a/pkg/provider/aws/expose_test.go
+++ b/pkg/provider/aws/expose_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/annotation"
@@ -425,19 +424,9 @@ func Test_ConvertPath(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.given, func(t *testing.T) {
-			for _, greedy := range []bool{true, false} { // https://www.youtube.com/watch?v=cwmDrQzsFT8#t=1m02s
-				t.Run(fmt.Sprintf(`greedy=%v`, greedy), func(t *testing.T) {
-					assert := assert.New(t)
-					actual := convertPath(tt.given, greedy)
-					var want string
-					if greedy {
-						want = tt.wantIfGreedy
-					} else {
-						want = tt.wantIfNoGreedy
-					}
-					assert.Equal(want, actual)
-				})
-			}
+			assert := assert.New(t)
+			assert.Equal(tt.wantIfGreedy, convertPath(tt.given, true), "greedy")
+			assert.Equal(tt.wantIfNoGreedy, convertPath(tt.given, false), "not greedy")
 		})
 	}
 }


### PR DESCRIPTION
I had considered also adding a fuller test of the APIG and all that, but it's a _lot_ of setup and makes for a pretty  unreadable test. Instead, I added just a simpler unit test of `convertPath`

In service of #524.

### Standard checks

- **Unit tests**: added
- **Docs**: n/a
- **Backwards compatibility**: n/a
