### PR TITLE
fix nil-deref effor in Subnet.Id()

### DIFF
--- a/pkg/provider/aws/resources/list_all.go
+++ b/pkg/provider/aws/resources/list_all.go
@@ -50,7 +50,7 @@ func ListAll() []core.Resource {
 		&SecretVersion{},
 		&Secret{},
 		&SecurityGroup{},
-		&Subnet{},
+		&Subnet{Vpc: &Vpc{}},
 		&TargetGroup{},
 		&VpcEndpoint{},
 		&VpcLink{},

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -631,14 +631,10 @@ func (subnet *Subnet) KlothoConstructRef() []core.AnnotationKey {
 
 // Id returns the id of the cloud resource
 func (subnet *Subnet) Id() core.ResourceId {
-	var namespace string
-	if subnet.Vpc != nil {
-		namespace = subnet.Vpc.Name
-	}
 	id := core.ResourceId{
 		Provider:  AWS_PROVIDER,
 		Type:      VPC_SUBNET_TYPE_PREFIX + subnet.Type,
-		Namespace: namespace,
+		Namespace: subnet.Vpc.Name,
 		Name:      subnet.Name,
 	}
 	return id

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -631,10 +631,14 @@ func (subnet *Subnet) KlothoConstructRef() []core.AnnotationKey {
 
 // Id returns the id of the cloud resource
 func (subnet *Subnet) Id() core.ResourceId {
+	var namespace string
+	if subnet.Vpc != nil {
+		namespace = subnet.Vpc.Name
+	}
 	id := core.ResourceId{
 		Provider:  AWS_PROVIDER,
 		Type:      VPC_SUBNET_TYPE_PREFIX + subnet.Type,
-		Namespace: subnet.Vpc.Name,
+		Namespace: namespace,
 		Name:      subnet.Name,
 	}
 	return id


### PR DESCRIPTION
The `TestAllTypesHaveIcons` test calls `Id()` on each resource, to get its type. This was failing for Subnets that hadn't been fully initialized with a VPC yet.

### Standard checks

- **Unit tests**: fixes it
- **Docs**: n/a
- **Backwards compatibility**: no issues
