### PR TITLE
validate visualizer types during GH test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: '*'
+    branches: ['*']
 concurrency:
   cancel-in-progress: true
   group: unit-tests-${{ github.ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ['*']
+    branches: '*'
 concurrency:
   cancel-in-progress: true
   group: unit-tests-${{ github.ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ concurrency:
   group: unit-tests-${{ github.ref }}
 name: unit tests
 env:
-  KLOTHO_VIZ_URL_BASE=https://viz-dev.klo.dev
+  KLOTHO_VIZ_URL_BASE: https://viz-dev.klo.dev
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ concurrency:
   cancel-in-progress: true
   group: unit-tests-${{ github.ref }}
 name: unit tests
+env:
+  KLOTHO_VIZ_URL_BASE=https://viz-dev.klo.dev
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/pkg/visualizer/all_types_test.go
+++ b/pkg/visualizer/all_types_test.go
@@ -33,7 +33,7 @@ func TestAllTypesHaveIcons(t *testing.T) {
 				assert := assert.New(t)
 				typeNameBuf := bytes.Buffer{}
 				typeNameBuf.WriteString(typeName)
-				_, err := api.request(http.MethodGet, `validate-types`, `application/text`, ``, &typeNameBuf)
+				_, err := api.request(http.MethodPost, `validate-types`, `application/text`, ``, &typeNameBuf)
 				assert.NoError(err)
 			})
 		}

--- a/pkg/visualizer/all_types_test.go
+++ b/pkg/visualizer/all_types_test.go
@@ -2,6 +2,7 @@ package visualizer
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -25,16 +26,38 @@ func TestAllTypesHaveIcons(t *testing.T) {
 	testedTypes := make(coretesting.TypeRefSet)
 
 	api := visApi{client: http.DefaultClient}
+	typeNamesBuf := bytes.Buffer{}
+	for _, res := range allResources {
+		_, typeNames := typeNamesForResource(res)
+		for _, typeName := range typeNames {
+			typeNamesBuf.WriteString(typeName + "\n")
+		}
+	}
+	validationBytes, err := api.request(http.MethodPost, `validate-types`, `application/text`, "", &typeNamesBuf)
+	if !assert.NoError(t, err) {
+		statusCode, isBadStatus := err.(httpStatusBad)
+		if !isBadStatus || (statusCode != 400) {
+			// If it's a 400 we can keep going — that just means there were unvalidated types, which we'll check below.
+			// Anything else is unrecoverable.
+			return
+		}
+	}
+
+	var validations map[string]bool
+	err = json.Unmarshal(validationBytes, &validations)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	for _, res := range allResources {
 		provider, typeNames := typeNamesForResource(res)
 		for _, typeName := range typeNames {
 			t.Run(fmt.Sprintf("%s:%s", provider, typeName), func(t *testing.T) {
 				testedTypes.Add(res)
-				assert := assert.New(t)
-				typeNameBuf := bytes.Buffer{}
-				typeNameBuf.WriteString(typeName)
-				_, err := api.request(http.MethodPost, `validate-types`, `application/text`, ``, &typeNameBuf)
-				assert.NoError(err)
+				known, found := validations[typeName]
+				if assert.True(t, found) {
+					assert.True(t, known)
+				}
 			})
 		}
 	}


### PR DESCRIPTION
This depends on https://github.com/klothoplatform/visualizer/pull/23 (which I already deployed to the dev stage).

It sets the `KLOTHO_VIZ_URL_BASE` env var, so that we run the visualizer's `all_types_test.go` tests. It also replaces the one-call-per-type pattern with a single call that fetches all of the validations, followed by a loop to test each one. This results in slightly more complicated test code, but is much faster

### Standard checks

- **Unit tests**: n/a
- **Docs**: not needed
- **Backwards compatibility**: no issues
