### PR TITLE
use release of k8s autoscaling/v2

### DIFF
--- a/pkg/infra/kubernetes/exec_unit.go
+++ b/pkg/infra/kubernetes/exec_unit.go
@@ -11,7 +11,7 @@ import (
 
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/yaml"

--- a/pkg/infra/kubernetes/exec_unit_test.go
+++ b/pkg/infra/kubernetes/exec_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	yaml2 "k8s.io/apimachinery/pkg/util/yaml"
 	k8s_yaml "sigs.k8s.io/yaml"
@@ -727,7 +727,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 		{
 			name: "Basic HPA, no cfg",
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -739,7 +739,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -751,9 +751,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},
@@ -763,7 +761,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				"replicas": 13,
 			}},
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -775,7 +773,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -788,9 +786,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},
@@ -802,7 +798,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				},
 			}},
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -815,7 +811,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -828,9 +824,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},
@@ -842,7 +836,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				},
 			}},
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -854,7 +848,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -873,9 +867,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},
@@ -887,7 +879,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				},
 			}},
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -904,7 +896,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -923,9 +915,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},
@@ -937,7 +927,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 				},
 			}},
 			file: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   name: testUnit
@@ -949,7 +939,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				values: nil,
 				newFile: testutil.UnIndent(`
-                apiVersion: autoscaling/v2beta2
+                apiVersion: autoscaling/v2
                 kind: HorizontalPodAutoscaler
                 metadata:
                   creationTimestamp: null
@@ -968,9 +958,7 @@ func Test_transformHorizontalPodAutoscaler(t *testing.T) {
                     kind: Deployment
                     name: testUnit
                 status:
-                  conditions: null
                   currentMetrics: null
-                  currentReplicas: 0
                   desiredReplicas: 0`),
 			},
 		},

--- a/pkg/infra/kubernetes/helm_chart.go
+++ b/pkg/infra/kubernetes/helm_chart.go
@@ -7,7 +7,7 @@ import (
 
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/infra/kubernetes/helm_chart_test.go
+++ b/pkg/infra/kubernetes/helm_chart_test.go
@@ -120,7 +120,7 @@ func Test_AssignFilesToUnits(t *testing.T) {
 			units: []string{"unit1"},
 			fileUnits: map[string]string{
 				"HorizontalPodAutoscaler.yaml": testutil.UnIndent(`
-                    apiVersion: autoscaling/v2beta2
+                    apiVersion: autoscaling/v2
                     kind: HorizontalPodAutoscaler
                     metadata:
                       name: example-hpa
@@ -231,7 +231,7 @@ func Test_AssignFilesToUnits(t *testing.T) {
 			units: []string{"unit1", "unit2"},
 			fileUnits: map[string]string{
 				"HorizontalPodAutoscaler.yaml": testutil.UnIndent(`
-                    apiVersion: autoscaling/v2beta2
+                    apiVersion: autoscaling/v2
                     kind: HorizontalPodAutoscaler
                     metadata:
                       name: unit1
@@ -788,7 +788,7 @@ func Test_addHorizontalPodAutoscaler(t *testing.T) {
 			want: result{
 				hpaPath: "test/templates/unit-horizontal-pod-autoscaler.yaml",
 				hpaFile: testutil.UnIndent(`
-                    apiVersion: autoscaling/v2beta2
+                    apiVersion: autoscaling/v2
                     kind: HorizontalPodAutoscaler
                     metadata:
                       creationTimestamp: null
@@ -816,9 +816,7 @@ func Test_addHorizontalPodAutoscaler(t *testing.T) {
                         kind: Deployment
                         name: unit
                     status:
-                      conditions: null
                       currentMetrics: null
-                      currentReplicas: 0
                       desiredReplicas: 0`),
 				values: nil,
 			},

--- a/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
+++ b/pkg/infra/kubernetes/manifests/horizontal_pod_autoscaler.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Name }}


### PR DESCRIPTION
This is to fix an error during `pulumi up`:

> error: creation of resource default/copilot-api failed because the Kubernetes API server reported that the apiVersion for this resource does not exist. Verify that any required CRDs have been created: no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta2"

### Standard checks

- **Unit tests**: n/a
- **Docs**: n/a
- **Backwards compatibility**: no known issues; but untetested so far
