### PR TITLE
Add sibling module to python import test

### DIFF
--- a/pkg/lang/python/queries/find_imports.scm
+++ b/pkg/lang/python/queries/find_imports.scm
@@ -1,22 +1,22 @@
 [
-  (import_statement [
-      name: (dotted_name) @module
-      name: (aliased_import
+  (import_statement
+    name: [
+      (dotted_name) @module
+      (aliased_import
         name: (dotted_name) @aliasedModule
         alias: (identifier) @alias)
     ]
   ) @standardImport
   (import_from_statement
     . module_name: [
-                     (dotted_name) @module
-                     (relative_import . (import_prefix) @importPrefix (dotted_name) ? @module)
-                     ]
-    [
-      name: (dotted_name) @attribute
-      name: (aliased_import
-              name: (dotted_name) @attribute
-              alias: (identifier) @alias)
-
-      ]
-    ) @fromImport
-  ] @importStatement
+      (dotted_name) @module
+      (relative_import . (import_prefix) @importPrefix (dotted_name) ? @module)
+    ]
+    name: [
+      (dotted_name) @attribute
+      (aliased_import
+        name: (dotted_name) @attribute
+        alias: (identifier) @alias)
+    ]
+  ) @fromImport
+] @importStatement


### PR DESCRIPTION
No actual changes here, just adding a case to the test. Thought this was broken, but either it wasn't broken, or the changes in https://github.com/klothoplatform/klotho/pull/584 fixed it.

Addresses https://github.com/klothoplatform/klotho/issues/589

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
