### PR TITLE
Fix bug with importing python modules

### DIFF
--- a/pkg/lang/python/imports.go
+++ b/pkg/lang/python/imports.go
@@ -44,6 +44,8 @@ func (imp Import) FullyQualifiedModule() string {
 	moduleRoot := imp.ParentModule
 	if imp.Name != "" {
 		if moduleRoot != "" && !strings.HasSuffix(moduleRoot, ".") {
+			// Only add a '.' delimiter if one doesn't already exist.
+			// It should only exist for `.ParentModule` in ['.' and '..'] cases
 			moduleRoot += "."
 		}
 		moduleRoot += imp.Name

--- a/pkg/lang/python/imports_test.go
+++ b/pkg/lang/python/imports_test.go
@@ -560,6 +560,22 @@ other.hello.world.say_hi()
 				"other.py": map[string]core.References{},
 			},
 		},
+		{
+			name: "import multiple with submodule",
+			input: map[string]string{
+				"main.py":    `from foo import bar, baz`,
+				"foo.py":     `pass`,
+				"foo/bar.py": `pass`,
+			},
+			expect: map[string]core.Imported{
+				"main.py": map[string]core.References{
+					"foo.py":     testutil.NewSet("baz"),
+					"foo/bar.py": testutil.NewSet[string](),
+				},
+				"foo.py":     map[string]core.References{},
+				"foo/bar.py": map[string]core.References{},
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The primary bug is in the `ModuleDir` function, but there's more cleanup and fixes as well.

The following test cases when ported to main fail:

```
--- FAIL: TestImport_FullyQualifiedModule (0.00s)
    --- FAIL: TestImport_FullyQualifiedModule/name_and_parent_relative (0.00s)
        /home/gordon/workspace/klotho/pkg/lang/python/imports_test.go:877: 
            	Error Trace:	/home/gordon/workspace/klotho/pkg/lang/python/imports_test.go:877
            	Error:      	Not equal: 
            	            	expected: ".foo"
            	            	actual  : "..foo"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-.foo
            	            	+..foo
            	Test:       	TestImport_FullyQualifiedModule/name_and_parent_relative

--- FAIL: TestResolveFileDependencies (0.01s)
    --- FAIL: TestResolveFileDependencies/import_multiple_with_submodule (0.00s)
        /home/gordon/workspace/klotho/pkg/lang/python/imports_test.go:600: 
            	Error Trace:	/home/gordon/workspace/klotho/pkg/lang/python/imports_test.go:600
            	Error:      	Not equal: 
            	            	expected: core.FileDependencies{"foo.py":core.Imported{}, "foo/bar.py":core.Imported{}, "main.py":core.Imported{"foo.py":core.References{"baz":struct {}{}}, "foo/bar.py":core.References{}}}
            	            	actual  : core.FileDependencies{"foo.py":core.Imported{}, "foo/bar.py":core.Imported{}, "main.py":core.Imported{"foo.py":core.References{"bar":struct {}{}, "baz":struct {}{}}}}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -5,8 +5,8 @@
            	            	  },
            	            	- (string) (len=7) "main.py": (core.Imported) (len=2) {
            	            	-  (string) (len=6) "foo.py": (core.References) (len=1) {
            	            	+ (string) (len=7) "main.py": (core.Imported) (len=1) {
            	            	+  (string) (len=6) "foo.py": (core.References) (len=2) {
            	            	+   (string) (len=3) "bar": (struct {}) {
            	            	+   },
            	            	    (string) (len=3) "baz": (struct {}) {
            	            	    }
            	            	-  },
            	            	-  (string) (len=10) "foo/bar.py": (core.References) {
            	            	   }
            	Test:       	TestResolveFileDependencies/import_multiple_with_submodule
```

### Standard checks

- **Unit tests**: ✅ 
- **Docs**: n/a
- **Backwards compatibility**: ✅ 
