### PR TITLE
Appends a docker image's sha256 hash to its tag to make it unique per build

### DIFF
--- a/pkg/infra/iac2/resource_creation_template_test.go
+++ b/pkg/infra/iac2/resource_creation_template_test.go
@@ -25,7 +25,7 @@ func TestParseTemplate(t *testing.T) {
 			},
 			parsed.InputTypes)
 		assert.Equal("aws.lambda.Function", parsed.OutputType)
-		assert.Equal("new Function({{parseTS .blah}})", parsed.ExpressionTemplate)
+		assert.Equal("new Function({{parseTS .blah}}, \"{{ `{{` }} .SomeLiteralValue }}\")", parsed.ExpressionTemplate)
 		assert.Equal(
 			map[string]struct{}{
 				`import * as aws from '@pulumi/aws'`:   {},
@@ -120,7 +120,17 @@ func Test_appliedOutputsToString(t *testing.T) {
 		input []AppliedOutput
 	}{
 		{
-			name: "simple test",
+			name: "single applied outputs uses output.apply()",
+			input: []AppliedOutput{
+				{
+					appliedName: fmt.Sprintf("%s.arn", "awsEksClusterTestAppCluster1"),
+					varName:     "cluster_arn",
+				},
+			},
+			want: "awsEksClusterTestAppCluster1.arn.apply(cluster_arn => { return ",
+		},
+		{
+			name: "multiple applied outputs uses pulumi.all().apply()",
 			input: []AppliedOutput{
 				{
 					appliedName: fmt.Sprintf("%s.openIdConnectIssuerUrl", "awsEksClusterTestAppCluster1"),
@@ -215,7 +225,7 @@ interface Args {
 }
 
 function create(args: Args): aws.lambda.Function {
-	return new Function(args.blah);
+	return new Function(args.blah, "~~{{ .SomeLiteralValue }}");
 }
 `
 

--- a/pkg/infra/iac2/templates/ecr_image/package.json
+++ b/pkg/infra/iac2/templates/ecr_image/package.json
@@ -3,6 +3,7 @@
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
         "@pulumi/pulumi": "^3.65.0",
-        "@pulumi/docker": "^4.1.2"
+        "@pulumi/docker": "^4.1.2",
+        "@pulumi/command": "^0.7.2"
     }
 }

--- a/pkg/infra/iac2/templates/lambda_function/factory.ts
+++ b/pkg/infra/iac2/templates/lambda_function/factory.ts
@@ -21,7 +21,6 @@ function create(args: Args): aws.lambda.Function {
         {
             packageType: 'Image',
             imageUri: args.Image.imageName,
-            sourceCodeHash: args.Image.repoDigest,
             //TMPL {{- if .MemorySize.Raw }}
             memorySize: args.MemorySize,
             //TMPL {{- end }}

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -599,8 +599,6 @@ func (tc TemplatesCompiler) handleIaCValue(v core.IaCValue, appliedOutputs *[]Ap
 		return fmt.Sprintf("%s.invokeUrl.apply((d) => d.split('//')[1].split('/')[0])", tc.getVarName(v.Resource)), nil
 	case resources.ECR_IMAGE_NAME_IAC_VALUE:
 		return fmt.Sprintf(`%s.imageName`, tc.getVarName(resource)), nil
-	case resources.ECR_REPO_DIGEST_IAC_VALUE:
-		return fmt.Sprintf(`%s.repoDigest`, tc.getVarName(resource)), nil
 	case resources.NLB_INTEGRATION_URI_IAC_VALUE:
 		integration, ok := resourceVal.Interface().(resources.ApiIntegration)
 		if !ok {

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -256,12 +256,6 @@ func Test_transformPod(t *testing.T) {
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
-					{
-						ExecUnitName: "testUnit",
-						Kind:         "Pod",
-						Type:         string(ImageHashTransformation),
-						Key:          "testUnitImagehash",
-					},
 				},
 				newFile: testutil.UnIndent(`
                     apiVersion: v1
@@ -273,10 +267,7 @@ func Test_transformPod(t *testing.T) {
                       name: test
                     spec:
                       containers:
-                      - env:
-                        - name: testUnitImagehash
-                          value: '{{ .Values.testUnitImagehash }}'
-                        image: '{{ .Values.testUnitImage }}'
+                      - image: '{{ .Values.testUnitImage }}'
                         name: web
                         resources: {}
                       serviceAccountName: testunit
@@ -309,12 +300,6 @@ func Test_transformPod(t *testing.T) {
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
-					{
-						ExecUnitName: "testUnit",
-						Kind:         "Pod",
-						Type:         string(ImageHashTransformation),
-						Key:          "testUnitImagehash",
-					},
 				},
 				newFile: testutil.UnIndent(`
                     apiVersion: v1
@@ -326,10 +311,7 @@ func Test_transformPod(t *testing.T) {
                       name: test
                     spec:
                       containers:
-                      - env:
-                        - name: testUnitImagehash
-                          value: '{{ .Values.testUnitImagehash }}'
-                        image: '{{ .Values.testUnitImage }}'
+                      - image: '{{ .Values.testUnitImage }}'
                         name: testunit
                         resources:
                           limits:
@@ -411,12 +393,6 @@ func Test_transformDeployment(t *testing.T) {
 			Type:         string(ImageTransformation),
 			Key:          "testUnitImage",
 		},
-		{
-			ExecUnitName: "testUnit",
-			Kind:         "Deployment",
-			Type:         string(ImageHashTransformation),
-			Key:          "testUnitImagehash",
-		},
 	}
 	tests := []struct {
 		name    string
@@ -456,10 +432,7 @@ func Test_transformDeployment(t *testing.T) {
                             klotho-fargate-enabled: "false"
                         spec:
                           containers:
-                          - env:
-                            - name: testUnitImagehash
-                              value: '{{ .Values.testUnitImagehash }}'
-                            image: '{{ .Values.testUnitImage }}'
+                          - image: '{{ .Values.testUnitImage }}'
                             name: nginx
                             resources: {}
                           serviceAccountName: testunit
@@ -533,10 +506,7 @@ func Test_transformDeployment(t *testing.T) {
                             klotho-fargate-enabled: "false"
                         spec:
                           containers:
-                          - env:
-                            - name: testUnitImagehash
-                              value: '{{ .Values.testUnitImagehash }}'
-                            image: '{{ .Values.testUnitImage }}'
+                          - image: '{{ .Values.testUnitImage }}'
                             name: testunit
                             resources: {}
                           serviceAccountName: testunit
@@ -571,12 +541,6 @@ spec:
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
 					},
-					{
-						ExecUnitName: "testUnit",
-						Kind:         "Deployment",
-						Type:         string(ImageHashTransformation),
-						Key:          "testUnitImagehash",
-					},
 				},
 				newFile: `apiVersion: apps/v1
 kind: Deployment
@@ -603,10 +567,7 @@ spec:
         klotho-fargate-enabled: "true"
     spec:
       containers:
-      - env:
-        - name: testUnitImagehash
-          value: '{{ .Values.testUnitImagehash }}'
-        image: '{{ .Values.testUnitImage }}'
+      - image: '{{ .Values.testUnitImage }}'
         name: nginx
         resources: {}
       serviceAccountName: testunit
@@ -641,12 +602,6 @@ spec:
 						Kind:         "Deployment",
 						Type:         string(ImageTransformation),
 						Key:          "testUnitImage",
-					},
-					{
-						ExecUnitName: "testUnit",
-						Kind:         "Deployment",
-						Type:         string(ImageHashTransformation),
-						Key:          "testUnitImagehash",
 					},
 					{
 						ExecUnitName: "testUnit",
@@ -686,10 +641,7 @@ spec:
         klotho-fargate-enabled: "false"
     spec:
       containers:
-      - env:
-        - name: testUnitImagehash
-          value: '{{ .Values.testUnitImagehash }}'
-        image: '{{ .Values.testUnitImage }}'
+      - image: '{{ .Values.testUnitImage }}'
         name: nginx
         resources: {}
       nodeSelector:

--- a/pkg/infra/kubernetes/helm_chart_test.go
+++ b/pkg/infra/kubernetes/helm_chart_test.go
@@ -478,12 +478,6 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Key:          "unitImage",
 				},
 				{
-					ExecUnitName: "unit",
-					Kind:         "Deployment",
-					Type:         "image_hash",
-					Key:          "unitImagehash",
-				},
-				{
 					ExecUnitName: testUnitName,
 					Kind:         "ServiceAccount",
 					Type:         "service_account_annotation",
@@ -503,12 +497,6 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Key:          "unitImage",
 				},
 				{
-					ExecUnitName: "unit",
-					Kind:         "Deployment",
-					Type:         "image_hash",
-					Key:          "unitImagehash",
-				},
-				{
 					ExecUnitName: testUnitName,
 					Kind:         "ServiceAccount",
 					Type:         "service_account_annotation",
@@ -526,12 +514,6 @@ func Test_handleExecutionUnit(t *testing.T) {
 					Kind:         "Deployment",
 					Type:         "image",
 					Key:          "unitImage",
-				},
-				{
-					ExecUnitName: "unit",
-					Kind:         "Deployment",
-					Type:         "image_hash",
-					Key:          "unitImagehash",
 				},
 				{
 					ExecUnitName: testUnitName,
@@ -742,10 +724,7 @@ spec:
         klotho-fargate-enabled: "false"
     spec:
       containers:
-      - env:
-        - name: unitImagehash
-          value: '{{ .Values.unitImagehash }}'
-        image: '{{ .Values.unitImage }}'
+      - image: '{{ .Values.unitImage }}'
         name: unit
         resources: {}
       serviceAccount: unit
@@ -758,12 +737,6 @@ status: {}
 						Kind:         "Deployment",
 						Type:         "image",
 						Key:          "unitImage",
-					},
-					{
-						ExecUnitName: "unit",
-						Kind:         "Deployment",
-						Type:         "image_hash",
-						Key:          "unitImagehash",
 					},
 				},
 			},

--- a/pkg/infra/kubernetes/values.go
+++ b/pkg/infra/kubernetes/values.go
@@ -16,7 +16,6 @@ type ProviderValueTypes string
 const (
 	TargetGroupTransformation              ProviderValueTypes = "target_group"
 	ImageTransformation                    ProviderValueTypes = "image"
-	ImageHashTransformation                ProviderValueTypes = "image_hash"
 	EnvironmentVariableTransformation      ProviderValueTypes = "env_var"
 	ServiceAccountAnnotationTransformation ProviderValueTypes = "service_account_annotation"
 	InstanceTypeKey                        ProviderValueTypes = "instance_type_key"

--- a/pkg/provider/aws/execution_unit.go
+++ b/pkg/provider/aws/execution_unit.go
@@ -108,12 +108,6 @@ func (a *AWS) GenerateExecUnitResources(unit *core.ExecutionUnit, result *core.C
 									Property: resources.ECR_IMAGE_NAME_IAC_VALUE,
 								}
 								dag.AddDependency(khChart, image)
-							case kubernetes.ImageHashTransformation:
-								khChart.Values[val.Key] = core.IaCValue{
-									Resource: image,
-									Property: resources.ECR_REPO_DIGEST_IAC_VALUE,
-								}
-								dag.AddDependency(khChart, image)
 							case kubernetes.ServiceAccountAnnotationTransformation:
 								khChart.Values[val.Key] = core.IaCValue{
 									Resource: role,

--- a/pkg/provider/aws/resources/ecr.go
+++ b/pkg/provider/aws/resources/ecr.go
@@ -10,8 +10,7 @@ const (
 	ECR_REPO_TYPE  = "ecr_repo"
 	ECR_IMAGE_TYPE = "ecr_image"
 
-	ECR_IMAGE_NAME_IAC_VALUE  = "ecr_image_name"
-	ECR_REPO_DIGEST_IAC_VALUE = "ecr_repo_digest"
+	ECR_IMAGE_NAME_IAC_VALUE = "ecr_image_name"
 )
 
 type (


### PR DESCRIPTION
This PR makes docker image tags unique per build to ensure that lambda functions or EKS deployments referencing a given image are updated when the image changes.

- Escaped "~~{{" as "{{ \`{{\` }}" in go templates to enable use of literal double curly braces inside of resource factories.
- Changed docker image resource factory to create a base image (not pushed) and then grab that image's sha256 hash with a pulumi local command and use it to uniquely identify the tag of the image we push to ECR.
- Removed `sourceCodeHash` from lambda factory now that `imageName` will change whenever a new image version is pushed
