### PR TITLE
Change python fargate dockerfile to be debian based

### DIFF
--- a/pkg/lang/python/aws_runtime/Fargate_Dockerfile.tmpl
+++ b/pkg/lang/python/aws_runtime/Fargate_Dockerfile.tmpl
@@ -1,37 +1,14 @@
-ARG WORK_DIR="/usr/src/app"
+FROM python:3-bullseye
 
-#########################################
-##           Builder Image             ##
-#########################################
-FROM python:alpine as builder
-ARG WORK_DIR
+WORKDIR /usr/src/app
 
-WORKDIR ${WORK_DIR}
+COPY {{.ProjectFilePath}} ./
 
-RUN apk --update add cmake autoconf automake libtool binutils gcc make g++ zlib-dev --no-cache
+RUN pip install -r {{.ProjectFilePath}}
 
-RUN mkdir -p ${WORK_DIR}
-
-COPY . ${WORK_DIR}
-
-# TODO: look into a cleaner location to install dependencies
-RUN pip install \
-        --target ${WORK_DIR} \
-        -r ${WORK_DIR}/{{.ProjectFilePath}}
-
-
-#########################################
-##            Runtime image            ##
-#########################################
-FROM python:alpine
-ARG WORK_DIR
-
-WORKDIR ${WORK_DIR}
 COPY . ./
 
-COPY --from=builder ${WORK_DIR} ${WORK_DIR}
-
-ENV PYTHONPATH=${WORK_DIR}:${PYTHONPATH}
+ENV PYTHONPATH=.:${PYTHONPATH}
 
 EXPOSE 3000
 ENTRYPOINT ["python"]

--- a/pkg/lang/python/aws_runtime/Fargate_Dockerfile.tmpl
+++ b/pkg/lang/python/aws_runtime/Fargate_Dockerfile.tmpl
@@ -1,5 +1,13 @@
 FROM python:3-bullseye
 
+# Install some common dependencies for python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    autoconf automake binutils gcc g++ \
+    clang make zlib1g zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 WORKDIR /usr/src/app
 
 COPY {{.ProjectFilePath}} ./


### PR DESCRIPTION
Tested with py-redis
![image](https://user-images.githubusercontent.com/90645437/234978192-5f219441-eddd-4ec4-947a-e320af438d79.png)

Can't get a request through the API Gateway yet though - likely due to unrelated issues, but want to get a complete test before it's ready for merge.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
