### PR TITLE
fix node selectors and metadata name sanitization

### DIFF
--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -623,6 +623,8 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		region := resources.NewRegion()
 		return fmt.Sprintf(`pulumi.all([obj.data["output.conf"], %s.name, %s.name]).apply(([obj, regionName, clusterName]) => obj.replace("region-code",regionName).replace("my-logs","/fargate/" +clusterName))`,
 			tc.getVarName(region), tc.getVarName(v.Resource)), nil
+	case resources.NODE_GROUP_NAME_IAC_VALUE:
+		return fmt.Sprintf(`%s.nodeGroupName`, tc.getVarName(resource)), nil
 	}
 
 	return "", errors.Errorf("unsupported IaC Value Property %T.%s", resource, property)

--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -3,8 +3,10 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	"github.com/klothoplatform/klotho/pkg/sanitization"
 	"regexp"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
+	sanitize "github.com/klothoplatform/klotho/pkg/sanitization/kubernetes"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -99,6 +101,14 @@ func GenerateTargetGroupBindingPlaceholder(unit string) string {
 	return fmt.Sprintf("%sTargetGroupArn", sanitizeString(unit))
 }
 
+func GenerateInstanceTypeKeyPlaceholder(unit string) string {
+	return fmt.Sprintf("%sInstanceTypeKey", sanitizeString(unit))
+}
+
+func GenerateInstanceTypeValuePlaceholder(unit string) string {
+	return fmt.Sprintf("%sInstanceTypeValue", sanitizeString(unit))
+
+}
 func GenerateEnvVarKeyValue(key string) (k string, v string) {
 	k = key
 	v = sanitizeString(key)
@@ -178,7 +188,7 @@ var deploymentTransformer = manifestTransformer[*apps.Deployment]{
 		}
 		var values []HelmChartValue
 		values = []HelmChartValue{
-			HelmChartValue{
+			{
 				ExecUnitName: unit.Name,
 				Kind:         deployment.Kind,
 				Type:         string(ImageTransformation),
@@ -224,8 +234,8 @@ var deploymentTransformer = manifestTransformer[*apps.Deployment]{
 			}
 
 			if kconfig := cfg.GetExecutionUnitParamsAsKubernetes(); kconfig.InstanceType != "" {
-				instanceTypeKey := unit.Name + "InstanceTypeKey"
-				instanceTypeValue := unit.Name + "InstanceTypeValue"
+				instanceTypeKey := GenerateInstanceTypeKeyPlaceholder(unit.Name)
+				instanceTypeValue := GenerateInstanceTypeValuePlaceholder(unit.Name)
 				deployment.Spec.Template.Spec.NodeSelector[fmt.Sprintf("{{ .Values.%s }}", instanceTypeKey)] = fmt.Sprintf("{{ .Values.%s }}", instanceTypeValue)
 				values = append(values,
 					HelmChartValue{
@@ -388,7 +398,7 @@ var targetGroupBindingTransformer = manifestTransformer[*elbv2api.TargetGroupBin
 		targetGroupBinding.Labels["execUnit"] = unit.Name
 
 		return []HelmChartValue{
-			HelmChartValue{
+			{
 				ExecUnitName: unit.Name,
 				Kind:         targetGroupBinding.Kind,
 				Type:         string(TargetGroupTransformation),
@@ -400,11 +410,11 @@ var targetGroupBindingTransformer = manifestTransformer[*elbv2api.TargetGroupBin
 
 func (unit *HelmExecUnit) getServiceAccountName() string {
 	if unit.ServiceAccount == nil {
-		return unit.Name
+		return sanitize.MetadataNameSanitizer.Apply(unit.Name)
 	}
 	obj, err := readFile(unit.ServiceAccount)
 	if err != nil {
-		return unit.Name
+		return sanitize.MetadataNameSanitizer.Apply(unit.Name)
 	}
 	serviceAccount, ok := obj.(*corev1.ServiceAccount)
 	if !ok {

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -279,7 +279,7 @@ func Test_transformPod(t *testing.T) {
                         image: '{{ .Values.testUnitImage }}'
                         name: web
                         resources: {}
-                      serviceAccountName: testUnit
+                      serviceAccountName: testnit
                     status: {}`),
 			},
 		},
@@ -336,7 +336,7 @@ func Test_transformPod(t *testing.T) {
                             cpu: "123"
                           requests:
                             cpu: "123"
-                      serviceAccountName: testUnit
+                      serviceAccountName: testnit
                     status: {}`),
 			},
 		},
@@ -462,7 +462,7 @@ func Test_transformDeployment(t *testing.T) {
                             image: '{{ .Values.testUnitImage }}'
                             name: nginx
                             resources: {}
-                          serviceAccountName: testUnit
+                          serviceAccountName: testnit
                     status: {}`),
 			},
 		},
@@ -539,7 +539,7 @@ func Test_transformDeployment(t *testing.T) {
                             image: '{{ .Values.testUnitImage }}'
                             name: testUnit
                             resources: {}
-                          serviceAccountName: testUnit
+                          serviceAccountName: testnit
                     status: {}`),
 			},
 		},
@@ -609,7 +609,7 @@ spec:
         image: '{{ .Values.testUnitImage }}'
         name: nginx
         resources: {}
-      serviceAccountName: testUnit
+      serviceAccountName: testnit
 status: {}
 `, // ?? Not sure why yaml marshalling adds the newline and indentation within the value of the instance type
 			},
@@ -696,7 +696,7 @@ spec:
         '{{ .Values.testUnitInstanceTypeKey }}': '{{ .Values.testUnitInstanceTypeValue
           }}'
         network_placement: private
-      serviceAccountName: testUnit
+      serviceAccountName: testnit
 status: {}
 `, // ?? Not sure why yaml marshalling adds the newline and indentation within the value of the instance type
 			},
@@ -1734,7 +1734,7 @@ metadata:
 		},
 		{
 			name: "no file",
-			want: "testUnit",
+			want: "testnit",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/infra/kubernetes/helm_chart_test.go
+++ b/pkg/infra/kubernetes/helm_chart_test.go
@@ -819,6 +819,8 @@ func Test_addHorizontalPodAutoscaler(t *testing.T) {
                     kind: HorizontalPodAutoscaler
                     metadata:
                       creationTimestamp: null
+                      labels:
+                        execUnit: unit
                       name: unit
                     spec:
                       maxReplicas: 4

--- a/pkg/infra/kubernetes/manifests/deployment.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/deployment.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     execUnit: {{ .ExecUnitName }}
-  name: {{ .ExecUnitName }}
+  name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:
   replicas: 2

--- a/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
@@ -1,12 +1,14 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .ExecUnitName }}
+  name: {{ .Name }}
+  labels:
+    execUnit: {{ .ExecUnitName }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .ExecUnitName }}
+    name: {{ .Name }}
   minReplicas: 2
   maxReplicas: 4
   metrics:

--- a/pkg/infra/kubernetes/manifests/service.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/service.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     execUnit: {{ .ExecUnitName }}
-  name: {{ .ExecUnitName }}
+  name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:
   ports:

--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -44,13 +44,13 @@ func Test_CreateEksCluster(t *testing.T) {
 					"aws:eks_addon:test-app-test-cluster-addon-vpc-cni",
 					"aws:eks_cluster:test-app-test-cluster",
 					"aws:eks_fargate_profile:test-app-test-cluster",
-					"aws:eks_node_group:private_g2",
-					"aws:eks_node_group:private_t3_medium",
+					"aws:eks_node_group:test-cluster_private_g2",
+					"aws:eks_node_group:test-cluster_private_t3_medium",
 					"aws:iam_oidc_provider:test-app-test-cluster",
 					"aws:iam_role:test-app-test-cluster-FargateExecutionRole",
 					"aws:iam_role:test-app-test-cluster-k8sAdmin",
-					"aws:iam_role:test-app-test-cluster.private_g2",
-					"aws:iam_role:test-app-test-cluster.private_t3_medium",
+					"aws:iam_role:test-app-test-cluster_private_g2",
+					"aws:iam_role:test-app-test-cluster_private_t3_medium",
 					"aws:region:region",
 					"aws:vpc:test_app",
 					"aws:vpc_subnet:test_app_test_subnet",
@@ -70,20 +70,20 @@ func Test_CreateEksCluster(t *testing.T) {
 					{Source: "aws:eks_fargate_profile:test-app-test-cluster", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "aws:eks_fargate_profile:test-app-test-cluster", Destination: "aws:iam_role:test-app-test-cluster-FargateExecutionRole"},
 					{Source: "aws:eks_fargate_profile:test-app-test-cluster", Destination: "aws:vpc_subnet:test_app_test_subnet"},
-					{Source: "aws:eks_node_group:private_g2", Destination: "aws:eks_cluster:test-app-test-cluster"},
-					{Source: "aws:eks_node_group:private_g2", Destination: "aws:iam_role:test-app-test-cluster.private_g2"},
-					{Source: "aws:eks_node_group:private_g2", Destination: "aws:vpc_subnet:test_app_test_subnet"},
-					{Source: "aws:eks_node_group:private_t3_medium", Destination: "aws:eks_cluster:test-app-test-cluster"},
-					{Source: "aws:eks_node_group:private_t3_medium", Destination: "aws:iam_role:test-app-test-cluster.private_t3_medium"},
-					{Source: "aws:eks_node_group:private_t3_medium", Destination: "aws:vpc_subnet:test_app_test_subnet"},
+					{Source: "aws:eks_node_group:test-cluster_private_g2", Destination: "aws:eks_cluster:test-app-test-cluster"},
+					{Source: "aws:eks_node_group:test-cluster_private_g2", Destination: "aws:iam_role:test-app-test-cluster_private_g2"},
+					{Source: "aws:eks_node_group:test-cluster_private_g2", Destination: "aws:vpc_subnet:test_app_test_subnet"},
+					{Source: "aws:eks_node_group:test-cluster_private_t3_medium", Destination: "aws:eks_cluster:test-app-test-cluster"},
+					{Source: "aws:eks_node_group:test-cluster_private_t3_medium", Destination: "aws:iam_role:test-app-test-cluster_private_t3_medium"},
+					{Source: "aws:eks_node_group:test-cluster_private_t3_medium", Destination: "aws:vpc_subnet:test_app_test_subnet"},
 					{Source: "aws:iam_oidc_provider:test-app-test-cluster", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "aws:iam_oidc_provider:test-app-test-cluster", Destination: "aws:region:region"},
 					{Source: "aws:vpc:test_app", Destination: "aws:region:region"},
 					{Source: "aws:vpc_subnet:test_app_test_subnet", Destination: "aws:vpc:test_app"},
-					{Source: "kubernetes:helm_chart:test-app-test-cluster-cert-manager", Destination: "aws:eks_node_group:private_g2"},
-					{Source: "kubernetes:helm_chart:test-app-test-cluster-cert-manager", Destination: "aws:eks_node_group:private_t3_medium"},
-					{Source: "kubernetes:helm_chart:test-app-test-cluster-metrics-server", Destination: "aws:eks_node_group:private_g2"},
-					{Source: "kubernetes:helm_chart:test-app-test-cluster-metrics-server", Destination: "aws:eks_node_group:private_t3_medium"},
+					{Source: "kubernetes:helm_chart:test-app-test-cluster-cert-manager", Destination: "aws:eks_node_group:test-cluster_private_g2"},
+					{Source: "kubernetes:helm_chart:test-app-test-cluster-cert-manager", Destination: "aws:eks_node_group:test-cluster_private_t3_medium"},
+					{Source: "kubernetes:helm_chart:test-app-test-cluster-metrics-server", Destination: "aws:eks_node_group:test-cluster_private_g2"},
+					{Source: "kubernetes:helm_chart:test-app-test-cluster-metrics-server", Destination: "aws:eks_node_group:test-cluster_private_t3_medium"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-awmazon-cloudwatch-ns", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-aws-observability-config-map", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-aws-observability-config-map", Destination: "kubernetes:manifest:test-app-test-cluster-aws-observability-ns"},
@@ -94,8 +94,8 @@ func Test_CreateEksCluster(t *testing.T) {
 					{Source: "kubernetes:manifest:test-app-test-cluster-fluent-bit-cluster-info-config-map", Destination: "aws:eks_cluster:test-app-test-cluster"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-fluent-bit-cluster-info-config-map", Destination: "kubernetes:manifest:test-app-test-cluster-awmazon-cloudwatch-ns"},
 					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_cluster:test-app-test-cluster"},
-					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:private_g2"},
-					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:private_t3_medium"},
+					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:test-cluster_private_g2"},
+					{Source: "kubernetes:manifest:test-app-test-cluster-nvidia-device-plugin", Destination: "aws:eks_node_group:test-cluster_private_t3_medium"},
 				},
 			},
 		},
@@ -233,38 +233,6 @@ func Test_createNodeRole(t *testing.T) {
 	})
 }
 
-func TestNodeGroupNameFromConfig(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  config.ExecutionUnit
-		want string
-	}{
-		{
-			name: "simple config",
-			cfg: config.ExecutionUnit{
-				NetworkPlacement: "public",
-				InfraParams:      config.InfraParams{"instance_type": "test"},
-			},
-			want: "public_test",
-		},
-		{
-			name: "translate config",
-			cfg: config.ExecutionUnit{
-				NetworkPlacement: "private",
-				InfraParams:      config.InfraParams{"instance_type": "t3.medium"},
-			},
-			want: "private_t3_medium",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			assert.Equal(tt.want, NodeGroupNameFromConfig(tt.cfg))
-		})
-	}
-}
-
 func Test_createNodeGroups(t *testing.T) {
 	cluster := &EksCluster{Name: "cluster"}
 	subnets := []*Subnet{
@@ -290,7 +258,7 @@ func Test_createNodeGroups(t *testing.T) {
 				"b": {},
 			},
 			want: []NodeGroupExpect{
-				{Name: "private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
+				{Name: "cluster_private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
 			},
 		},
 		{
@@ -300,8 +268,8 @@ func Test_createNodeGroups(t *testing.T) {
 				"b": {NetworkPlacement: "public"},
 			},
 			want: []NodeGroupExpect{
-				{Name: "private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
-				{Name: "public_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
+				{Name: "cluster_private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
+				{Name: "cluster_public_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
 			},
 		},
 		{
@@ -311,8 +279,8 @@ func Test_createNodeGroups(t *testing.T) {
 				"b": {InfraParams: config.InfraParams{"instance_type": "g2.medium"}},
 			},
 			want: []NodeGroupExpect{
-				{Name: "private_c1_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
-				{Name: "private_g2_medium", DiskSize: 20, AmiType: "AL2_x86_64_GPU"},
+				{Name: "cluster_private_c1_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
+				{Name: "cluster_private_g2_medium", DiskSize: 20, AmiType: "AL2_x86_64_GPU"},
 			},
 		},
 		{
@@ -322,8 +290,8 @@ func Test_createNodeGroups(t *testing.T) {
 				"b": {NetworkPlacement: "public", InfraParams: config.InfraParams{"disk_size_gib": 50}},
 			},
 			want: []NodeGroupExpect{
-				{Name: "private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
-				{Name: "public_t3_medium", DiskSize: 50, AmiType: "AL2_x86_64"},
+				{Name: "cluster_private_t3_medium", DiskSize: 20, AmiType: "AL2_x86_64"},
+				{Name: "cluster_public_t3_medium", DiskSize: 50, AmiType: "AL2_x86_64"},
 			},
 		},
 	}

--- a/pkg/sanitization/kubernetes/kubernetes.go
+++ b/pkg/sanitization/kubernetes/kubernetes.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"regexp"
+
+	"github.com/klothoplatform/klotho/pkg/sanitization"
+)
+
+// VpcSanitizer returns a sanitized vpc name when applied.
+var MetadataNameSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
+		// strip any leading non alpha characters
+		{
+			Pattern:     regexp.MustCompile(`^[^a-z]+`),
+			Replacement: "",
+		},
+		// strip any ending non alpha characters
+		{
+			Pattern:     regexp.MustCompile(`[^a-z]$`),
+			Replacement: "",
+		},
+		// strip any other invalid characters
+		{
+			Pattern:     regexp.MustCompile(`[^a-z0-9-.]+`),
+			Replacement: "",
+		},
+	}, 253)
+
+// VpcSanitizer returns a sanitized vpc name when applied.
+var HelmValueSanitizer = sanitization.NewSanitizer(
+	[]sanitization.Rule{
+		{
+			Pattern:     regexp.MustCompile(`[^a-zA-Z0-9]+`),
+			Replacement: "",
+		},
+	}, 100)


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes #550 closes #552 and closes #553 

our node selectors didnt work because of 2 reasons.
- The value wasnt sanitized, so if there was a - in your exec unit ID then the helm chart failed to render
- We didnt set the value to the actual node group name thats deployed only to our local name, which doesnt match whats in the cloud

Our metadata name on all manifests failed if there were capital letters in the exec unit ID so added sanitization for that as well


### Standard checks

- **Unit tests**: Any special considerations? updated
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
