### PR TITLE
Add dependencies after env vars are added

### DIFF
--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -311,9 +311,9 @@ func (a *AWS) convertExecUnitParams(result *core.ConstructGraph, dag *core.Resou
 							}
 						}
 					}
-
 				}
 			}
+			dag.AddDependenciesReflect(resource)
 		}
 	}
 	return nil


### PR DESCRIPTION
This fixes lambda referencing environment variables before they're defined (due to a missing dependency).

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
