### PR TITLE
Update go to 1.20.4

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - uses: actions/checkout@v3
       - name: List files to check
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
 
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1

--- a/.github/workflows/run-integ-tests.yaml
+++ b/.github/workflows/run-integ-tests.yaml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - name: pre-build
         if: ${{ inputs.pre-build-script }}
         run: ${{ inputs.pre-build-script }}

--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.3'
+          go-version: '1.20.4'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Fixes
```
Vulnerability #1: GO-2023-[17](https://github.com/klothoplatform/klotho/actions/runs/4920737601/jobs/8789830062?pr=577#step:6:18)53
  Templates containing actions in unquoted HTML attributes (e.g.
  "attr={{.}}") executed with empty input can result in output
  with unexpected results when parsed due to HTML normalization
  rules. This may allow injection of arbitrary attributes into
  tags.

  More info: https://pkg.go.dev/vuln/GO-2023-1753

  Standard library
    Found in: html/template@go1.[20](https://github.com/klothoplatform/klotho/actions/runs/4920737601/jobs/8789830062?pr=577#step:6:21).3
    Fixed in: html/template@go1.20.4
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
