### PR TITLE
Set up VPC for subnet test

### DIFF
--- a/pkg/provider/aws/resources/eks_test.go
+++ b/pkg/provider/aws/resources/eks_test.go
@@ -236,11 +236,12 @@ func Test_createNodeRole(t *testing.T) {
 
 func Test_createNodeGroups(t *testing.T) {
 	cluster := &EksCluster{Name: "cluster"}
+	vpc := &Vpc{Name: "vpc"}
 	subnets := []*Subnet{
-		{Name: "private 1", Type: PrivateSubnet},
-		{Name: "private 2", Type: PrivateSubnet},
-		{Name: "public 1", Type: PublicSubnet},
-		{Name: "public 2", Type: PublicSubnet},
+		{Name: "private 1", Type: PrivateSubnet, Vpc: vpc},
+		{Name: "private 2", Type: PrivateSubnet, Vpc: vpc},
+		{Name: "public 1", Type: PublicSubnet, Vpc: vpc},
+		{Name: "public 2", Type: PublicSubnet, Vpc: vpc},
 	}
 	type NodeGroupExpect struct {
 		Name     string

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -398,13 +398,10 @@ func (subnet *Subnet) KlothoConstructRef() []core.AnnotationKey {
 // Id returns the id of the cloud resource
 func (subnet *Subnet) Id() core.ResourceId {
 	id := core.ResourceId{
-		Provider: AWS_PROVIDER,
-		Type:     VPC_SUBNET_TYPE_PREFIX + subnet.Type,
-		Name:     subnet.Name,
-	}
-	if subnet.Vpc != nil {
-		// Realistically, this should only be the case for tests
-		id.Namespace = subnet.Vpc.Name
+		Provider:  AWS_PROVIDER,
+		Type:      VPC_SUBNET_TYPE_PREFIX + subnet.Type,
+		Namespace: subnet.Vpc.Name,
+		Name:      subnet.Name,
 	}
 	return id
 }


### PR DESCRIPTION
Removes the special casing in the subnet id for a missing vpc which was only "valid" in unit tests.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
