### PR TITLE
be able to parse constsruct graph for a run

### DIFF
--- a/pkg/core/config.go
+++ b/pkg/core/config.go
@@ -12,8 +12,6 @@ type (
 	}
 )
 
-const ConfigKind = "config"
-
 func (p *Config) Provenance() AnnotationKey {
 	return p.AnnotationKey
 }


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue?

Mainly want some opinions, but this gets us to a full end to end flow we are looking for in ICoP

Introduces a new hidden flag for `construct-graph` which takes in a path to a file.
If the flag is passed, we remove all analysis and transformation plugins from the compiler.
We create the construct graph from the file passed in and run provider + IaC Plugins.



### Standard checks

- **Unit tests**: Any special considerations? will add, but wanted to make sure this approach can get some alignment
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
