### PR TITLE
fix python multiple imports

### DIFF
--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -149,7 +149,6 @@ func FindImports(file *core.SourceFile) Imports {
 			} else {
 				attributeAliases[alias.Content()] = struct{}{}
 			}
-			// TODO -- test this!
 			ia[attributeName] = Attribute{
 				Name:   attributeName,
 				Node:   attribute,

--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -149,7 +149,7 @@ func FindImports(file *core.SourceFile) Imports {
 			} else {
 				attributeAliases[alias.Content()] = struct{}{}
 			}
-			panic("TODO -- test me!")
+			// TODO -- test this!
 			ia[attributeName] = Attribute{
 				Name:   attributeName,
 				Node:   attribute,

--- a/pkg/lang/python/imports_test.go
+++ b/pkg/lang/python/imports_test.go
@@ -130,8 +130,23 @@ func TestFindImports(t *testing.T) {
 				"mymodule": {
 					Name: "mymodule",
 					ImportedAttributes: map[string]Attribute{
-						"attribute1": {Name: "attribute1", Alias: "a1"},
-						"attribute2": {Name: "attribute2", Alias: "a2"},
+						"attribute1": {Name: "attribute1", UsedAs: testutil.NewSet("a1")},
+						"attribute2": {Name: "attribute2", UsedAs: testutil.NewSet("a2")},
+					}},
+			},
+		},
+		{
+			name: "from module import attributes aliased multiple times",
+			source: testutil.UnIndent(`
+				from mymodule import attribute1
+				from mymodule import attribute1 as a1
+				from mymodule import attribute1 as a2
+				`),
+			want: map[string]Import{
+				"mymodule": {
+					Name: "mymodule",
+					ImportedAttributes: map[string]Attribute{
+						"attribute1": {Name: "attribute1", UsedAs: testutil.NewSet("attribute1", "a1", "a2")},
 					}},
 			},
 		},
@@ -274,6 +289,18 @@ func TestResolveFileDependencies(t *testing.T) {
 		},
 		{
 			name: "import attribute with alias",
+			input: map[string]string{
+				"main.py":  `from other import method_a as aaa`,
+				"other.py": `pass`,
+			},
+			expect: map[string]core.Imported{
+				"main.py": map[string]core.References{
+					"other.py": testutil.NewSet("method_a"),
+				},
+				"other.py": map[string]core.References{},
+			},
+		},
+		{
 			input: map[string]string{
 				"main.py":  `from other import method_a as aaa`,
 				"other.py": `pass`,

--- a/pkg/lang/python/imports_test.go
+++ b/pkg/lang/python/imports_test.go
@@ -174,15 +174,14 @@ func TestFindImports(t *testing.T) {
 				},
 			},
 		},
-		{ // TODO https://github.com/klothoplatform/klotho/issues/567
+		{
 			name: "import module aliased twice",
 			source: `
 				import module1 as a
 				import module1 as b
 `,
 			want: map[string]Import{
-				"module1": {Name: "module1", Alias: "a"},
-				// missing alias 'b'
+				"module1": {Name: "module1", Alias: "TODO a and b"},
 			},
 		},
 	}
@@ -607,6 +606,7 @@ func TestFindImportedFile(t *testing.T) {
 func validateImport(assert *assert.Assertions, content []byte, expected Import, actual Import) {
 	assert.Equal(expected.ParentModule, actual.ParentModule)
 	assert.Equal(expected.Name, actual.Name)
+	assert.Equal(expected.Alias, actual.Alias)
 
 	assert.Equal(len(expected.ImportedAttributes), len(actual.ImportedAttributes))
 	for i := range expected.ImportedAttributes {

--- a/pkg/lang/python/plugin_persist.go
+++ b/pkg/lang/python/plugin_persist.go
@@ -436,8 +436,6 @@ func (p *persister) queryKV(file *core.SourceFile, annotation *core.Annotation, 
 	}
 	aiocacheImported := len(aiocacheImport.ImportedAttributes) == 0
 	cacheImport, cacheImported := aiocacheImport.ImportedAttributes["Cache"]
-	functionHostName := aiocacheImport.Name
-	cacheFunction := cacheImport.Name
 
 	nextMatch := DoQuery(annotation.Node, persistKV)
 
@@ -449,12 +447,12 @@ func (p *persister) queryKV(file *core.SourceFile, annotation *core.Annotation, 
 	expression, name, functionHost, function := match["expression"], match["name"], match["functionHost"], match["function"]
 
 	// this assignment/invocation is unrelated to aiocache.Cache instantiation
-	if !aiocacheImported && !query.NodeContentEquals(function, cacheFunction) {
+	if !aiocacheImported && !query.NodeContentIn(function, cacheImport.UsedAs) {
 		return nil
 	}
 
 	// this Cache() invocation belongs to an object other the aiocache module
-	if aiocacheImported && functionHost != nil && !query.NodeContentEquals(functionHost, functionHostName) {
+	if aiocacheImported && functionHost != nil && !query.NodeContentIn(functionHost, aiocacheImport.UsedAs) {
 		return nil
 	}
 

--- a/pkg/lang/python/plugin_persist.go
+++ b/pkg/lang/python/plugin_persist.go
@@ -436,8 +436,8 @@ func (p *persister) queryKV(file *core.SourceFile, annotation *core.Annotation, 
 	}
 	aiocacheImported := len(aiocacheImport.ImportedAttributes) == 0
 	cacheImport, cacheImported := aiocacheImport.ImportedAttributes["Cache"]
-	//functionHostName := aiocacheImport.Name
-	//cacheFunction := cacheImport.Name
+	functionHostName := aiocacheImport.Name
+	cacheFunction := cacheImport.Name
 
 	nextMatch := DoQuery(annotation.Node, persistKV)
 

--- a/pkg/lang/python/plugin_persist.go
+++ b/pkg/lang/python/plugin_persist.go
@@ -640,12 +640,9 @@ func (p *persister) queryRedis(file *core.SourceFile, annotation *core.Annotatio
 		return nil
 	}
 	redisImported := len(redisClusterImport.ImportedAttributes) == 0
-	//redisImportName := redisImport.Name
 	constructorImport, constructorImported := redisImport.ImportedAttributes["Redis"]
 	clusterConstructorImport, clusterConstructorImported := redisClusterImport.ImportedAttributes["RedisCluster"]
 	clustermoduleImport, clusterModuleImported := redisImport.ImportedAttributes["cluster"]
-	//clusterRedisFunction := clusterConstructorImport.Name
-	//clustermoduleImportName := clustermoduleImport.Name
 
 	redisFunctions := constructorImport.UsedAs
 	if redisFunctions == nil {
@@ -656,25 +653,6 @@ func (p *persister) queryRedis(file *core.SourceFile, annotation *core.Annotatio
 	if clusterRedisFunctions == nil {
 		clusterRedisFunctions = map[string]struct{}{"RedisCluster": {}}
 	}
-
-	//redisFunction := constructorImport.Name
-	//if redisFunction == "" {
-	//	redisFunction = "Redis"
-	//} else if constructorImport.Alias != "" {
-	//	redisFunction = constructorImport.Alias
-	//}
-	//if clusterRedisFunction == "" {
-	//	clusterRedisFunction = "RedisCluster"
-	//} else if clusterConstructorImport.Alias != "" {
-	//	clusterRedisFunction = clusterConstructorImport.Alias
-	//}
-
-	//if redisImport.Alias != "" {
-	//	redisImportName = redisImport.Alias
-	//}
-	//if clustermoduleImport.Alias != "" {
-	//	clustermoduleImportName = clustermoduleImport.Alias
-	//}
 
 	nextMatch := DoQuery(annotation.Node, redis)
 

--- a/pkg/lang/python/plugin_persist_test.go
+++ b/pkg/lang/python/plugin_persist_test.go
@@ -170,7 +170,8 @@ func Test_persister_queryFs(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
-		want   []result
+		// want is a slice of results, each corresponding to one top-level node in the source
+		want []result
 	}{
 		{
 			name:   "aiofiles import match",
@@ -208,7 +209,7 @@ func Test_persister_queryFs(t *testing.T) {
 			},
 		},
 		{
-			name: "imported twice with different aliases; use first",
+			name: "imported twice with different aliases",
 			source: testutil.UnIndent(`
 				import aiofiles as first
 				import aiofiles as second`),
@@ -217,16 +218,6 @@ func Test_persister_queryFs(t *testing.T) {
 					matchName:       "first",
 					matchExpression: `import aiofiles as first`,
 				},
-				{},
-			},
-		},
-		{
-			name: "imported twice with different aliases; use second",
-			source: testutil.UnIndent(`
-				import aiofiles as first
-				import aiofiles as second`),
-			want: []result{
-				{},
 				{
 					matchName:       "second",
 					matchExpression: `import aiofiles as second`,
@@ -263,11 +254,9 @@ func Test_persister_queryFs(t *testing.T) {
 						assert.Equal(want.matchName, kvResult.name)
 					}
 				} else {
-					assert.Nil(kvResult)
+					assert.Nilf(kvResult, "for item %d", childIdx)
 				}
-
 			}
-
 		})
 	}
 }

--- a/pkg/lang/python/plugin_persist_test.go
+++ b/pkg/lang/python/plugin_persist_test.go
@@ -31,10 +31,17 @@ func Test_persister_queryKV(t *testing.T) {
 			matchExpression: "myCache=aiocache.Cache(aiocache.Cache.MEMORY)",
 		},
 		{
+			name: "aiocache import with alias",
+			source: testutil.UnIndent(`
+				import aiocache as a
+				myCache=a.Cache(a.Cache.MEMORY)`),
+			matchName:       "myCache",
+			matchExpression: "myCache=aiocache.Cache(aiocache.Cache.MEMORY)",
+		},
+		{
 			name:   "other 'Cache' function not matched",
 			source: "import other\nmyCache=other.Cache(aiocache.Cache.MEMORY)\nmyCache=Cache(aiocache.Cache.MEMORY)",
 		},
-		// TODO: add cases for import aliases when adding alias support
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/query/node.go
+++ b/pkg/query/node.go
@@ -24,9 +24,19 @@ func NodeContentEquals(node *sitter.Node, s string) bool {
 	return false
 }
 
-func NodeContentIn[K any](node *sitter.Node, m map[string]K) bool {
-	_, keyExists := m[node.Content()]
+// NodeContentIn returns whether the node's content is a key in the given map. It is just shorthand for:
+//
+//	_, result := GetMatchingNodeContent(node, m)
+func NodeContentIn(node *sitter.Node, m map[string]struct{}) bool {
+	_, keyExists := GetMatchingNodeContent(node, m)
 	return keyExists
+}
+
+// GetMatchingNodeContent returns the node's content, and whether that node content is a key in the given set.
+func GetMatchingNodeContent(node *sitter.Node, m map[string]struct{}) (string, bool) {
+	content := node.Content()
+	_, keyExists := m[content]
+	return content, keyExists
 }
 
 func NodeContentRegex(node *sitter.Node, regex *regexp.Regexp) bool {

--- a/pkg/query/node.go
+++ b/pkg/query/node.go
@@ -24,6 +24,11 @@ func NodeContentEquals(node *sitter.Node, s string) bool {
 	return false
 }
 
+func NodeContentIn[K any](node *sitter.Node, m map[string]K) bool {
+	_, keyExists := m[node.Content()]
+	return keyExists
+}
+
 func NodeContentRegex(node *sitter.Node, regex *regexp.Regexp) bool {
 	content := node.Content()
 	return regex.MatchString(content)

--- a/pkg/testutil/set.go
+++ b/pkg/testutil/set.go
@@ -1,0 +1,9 @@
+package testutil
+
+func NewSet[T comparable](ss ...T) map[T]struct{} {
+	set := make(map[T]struct{}, len(ss))
+	for _, s := range ss {
+		set[s] = struct{}{}
+	}
+	return set
+}

--- a/pkg/testutil/sitter.go
+++ b/pkg/testutil/sitter.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// FindNodeByContent returns a node whose content is the given content string. If there are multiple such nodes, this
+// will return one of them, but it's unspecified which.
+func FindNodeByContent(tree *sitter.Tree, content string) *sitter.Node {
+	var findNode0 func(node *sitter.Node) *sitter.Node
+	findNode0 = func(node *sitter.Node) *sitter.Node {
+		if node.Content() == content {
+			return node
+		}
+		for childIdx := 0; childIdx < int(node.ChildCount()); childIdx += 1 {
+			child := node.Child(childIdx)
+			if result := findNode0(child); result != nil {
+				return result
+			}
+		}
+		return nil
+	}
+	return findNode0(tree.RootNode())
+}

--- a/pkg/testutil/strings.go
+++ b/pkg/testutil/strings.go
@@ -2,9 +2,10 @@ package testutil
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 // UnIndent removes a level of indentation from the given string. The rules are very simple:


### PR DESCRIPTION
Python lets you import modules multiple times:

```python
import my_module
import my_module as x
import my_module as y
```

Previously, we would drop all but the last of these. Now, we'll capture all of them.

A big structural change in this is to remove the `Alias string` and `ImportedAs() string` in `Import struct`, and similarly for `Attribute`. Instead, there is only a `UsedAs map[string]struct{}`:

- `import my_module`
  ↳ UsedAs = {"my_module"}`
- `import my_module as a`
  ↳ UsedAs = {"a"}
- `import my_module` + `import my_module as a`
  ↳ UsedAs = {"my_module", "a"}

This resolves #567 

### Standard checks

- **Unit tests**: added a bunch, and modified a bunch, to handle multi-imports
- **Docs**: none needed
- **Backwards compatibility**: should be fully backwards compatible
