### PR TITLE
Copies config secret path when overriding values

### DIFF
--- a/pkg/config/config_construct.go
+++ b/pkg/config/config_construct.go
@@ -18,6 +18,7 @@ func (a Application) GetConfig(id string) Config {
 	ecfg, hasOverride := a.Config[id]
 	if hasOverride {
 		overrideValue(&cfg.Type, ecfg.Type)
+		overrideValue(&cfg.Path, ecfg.Path)
 		cfg.InfraParams = ecfg.InfraParams
 	}
 	cfg.InfraParams.ApplyDefaults(a.Defaults.Config.InfraParamsByType[cfg.Type])


### PR DESCRIPTION
This PR copies over the `Config` struct's `Path` field when merging config overrides.