### PR TITLE
use viz.klo.dev by default

### DIFF
--- a/pkg/visualizer/all_types_test.go
+++ b/pkg/visualizer/all_types_test.go
@@ -14,8 +14,8 @@ import (
 
 // TestAllTypesHaveIcons is an integration test — not a unit test!
 //
-// To run it, set the env var KLOTHO_VIZ_BASE_URL to a visualizer service endpoint. For local testing, this is probably
-// "http://localhost:3000". If the env var isn't set, this test will be skipped.
+// To run it, set the env var KLOTHO_VIZ_URL_BASE to a visualizer service endpoint. For local testing, this is probably
+// "http://localhost:3000" or "https://viz-dev.klo.dev". If the env var isn't set, this test will be skipped.
 func TestAllTypesHaveIcons(t *testing.T) {
 	if !visualizerBaseUrlEnv.IsSet() {
 		t.Skipf(`Skipping because %s isn't set`, visualizerBaseUrlEnv)

--- a/pkg/visualizer/plugin.go
+++ b/pkg/visualizer/plugin.go
@@ -32,8 +32,8 @@ func (p Plugin) Name() string {
 	return "visualizer"
 }
 
-var visualizerBaseUrlEnv = cli_config.EnvVar("KLOTHO_VIZ_BASE_URL")
-var visualizerBaseUrl = visualizerBaseUrlEnv.GetOr("https://1kbh9oapga.execute-api.us-west-2.amazonaws.com/stage")
+var visualizerBaseUrlEnv = cli_config.EnvVar("KLOTHO_VIZ_URL_BASE")
+var visualizerBaseUrl = visualizerBaseUrlEnv.GetOr("https://viz.klo.dev")
 var validateTypes = cli_config.EnvVar("KLOTHO_VIZ_VALIDATE_TYPES").GetBool()
 
 func (a *visApi) request(method string, path string, contentType string, accept string, f io.WriterTo) ([]byte, error) {


### PR DESCRIPTION
- use the domain instead of the hard-coded gateway url
- tweak the env var name

### Standard checks

- **Unit tests**: none; manually tested
- **Docs**: n/a
- **Backwards compatibility**: no issues (the env var is only an internal/debug thing)
