### PR TITLE
Ifc2/more fixes

### DIFF
--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -599,6 +599,8 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		return fmt.Sprintf("%s.invokeUrl.apply((d) => d.split('//')[1].split('/')[0])", tc.getVarName(v.Resource)), nil
 	case resources.ECR_IMAGE_NAME_IAC_VALUE:
 		return fmt.Sprintf(`%s.imageName`, tc.getVarName(resource)), nil
+	case resources.ECR_REPO_DIGEST_IAC_VALUE:
+		return fmt.Sprintf(`%s.repoDigest`, tc.getVarName(resource)), nil
 	case resources.NLB_INTEGRATION_URI_IAC_VALUE:
 		integration, ok := resourceVal.Interface().(resources.ApiIntegration)
 		if !ok {

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	"github.com/klothoplatform/klotho/pkg/sanitization"
 	"regexp"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +40,8 @@ type manifestTransformer[K runtime.Object] struct {
 	// it blank, in which case the transformer will assume readFile.
 	readF func(f *core.SourceFile) (runtime.Object, error)
 }
+
+var sanitizeEnvVar = sanitization.EnvVarKeySanitizer.Apply
 
 func (transformer manifestTransformer[K]) apply(unit *HelmExecUnit, cfg config.ExecutionUnit) ([]HelmChartValue, error) {
 	source := transformer.fieldToTransform(unit)
@@ -153,6 +156,12 @@ var podTransformer = manifestTransformer[*corev1.Pod]{
 				Type:         string(ImageTransformation),
 				Key:          imagePlaceholder,
 			},
+			{
+				ExecUnitName: unit.Name,
+				Kind:         pod.Kind,
+				Type:         string(ImageHashTransformation),
+				Key:          imagePlaceholder + "hash",
+			},
 		}, nil
 	},
 }
@@ -174,6 +183,12 @@ var deploymentTransformer = manifestTransformer[*apps.Deployment]{
 				Kind:         deployment.Kind,
 				Type:         string(ImageTransformation),
 				Key:          imagePlaceholder,
+			},
+			{
+				ExecUnitName: unit.Name,
+				Kind:         deployment.Kind,
+				Type:         string(ImageHashTransformation),
+				Key:          imagePlaceholder + "hash",
 			},
 		}
 
@@ -437,7 +452,7 @@ func (unit *HelmExecUnit) AddUnitsEnvironmentVariables(eu *core.ExecutionUnit) (
 	return
 }
 func (unit *HelmExecUnit) addEnvsVarToDeployment(envVars core.EnvironmentVariables) ([]HelmChartValue, error) {
-	values := []HelmChartValue{}
+	var values []HelmChartValue
 
 	log := zap.L().Sugar().With(logging.FileField(unit.Deployment), zap.String("unit", unit.Name))
 	log.Debugf("Adding environment variables to file, %s, for exec unit, %s", unit.Deployment.Path(), unit.Name)
@@ -562,6 +577,13 @@ func (unit *HelmExecUnit) upsertOnlyContainer(containers *[]corev1.Container, cf
 	value := GenerateImagePlaceholder(unit.Name)
 	container.Image = fmt.Sprintf("{{ .Values.%s }}", value)
 
+	// the image hash environment variable changes when an image's hash changes
+	// this will cause the IaC provider to trigger a new deployment
+	hashValue := value + "hash"
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  sanitizeEnvVar(hashValue),
+		Value: fmt.Sprintf("{{ .Values.%s }}", hashValue),
+	})
 	k8config, err := unit.configureContainer(container, cfg)
 	if err != nil {
 		return k8config, "", err

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -256,6 +256,12 @@ func Test_transformPod(t *testing.T) {
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
+					{
+						ExecUnitName: "testUnit",
+						Kind:         "Pod",
+						Type:         string(ImageHashTransformation),
+						Key:          "testUnitImagehash",
+					},
 				},
 				newFile: testutil.UnIndent(`
                     apiVersion: v1
@@ -267,7 +273,10 @@ func Test_transformPod(t *testing.T) {
                       name: test
                     spec:
                       containers:
-                      - image: '{{ .Values.testUnitImage }}'
+                      - env:
+                        - name: testUnitImagehash
+                          value: '{{ .Values.testUnitImagehash }}'
+                        image: '{{ .Values.testUnitImage }}'
                         name: web
                         resources: {}
                       serviceAccountName: testUnit
@@ -300,6 +309,12 @@ func Test_transformPod(t *testing.T) {
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
+					{
+						ExecUnitName: "testUnit",
+						Kind:         "Pod",
+						Type:         string(ImageHashTransformation),
+						Key:          "testUnitImagehash",
+					},
 				},
 				newFile: testutil.UnIndent(`
                     apiVersion: v1
@@ -311,7 +326,10 @@ func Test_transformPod(t *testing.T) {
                       name: test
                     spec:
                       containers:
-                      - image: '{{ .Values.testUnitImage }}'
+                      - env:
+                        - name: testUnitImagehash
+                          value: '{{ .Values.testUnitImagehash }}'
+                        image: '{{ .Values.testUnitImage }}'
                         name: testUnit
                         resources:
                           limits:
@@ -393,6 +411,12 @@ func Test_transformDeployment(t *testing.T) {
 			Type:         string(ImageTransformation),
 			Key:          "testUnitImage",
 		},
+		{
+			ExecUnitName: "testUnit",
+			Kind:         "Deployment",
+			Type:         string(ImageHashTransformation),
+			Key:          "testUnitImagehash",
+		},
 	}
 	tests := []struct {
 		name    string
@@ -432,7 +456,10 @@ func Test_transformDeployment(t *testing.T) {
                             klotho-fargate-enabled: "false"
                         spec:
                           containers:
-                          - image: '{{ .Values.testUnitImage }}'
+                          - env:
+                            - name: testUnitImagehash
+                              value: '{{ .Values.testUnitImagehash }}'
+                            image: '{{ .Values.testUnitImage }}'
                             name: nginx
                             resources: {}
                           serviceAccountName: testUnit
@@ -506,7 +533,10 @@ func Test_transformDeployment(t *testing.T) {
                             klotho-fargate-enabled: "false"
                         spec:
                           containers:
-                          - image: '{{ .Values.testUnitImage }}'
+                          - env:
+                            - name: testUnitImagehash
+                              value: '{{ .Values.testUnitImagehash }}'
+                            image: '{{ .Values.testUnitImage }}'
                             name: testUnit
                             resources: {}
                           serviceAccountName: testUnit
@@ -541,6 +571,12 @@ spec:
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
+					{
+						ExecUnitName: "testUnit",
+						Kind:         "Deployment",
+						Type:         string(ImageHashTransformation),
+						Key:          "testUnitImagehash",
+					},
 				},
 				newFile: `apiVersion: apps/v1
 kind: Deployment
@@ -567,7 +603,10 @@ spec:
         klotho-fargate-enabled: "true"
     spec:
       containers:
-      - image: '{{ .Values.testUnitImage }}'
+      - env:
+        - name: testUnitImagehash
+          value: '{{ .Values.testUnitImagehash }}'
+        image: '{{ .Values.testUnitImage }}'
         name: nginx
         resources: {}
       serviceAccountName: testUnit
@@ -602,6 +641,12 @@ spec:
 						Kind:         "Deployment",
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
+					},
+					{
+						ExecUnitName: "testUnit",
+						Kind:         "Deployment",
+						Type:         string(ImageHashTransformation),
+						Key:          "testUnitImagehash",
 					},
 					{
 						ExecUnitName: "testUnit",
@@ -641,7 +686,10 @@ spec:
         klotho-fargate-enabled: "false"
     spec:
       containers:
-      - image: '{{ .Values.testUnitImage }}'
+      - env:
+        - name: testUnitImagehash
+          value: '{{ .Values.testUnitImagehash }}'
+        image: '{{ .Values.testUnitImage }}'
         name: nginx
         resources: {}
       nodeSelector:

--- a/pkg/infra/kubernetes/helm_chart_test.go
+++ b/pkg/infra/kubernetes/helm_chart_test.go
@@ -478,6 +478,12 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Key:          "unitImage",
 				},
 				{
+					ExecUnitName: "unit",
+					Kind:         "Deployment",
+					Type:         "image_hash",
+					Key:          "unitImagehash",
+				},
+				{
 					ExecUnitName: testUnitName,
 					Kind:         "ServiceAccount",
 					Type:         "service_account_annotation",
@@ -497,6 +503,12 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Key:          "unitImage",
 				},
 				{
+					ExecUnitName: "unit",
+					Kind:         "Deployment",
+					Type:         "image_hash",
+					Key:          "unitImagehash",
+				},
+				{
 					ExecUnitName: testUnitName,
 					Kind:         "ServiceAccount",
 					Type:         "service_account_annotation",
@@ -514,6 +526,12 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Kind:         "Deployment",
 					Type:         "image",
 					Key:          "unitImage",
+				},
+				{
+					ExecUnitName: "unit",
+					Kind:         "Deployment",
+					Type:         "image_hash",
+					Key:          "unitImagehash",
 				},
 				{
 					ExecUnitName: testUnitName,
@@ -724,7 +742,10 @@ spec:
         klotho-fargate-enabled: "false"
     spec:
       containers:
-      - image: '{{ .Values.unitImage }}'
+      - env:
+        - name: unitImagehash
+          value: '{{ .Values.unitImagehash }}'
+        image: '{{ .Values.unitImage }}'
         name: unit
         resources: {}
       serviceAccount: unit
@@ -737,6 +758,12 @@ status: {}
 						Kind:         "Deployment",
 						Type:         "image",
 						Key:          "unitImage",
+					},
+					{
+						ExecUnitName: "unit",
+						Kind:         "Deployment",
+						Type:         "image_hash",
+						Key:          "unitImagehash",
 					},
 				},
 			},

--- a/pkg/infra/kubernetes/values.go
+++ b/pkg/infra/kubernetes/values.go
@@ -16,6 +16,7 @@ type ProviderValueTypes string
 const (
 	TargetGroupTransformation              ProviderValueTypes = "target_group"
 	ImageTransformation                    ProviderValueTypes = "image"
+	ImageHashTransformation                ProviderValueTypes = "image_hash"
 	EnvironmentVariableTransformation      ProviderValueTypes = "env_var"
 	ServiceAccountAnnotationTransformation ProviderValueTypes = "service_account_annotation"
 	InstanceTypeKey                        ProviderValueTypes = "instance_type_key"

--- a/pkg/lang/python/aws_runtime/proxy_eks.py
+++ b/pkg/lang/python/aws_runtime/proxy_eks.py
@@ -1,7 +1,9 @@
 import boto3
+import json
 import os
-import logging
 import requests
+
+import logging
 
 sd_client = boto3.client("servicediscovery")
 APP_NAME = os.environ.get("APP_NAME")
@@ -16,7 +18,7 @@ async def proxy_call(exec_group_name, module_name, function_to_call, params):
             'module_name': module_name,
             'params': params,
         })
-        return res.content
+        return json.loads(res.content)
     except Exception as e:
         logging.error(e)
         raise e

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -83,6 +83,7 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 			return errors.Errorf("Expected to have cluster created for unit, %s, but did not find cluster in graph", unit.ID)
 		}
 		role.AssumeRolePolicyDoc, err = cluster.GetServiceAccountAssumeRolePolicy(unit.ID, dag)
+		dag.AddDependenciesReflect(role)
 		if err != nil {
 			return err
 		}

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -108,6 +108,12 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 									Property: resources.ECR_IMAGE_NAME_IAC_VALUE,
 								}
 								dag.AddDependency(khChart, image)
+							case kubernetes.ImageHashTransformation:
+								khChart.Values[val.Key] = core.IaCValue{
+									Resource: image,
+									Property: resources.ECR_REPO_DIGEST_IAC_VALUE,
+								}
+								dag.AddDependency(khChart, image)
 							case kubernetes.ServiceAccountAnnotationTransformation:
 								khChart.Values[val.Key] = core.IaCValue{
 									Resource: role,

--- a/pkg/provider/aws/execution_unit_test.go
+++ b/pkg/provider/aws/execution_unit_test.go
@@ -141,6 +141,7 @@ func Test_GenerateExecUnitResources(t *testing.T) {
 					{Source: "aws:iam_role:test-test-ExecutionRole", Destination: "aws:iam_policy:policy1"},
 					{Source: "aws:iam_role:test-test-ExecutionRole", Destination: "aws:iam_policy:policy2"},
 					{Source: "aws:iam_role:test-test-ExecutionRole", Destination: "aws:s3_bucket:test-test"},
+					{Source: "aws:iam_role:test-test-ExecutionRole", Destination: "aws:iam_oidc_provider:test-eks-cluster"},
 					{Source: "aws:internet_gateway:test_igw1", Destination: "aws:vpc:test"},
 					{Source: "aws:load_balancer:test-test", Destination: "aws:vpc_subnet:test_private1"},
 					{Source: "aws:load_balancer:test-test", Destination: "aws:vpc_subnet:test_private2"},

--- a/pkg/provider/aws/resources/ecr.go
+++ b/pkg/provider/aws/resources/ecr.go
@@ -10,7 +10,8 @@ const (
 	ECR_REPO_TYPE  = "ecr_repo"
 	ECR_IMAGE_TYPE = "ecr_image"
 
-	ECR_IMAGE_NAME_IAC_VALUE = "ecr_image_name"
+	ECR_IMAGE_NAME_IAC_VALUE  = "ecr_image_name"
+	ECR_REPO_DIGEST_IAC_VALUE = "ecr_repo_digest"
 )
 
 type (


### PR DESCRIPTION
This PR includes the following fixes:

- Wrapped the response from the python EKS proxy runtime in `json.loads` instead of returning the binary blob to the caller
- Added an environment variable to each EKS deployment or pod referencing its ECR image digest to trigger updates when the image is updated in ECR
- Added missing dependencies between an IAM Role and the resources referenced by its `assumeRolePolicy`
