### PR TITLE
add S3Bucket.Create, and factor out a test util

### DIFF
--- a/pkg/collectionutil/slices.go
+++ b/pkg/collectionutil/slices.go
@@ -1,0 +1,24 @@
+package collectionutil
+
+// FlattenUnique appends each unique item in each list, in the order in which it first appears.
+//
+// Examples:
+//   - FlattenUnique([]int{1, 2, 3}, []int{4, 3, 4}) => []int{1, 2, 3, 4}
+//   - FlattenUnique([]int{1, 2, 2}, []int{3, 4}) => []int{1, 2, 3, 4}
+func FlattenUnique[E comparable](slices ...[]E) []E {
+	alreadyInResult := make(map[E]struct{})
+
+	var result []E
+	for _, slice := range slices {
+		for _, elem := range slice {
+			_, alreadyIn := alreadyInResult[elem]
+			if !alreadyIn {
+				result = append(result, elem)
+				alreadyInResult[elem] = struct{}{}
+			}
+		}
+
+	}
+
+	return result
+}

--- a/pkg/collectionutil/slices_test.go
+++ b/pkg/collectionutil/slices_test.go
@@ -1,0 +1,69 @@
+package collectionutil
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+)
+
+func Test_AppendUnique(t *testing.T) {
+	cases := []struct {
+		name   string
+		inputs [][]int
+		b      []int
+		want   []int
+	}{
+		{
+			name: "unique elems",
+			inputs: [][]int{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			want: []int{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name: "first is non-unique",
+			inputs: [][]int{
+				{1, 2, 2},
+				{3, 4},
+			},
+			want: []int{1, 2, 3, 4},
+		},
+		{
+			name: "second is non-unique",
+			inputs: [][]int{
+				{1, 2},
+				{3, 3, 4},
+			},
+			want: []int{1, 2, 3, 4},
+		},
+		{
+			name: "both unique but share elements",
+			inputs: [][]int{
+				{1, 2, 3},
+				{4, 3, 5},
+			},
+			want: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name: "one is nil",
+			inputs: [][]int{
+				{1, 2, 3},
+				nil,
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name:   "overall is nil",
+			inputs: nil,
+			want:   nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			actual := FlattenUnique(tt.inputs...)
+			assert.Equal(tt.want, actual)
+		})
+	}
+}

--- a/pkg/core/coretesting/expandable_resource.go
+++ b/pkg/core/coretesting/expandable_resource.go
@@ -1,0 +1,55 @@
+package coretesting
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+type CreateCase[P any, R core.ExpandableResource[P]] struct {
+	Name     string
+	Existing R
+	Params   P
+	Want     ResourcesExpectation
+	Check    func(assertions *assert.Assertions, resource R)
+	WantErr  bool
+}
+
+func (tt CreateCase[P, R]) Run(t *testing.T) {
+	assert := assert.New(t)
+
+	dag := core.NewResourceGraph()
+	// We have to use reflect, since Go doesn't know that R is a pointer, or even something whose zero-type is
+	// comparable (so we can't do "var R zero; if tt.Existing != zero").
+	if !reflect.ValueOf(tt.Existing).IsZero() {
+		dag.AddResource(tt.Existing)
+	}
+
+	var res R
+	rType := reflect.TypeOf(tt.Existing)
+	if rType.Kind() == reflect.Pointer {
+		res = reflect.New(rType.Elem()).Interface().(R)
+	}
+	err := res.Create(dag, tt.Params)
+	if tt.WantErr {
+		assert.Error(err)
+		return
+	} else if !assert.NoError(err) {
+		return
+	}
+
+	tt.Want.Assert(t, dag)
+
+	found := dag.GetResource(res.Id())
+	if !assert.NotNil(found) {
+		return
+	}
+	foundR := found.(R)
+
+	if !assert.NotNil(tt.Check, "bug in test itself: no Case.Check provided!") {
+		return
+	}
+	tt.Check(assert, foundR)
+}

--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -25,6 +25,15 @@ type (
 		Id() ResourceId
 	}
 
+	// ExpandableResource is a resource that can generate its own dependencies. See [CreateResource].
+	//
+	// As of the time of this writing, we don't actually use this interface; it's just here for IDE goodness
+	// (cross-references in our IDEs to this doc, auto-generate, etc).
+	ExpandableResource[K any] interface {
+		Resource
+		Create(dag *ResourceGraph, param K) error
+	}
+
 	ResourceId struct {
 		Provider string
 		Type     string

--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -26,9 +26,6 @@ type (
 	}
 
 	// ExpandableResource is a resource that can generate its own dependencies. See [CreateResource].
-	//
-	// As of the time of this writing, we don't actually use this interface; it's just here for IDE goodness
-	// (cross-references in our IDEs to this doc, auto-generate, etc).
 	ExpandableResource[K any] interface {
 		Resource
 		Create(dag *ResourceGraph, param K) error

--- a/pkg/provider/aws/resources/s3_test.go
+++ b/pkg/provider/aws/resources/s3_test.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/annotation"
+	"github.com/klothoplatform/klotho/pkg/core"
+	"github.com/klothoplatform/klotho/pkg/core/coretesting"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_S3BucketCreate(t *testing.T) {
+	annotationKey := core.AnnotationKey{ID: "test", Capability: annotation.ExecutionUnitCapability}
+	cases := []coretesting.CreateCase[S3BucketCreateParams, *S3Bucket]{
+		{
+			Name: "single payloads bucket",
+			Want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:s3_bucket:my-app-payloads",
+				},
+				Deps: nil,
+			},
+			Check: func(assert *assert.Assertions, bucket *S3Bucket) {
+				assert.Equal("my-app-payloads", bucket.Name)
+				assert.ElementsMatch(bucket.ConstructsRef, []core.AnnotationKey{annotationKey})
+			},
+		},
+		{
+			Name: "two payloads buckets converge",
+			Existing: &S3Bucket{
+				Name: "my-app-payloads",
+				ConstructsRef: []core.AnnotationKey{core.AnnotationKey{
+					ID:         "some-other-eu",
+					Capability: annotation.ExecutionUnitCapability}},
+			},
+			Want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:s3_bucket:my-app-payloads",
+				},
+				Deps: nil,
+			},
+			Check: func(assert *assert.Assertions, bucket *S3Bucket) {
+				assert.Equal("my-app-payloads", bucket.Name)
+				assert.ElementsMatch(bucket.ConstructsRef,
+					[]core.AnnotationKey{
+						annotationKey,
+						core.AnnotationKey{
+							ID:         "some-other-eu",
+							Capability: annotation.ExecutionUnitCapability},
+					},
+				)
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			tt.Params = S3BucketCreateParams{
+				AppName: "my-app",
+				Refs:    []core.AnnotationKey{annotationKey},
+				Name:    "payloads",
+			}
+			tt.Run(t)
+		})
+	}
+}


### PR DESCRIPTION
The bucket create is pretty simple, because it doesn't have any
dependencies.

I realized that its test was almost identical to that of
LamdbaFunction.Create, so I factored out a helper that I hope will
provide a nice pattern for testing these as we write them. I backported
the LambdaFunction's test as a check that there really is commonality,
but kept the rest unchanged just in the interest of time (and smaller
diff).


### Standard checks

- **Unit tests**: added, plus a refactor
- **Docs**: n/a
- **Backwards compatibility**: no issues
