### PR TITLE
Adds RedisNode creation + lambda -> elasticache expansion

### DIFF
--- a/pkg/provider/aws/knowledgebase/edges.go
+++ b/pkg/provider/aws/knowledgebase/edges.go
@@ -10,7 +10,7 @@ import (
 
 func GetAwsKnowledgeBase() (knowledgebase.EdgeKB, error) {
 	var err error
-	kbsToUse := []knowledgebase.EdgeKB{AwsExtraEdgesKB, IamKB, NetworkingKB, RdsKB, LambdaKB, ApiGatewayKB}
+	kbsToUse := []knowledgebase.EdgeKB{AwsExtraEdgesKB, IamKB, NetworkingKB, RdsKB, LambdaKB, ApiGatewayKB, ElasticacheKB}
 	awsKB := make(knowledgebase.EdgeKB)
 	for _, kb := range kbsToUse {
 		for edge, detail := range kb {

--- a/pkg/provider/aws/knowledgebase/elasticache.go
+++ b/pkg/provider/aws/knowledgebase/elasticache.go
@@ -1,0 +1,26 @@
+package knowledgebase
+
+import (
+	"fmt"
+	"github.com/klothoplatform/klotho/pkg/core"
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
+)
+
+var ElasticacheKB = knowledgebase.Build(
+	knowledgebase.EdgeBuilder[*resources.ElasticacheCluster, *resources.ElasticacheSubnetgroup]{
+		Configure: func(cluster *resources.ElasticacheCluster, subnetgroup *resources.ElasticacheSubnetgroup, dag *core.ResourceGraph, data knowledgebase.EdgeData) error {
+			cluster.SubnetGroup = subnetgroup
+			return nil
+		},
+	},
+	knowledgebase.EdgeBuilder[*resources.ElasticacheCluster, *resources.SecurityGroup]{},
+	knowledgebase.EdgeBuilder[*resources.ElasticacheCluster, *resources.LogGroup]{
+		Configure: func(cluster *resources.ElasticacheCluster, logGroup *resources.LogGroup, dag *core.ResourceGraph, data knowledgebase.EdgeData) error {
+			logGroup.LogGroupName = fmt.Sprintf("/aws/elasticache/%s", cluster.Name)
+			logGroup.RetentionInDays = 5
+			return nil
+		},
+	},
+	knowledgebase.EdgeBuilder[*resources.ElasticacheSubnetgroup, *resources.Subnet]{},
+)

--- a/pkg/provider/aws/knowledgebase/iam.go
+++ b/pkg/provider/aws/knowledgebase/iam.go
@@ -35,7 +35,11 @@ var IamKB = knowledgebase.Build(
 	knowledgebase.EdgeBuilder[*resources.LambdaFunction, *resources.IamRole]{
 		Configure: func(lambda *resources.LambdaFunction, role *resources.IamRole, dag *core.ResourceGraph, data knowledgebase.EdgeData) error {
 			role.AssumeRolePolicyDoc = resources.LAMBDA_ASSUMER_ROLE_POLICY
-			role.AddAwsManagedPolicies([]string{"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"})
+			if len(lambda.Subnets) == 0 {
+				role.AddAwsManagedPolicies([]string{"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"})
+			} else {
+				role.AddAwsManagedPolicies([]string{"arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"})
+			}
 			return nil
 		},
 	},

--- a/pkg/provider/aws/knowledgebase/networking.go
+++ b/pkg/provider/aws/knowledgebase/networking.go
@@ -10,6 +10,7 @@ import (
 
 var NetworkingKB = knowledgebase.Build(
 	knowledgebase.EdgeBuilder[*resources.NatGateway, *resources.Subnet]{},
+	knowledgebase.EdgeBuilder[*resources.NatGateway, *resources.ElasticIp]{},
 	knowledgebase.EdgeBuilder[*resources.RouteTable, *resources.Subnet]{},
 	knowledgebase.EdgeBuilder[*resources.RouteTable, *resources.NatGateway]{
 		Configure: func(routeTable *resources.RouteTable, nat *resources.NatGateway, dag *core.ResourceGraph, data knowledgebase.EdgeData) error {

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -39,3 +39,23 @@ func (a *AWS) expandRedisNode(dag *core.ResourceGraph, construct *core.RedisNode
 	}
 	return a.MapResourceToConstruct(redis, construct)
 }
+
+func (a *AWS) getElasticacheConfiguration(result *core.ConstructGraph, refs []core.AnnotationKey) (resources.ElasticacheClusterConfigureParams, error) {
+	clusterConfig := resources.ElasticacheClusterConfigureParams{}
+	if len(refs) != 1 {
+		return clusterConfig, fmt.Errorf("elasticache cluster must only have one construct reference")
+	}
+	construct := result.GetConstruct(refs[0].ToId())
+	if construct == nil {
+		return clusterConfig, fmt.Errorf("construct with id %s does not exist", refs[0].ToId())
+	}
+	if _, ok := construct.(*core.RedisNode); !ok {
+		return clusterConfig, fmt.Errorf("elasticache cluster must only have a construct reference to a redis node")
+	}
+
+	return resources.ElasticacheClusterConfigureParams{
+		NumCacheNodes: 1,
+		NodeType:      "cache.t3.micro",
+		Engine:        "redis",
+	}, nil
+}

--- a/pkg/provider/aws/persist.go
+++ b/pkg/provider/aws/persist.go
@@ -28,8 +28,14 @@ func (a *AWS) GenerateFsResources(construct core.Construct, result *core.Constru
 	return nil
 }
 
-func (a *AWS) GenerateRedisResources(construct core.Construct, result *core.ConstructGraph, dag *core.ResourceGraph) error {
-	ec := resources.CreateElasticache(a.Config, dag, construct)
-	a.MapResourceDirectlyToConstruct(ec, construct)
-	return nil
+func (a *AWS) expandRedisNode(dag *core.ResourceGraph, construct *core.RedisNode) error {
+	redis, err := core.CreateResource[*resources.ElasticacheCluster](dag, resources.ElasticacheClusterCreateParams{
+		AppName: a.Config.AppName,
+		Refs:    []core.AnnotationKey{construct.AnnotationKey},
+		Name:    construct.ID,
+	})
+	if err != nil {
+		return err
+	}
+	return a.MapResourceToConstruct(redis, construct)
 }

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -24,6 +24,8 @@ func (a *AWS) ExpandConstructs(result *core.ConstructGraph, dag *core.ResourceGr
 			merr.Append(a.expandOrm(dag, construct))
 		case *core.Kv:
 			merr.Append(a.expandKv(dag, construct))
+		case *core.RedisNode:
+			merr.Append(a.expandRedisNode(dag, construct))
 		}
 	}
 	return merr.ErrOrNil()
@@ -59,7 +61,7 @@ func (a *AWS) CopyConstructEdgesToDag(result *core.ConstructGraph, dag *core.Res
 			}
 			for _, envVar := range construct.EnvironmentVariables {
 				if envVar.Construct == dep.Destination {
-					data.EnvironmentVariables = []core.EnvironmentVariable{envVar}
+					data.EnvironmentVariables = append(data.EnvironmentVariables, envVar)
 				}
 			}
 		case *core.Gateway:

--- a/pkg/provider/aws/plugin.go
+++ b/pkg/provider/aws/plugin.go
@@ -102,6 +102,12 @@ func (a *AWS) configureResources(result *core.ConstructGraph, dag *core.Resource
 			}
 		case *resources.DynamodbTable:
 			configuration = a.getKvConfiguration()
+		case *resources.ElasticacheCluster:
+			configuration, err = a.getElasticacheConfiguration(result, res.ConstructsRef)
+			if err != nil {
+				merr.Append(err)
+				continue
+			}
 		}
 		merr.Append(dag.CallConfigure(resource, configuration))
 	}

--- a/pkg/provider/aws/resources/elasticache.go
+++ b/pkg/provider/aws/resources/elasticache.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"fmt"
 
-	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/sanitization/aws"
 )
@@ -30,10 +29,6 @@ type (
 const (
 	EC_TYPE   = "elasticache"
 	ECSN_TYPE = "elasticache_subnetgroup"
-)
-
-var (
-	elasticacheClusterSanitizer = aws.ElasticacheClusterSanitizer
 )
 
 // KlothoConstructRef returns AnnotationKey of the klotho resource the cloud resource is correlated to
@@ -64,35 +59,91 @@ func (ecsn *ElasticacheSubnetgroup) Id() core.ResourceId {
 	}
 }
 
-func CreateElasticache(cfg *config.Application, dag *core.ResourceGraph, source core.Construct) *ElasticacheCluster {
-	ec := &ElasticacheCluster{
-		Name:            elasticacheClusterSanitizer.Apply(fmt.Sprintf("%s-%s", cfg.AppName, source.Provenance().ID)),
-		Engine:          "redis", // TODO determine this from the type of `source`
-		CloudwatchGroup: NewLogGroup(cfg.AppName, fmt.Sprintf("/aws/elasticache/%s-%s-persist-redis", cfg.AppName, source.Id()), source.Provenance(), 0),
-		SubnetGroup: &ElasticacheSubnetgroup{
-			Name:          elasticacheClusterSanitizer.Apply(fmt.Sprintf("%s-%s", cfg.AppName, source.Provenance().ID)),
-			Subnets:       GetSubnets(cfg, dag), // TODO when we allow for segmented networks, need to determine which network (subnets) this lives in
-			ConstructsRef: []core.AnnotationKey{source.Provenance()},
+type ElasticacheClusterCreateParams struct {
+	AppName string
+	Refs    []core.AnnotationKey
+	Name    string
+}
+
+func (ec *ElasticacheCluster) Create(dag *core.ResourceGraph, params ElasticacheClusterCreateParams) error {
+	ec.Name = aws.ElasticacheClusterSanitizer.Apply(fmt.Sprintf("%s-%s", params.AppName, params.Name))
+	ec.ConstructsRef = params.Refs
+	ec.NumCacheNodes = 1
+	ec.NodeType = "cache.t3.micro"
+	ec.Engine = "redis"
+	ec.SecurityGroups = make([]*SecurityGroup, 1)
+
+	if existingCluster, ok := core.GetResource[*ElasticacheCluster](dag, ec.Id()); ok {
+		existingCluster.ConstructsRef = core.DedupeAnnotationKeys(append(existingCluster.KlothoConstructRef(), params.Refs...))
+	}
+
+	subParams := map[string]any{
+		"CloudwatchGroup": params,
+		"SubnetGroup": ElasticacheSubnetgroupCreateParams{
+			AppName: params.AppName,
+			Name:    fmt.Sprintf("%s-subnetgroup", params.Name),
+			Refs:    params.Refs,
 		},
-		SecurityGroups: []*SecurityGroup{GetSecurityGroup(cfg, dag)},
-		ConstructsRef:  []core.AnnotationKey{source.Provenance()},
-		NodeType:       "cache.t3.micro",
-		NumCacheNodes:  1,
-	}
-	dag.AddResource(ec)
-	dag.AddResource(ec.CloudwatchGroup)
-	dag.AddResource(ec.SubnetGroup)
-	dag.AddDependency(ec, ec.CloudwatchGroup)
-	dag.AddDependency(ec, ec.SubnetGroup)
-
-	for _, sg := range ec.SecurityGroups {
-		sg.ConstructsRef = append(sg.ConstructsRef, source.Provenance())
-		dag.AddDependency(ec, sg)
-	}
-	for _, sn := range ec.SubnetGroup.Subnets {
-		sn.ConstructsRef = append(sn.ConstructsRef, source.Provenance())
-		dag.AddDependency(ec.SubnetGroup, sn)
+		"SecurityGroups": []SecurityGroupCreateParams{{
+			AppName: params.AppName,
+			Refs:    params.Refs,
+		}},
 	}
 
-	return ec
+	err := dag.CreateDependencies(ec, subParams)
+	return err
+}
+
+type ElasticacheClusterConfigureParams struct {
+	Engine        string
+	NodeType      string
+	NumCacheNodes int
+}
+
+func (ec *ElasticacheCluster) Configure(params ElasticacheClusterConfigureParams) error {
+	if params.Engine != "" {
+		ec.Engine = params.Engine
+	}
+	if params.NodeType != "" {
+		ec.NodeType = params.NodeType
+	}
+	if params.NumCacheNodes > 0 {
+		ec.NumCacheNodes = params.NumCacheNodes
+	}
+	return nil
+}
+
+type ElasticacheSubnetgroupCreateParams struct {
+	Refs    []core.AnnotationKey
+	AppName string
+	Name    string
+}
+
+func (ecsn *ElasticacheSubnetgroup) Create(dag *core.ResourceGraph, params ElasticacheSubnetgroupCreateParams) error {
+	ecsn.Name = aws.ElasticacheClusterSanitizer.Apply(fmt.Sprintf("%s-%s", params.AppName, params.Name))
+	ecsn.ConstructsRef = params.Refs
+	ecsn.Subnets = make([]*Subnet, 2)
+	if existingSubnetGroup, ok := core.GetResource[*ElasticacheSubnetgroup](dag, ecsn.Id()); ok {
+		existingSubnetGroup.ConstructsRef = core.DedupeAnnotationKeys(append(existingSubnetGroup.KlothoConstructRef(), params.Refs...))
+	}
+
+	subParams := map[string]any{
+		"Subnets": []SubnetCreateParams{
+			{
+				AppName: params.AppName,
+				Refs:    params.Refs,
+				AZ:      "0",
+				Type:    PrivateSubnet,
+			},
+			{
+				AppName: params.AppName,
+				Refs:    params.Refs,
+				AZ:      "1",
+				Type:    PrivateSubnet,
+			},
+		},
+	}
+
+	err := dag.CreateDependencies(ecsn, subParams)
+	return err
 }

--- a/pkg/provider/aws/resources/elasticache.go
+++ b/pkg/provider/aws/resources/elasticache.go
@@ -68,9 +68,6 @@ type ElasticacheClusterCreateParams struct {
 func (ec *ElasticacheCluster) Create(dag *core.ResourceGraph, params ElasticacheClusterCreateParams) error {
 	ec.Name = aws.ElasticacheClusterSanitizer.Apply(fmt.Sprintf("%s-%s", params.AppName, params.Name))
 	ec.ConstructsRef = params.Refs
-	ec.NumCacheNodes = 1
-	ec.NodeType = "cache.t3.micro"
-	ec.Engine = "redis"
 	ec.SecurityGroups = make([]*SecurityGroup, 1)
 
 	if existingCluster, ok := core.GetResource[*ElasticacheCluster](dag, ec.Id()); ok {
@@ -101,15 +98,9 @@ type ElasticacheClusterConfigureParams struct {
 }
 
 func (ec *ElasticacheCluster) Configure(params ElasticacheClusterConfigureParams) error {
-	if params.Engine != "" {
-		ec.Engine = params.Engine
-	}
-	if params.NodeType != "" {
-		ec.NodeType = params.NodeType
-	}
-	if params.NumCacheNodes > 0 {
-		ec.NumCacheNodes = params.NumCacheNodes
-	}
+	ec.Engine = params.Engine
+	ec.NodeType = params.NodeType
+	ec.NumCacheNodes = params.NumCacheNodes
 	return nil
 }
 

--- a/pkg/provider/aws/resources/elasticache_test.go
+++ b/pkg/provider/aws/resources/elasticache_test.go
@@ -1,32 +1,148 @@
 package resources
 
 import (
+	"github.com/klothoplatform/klotho/pkg/annotation"
+	"github.com/klothoplatform/klotho/pkg/core/coretesting"
 	"testing"
 
-	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateElasticache(t *testing.T) {
-	dag := core.NewResourceGraph()
-	cfg := &config.Application{AppName: "test"}
-	source := &core.RedisNode{}
-
-	ec := CreateElasticache(cfg, dag, source)
-
-	assert := assert.New(t)
-
-	assert.NotNil(ec)
-	assert.NotNil(dag.GetDependency(ec, ec.CloudwatchGroup))
-	assert.NotNil(dag.GetDependency(ec, ec.SubnetGroup))
-	for _, sn := range ec.SubnetGroup.Subnets {
-		assert.NotNil(dag.GetDependency(ec.SubnetGroup, sn))
+func Test_ElasticacheClusterCreate(t *testing.T) {
+	cluster := &core.RedisNode{AnnotationKey: core.AnnotationKey{ID: "test", Capability: annotation.PersistCapability}}
+	existingKey := core.AnnotationKey{ID: "existing", Capability: annotation.PersistCapability}
+	cases := []coretesting.CreateCase[ElasticacheClusterCreateParams, *ElasticacheCluster]{
+		{
+			Name: "nil elasticache cluster",
+			Want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:availability_zones:AvailabilityZones",
+					"aws:elastic_ip:my_app_0",
+					"aws:elastic_ip:my_app_1",
+					"aws:elasticache:my-app-test",
+					"aws:elasticache_subnetgroup:my-app-test-subnetgroup",
+					"aws:internet_gateway:my_app_igw",
+					"aws:log_group:my-app-test",
+					"aws:nat_gateway:my_app_0",
+					"aws:nat_gateway:my_app_1",
+					"aws:route_table:my_app_private0",
+					"aws:route_table:my_app_private1",
+					"aws:route_table:my_app_public",
+					"aws:security_group:my_app:my-app",
+					"aws:subnet_private:my_app:my_app_private0",
+					"aws:subnet_private:my_app:my_app_private1",
+					"aws:subnet_public:my_app:my_app_public0",
+					"aws:subnet_public:my_app:my_app_public1",
+					"aws:vpc:my_app",
+				},
+				Deps: []coretesting.StringDep{
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:elasticache_subnetgroup:my-app-test-subnetgroup"},
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:log_group:my-app-test"},
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:security_group:my_app:my-app"},
+					{Source: "aws:elasticache_subnetgroup:my-app-test-subnetgroup", Destination: "aws:subnet_private:my_app:my_app_private0"},
+					{Source: "aws:elasticache_subnetgroup:my-app-test-subnetgroup", Destination: "aws:subnet_private:my_app:my_app_private1"},
+					{Source: "aws:internet_gateway:my_app_igw", Destination: "aws:vpc:my_app"},
+					{Source: "aws:nat_gateway:my_app_0", Destination: "aws:elastic_ip:my_app_0"},
+					{Source: "aws:nat_gateway:my_app_0", Destination: "aws:subnet_public:my_app:my_app_public0"},
+					{Source: "aws:nat_gateway:my_app_1", Destination: "aws:elastic_ip:my_app_1"},
+					{Source: "aws:nat_gateway:my_app_1", Destination: "aws:subnet_public:my_app:my_app_public1"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:nat_gateway:my_app_0"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:subnet_private:my_app:my_app_private0"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:nat_gateway:my_app_1"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:subnet_private:my_app:my_app_private1"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:vpc:my_app"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:internet_gateway:my_app_igw"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:subnet_public:my_app:my_app_public0"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:subnet_public:my_app:my_app_public1"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:vpc:my_app"},
+					{Source: "aws:security_group:my_app:my-app", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_private:my_app:my_app_private0", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_private:my_app:my_app_private0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_private:my_app:my_app_private1", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_private:my_app:my_app_private1", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_public:my_app:my_app_public0", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_public:my_app:my_app_public0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_public:my_app:my_app_public1", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_public:my_app:my_app_public1", Destination: "aws:vpc:my_app"},
+				},
+			},
+			Check: func(assert *assert.Assertions, table *ElasticacheCluster) {
+				assert.Equal(table.Name, "my-app-test")
+				assert.ElementsMatch(table.ConstructsRef, []core.AnnotationKey{cluster.AnnotationKey})
+			},
+		},
+		{
+			Name:     "existing elasticache cluster",
+			Existing: &ElasticacheCluster{Name: "my-app-test", ConstructsRef: []core.AnnotationKey{existingKey}},
+			Want: coretesting.ResourcesExpectation{
+				Nodes: []string{
+					"aws:availability_zones:AvailabilityZones",
+					"aws:elastic_ip:my_app_0",
+					"aws:elastic_ip:my_app_1",
+					"aws:elasticache:my-app-test",
+					"aws:elasticache_subnetgroup:my-app-test-subnetgroup",
+					"aws:internet_gateway:my_app_igw",
+					"aws:log_group:my-app-test",
+					"aws:nat_gateway:my_app_0",
+					"aws:nat_gateway:my_app_1",
+					"aws:route_table:my_app_private0",
+					"aws:route_table:my_app_private1",
+					"aws:route_table:my_app_public",
+					"aws:security_group:my_app:my-app",
+					"aws:subnet_private:my_app:my_app_private0",
+					"aws:subnet_private:my_app:my_app_private1",
+					"aws:subnet_public:my_app:my_app_public0",
+					"aws:subnet_public:my_app:my_app_public1",
+					"aws:vpc:my_app",
+				},
+				Deps: []coretesting.StringDep{
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:elasticache_subnetgroup:my-app-test-subnetgroup"},
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:log_group:my-app-test"},
+					{Source: "aws:elasticache:my-app-test", Destination: "aws:security_group:my_app:my-app"},
+					{Source: "aws:elasticache_subnetgroup:my-app-test-subnetgroup", Destination: "aws:subnet_private:my_app:my_app_private0"},
+					{Source: "aws:elasticache_subnetgroup:my-app-test-subnetgroup", Destination: "aws:subnet_private:my_app:my_app_private1"},
+					{Source: "aws:internet_gateway:my_app_igw", Destination: "aws:vpc:my_app"},
+					{Source: "aws:nat_gateway:my_app_0", Destination: "aws:elastic_ip:my_app_0"},
+					{Source: "aws:nat_gateway:my_app_0", Destination: "aws:subnet_public:my_app:my_app_public0"},
+					{Source: "aws:nat_gateway:my_app_1", Destination: "aws:elastic_ip:my_app_1"},
+					{Source: "aws:nat_gateway:my_app_1", Destination: "aws:subnet_public:my_app:my_app_public1"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:nat_gateway:my_app_0"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:subnet_private:my_app:my_app_private0"},
+					{Source: "aws:route_table:my_app_private0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:nat_gateway:my_app_1"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:subnet_private:my_app:my_app_private1"},
+					{Source: "aws:route_table:my_app_private1", Destination: "aws:vpc:my_app"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:internet_gateway:my_app_igw"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:subnet_public:my_app:my_app_public0"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:subnet_public:my_app:my_app_public1"},
+					{Source: "aws:route_table:my_app_public", Destination: "aws:vpc:my_app"},
+					{Source: "aws:security_group:my_app:my-app", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_private:my_app:my_app_private0", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_private:my_app:my_app_private0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_private:my_app:my_app_private1", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_private:my_app:my_app_private1", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_public:my_app:my_app_public0", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_public:my_app:my_app_public0", Destination: "aws:vpc:my_app"},
+					{Source: "aws:subnet_public:my_app:my_app_public1", Destination: "aws:availability_zones:AvailabilityZones"},
+					{Source: "aws:subnet_public:my_app:my_app_public1", Destination: "aws:vpc:my_app"},
+				}},
+			Check: func(assert *assert.Assertions, table *ElasticacheCluster) {
+				assert.Equal(table.Name, "my-app-test")
+				assert.ElementsMatch(table.ConstructsRef, []core.AnnotationKey{cluster.AnnotationKey, existingKey})
+			},
+		},
 	}
-	for _, sg := range ec.SecurityGroups {
-		assert.NotNil(dag.GetDependency(ec, sg))
-	}
-	if assert.Len(ec.KlothoConstructRef(), 1) {
-		assert.Equal(source.Provenance(), ec.KlothoConstructRef()[0])
+	for _, tt := range cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			tt.Params = ElasticacheClusterCreateParams{
+				AppName: "my-app",
+				Refs:    []core.AnnotationKey{cluster.AnnotationKey},
+				Name:    "test",
+			}
+
+			tt.Run(t)
+		})
 	}
 }


### PR DESCRIPTION
Resolves #610 

This PR expands the `RedisNode` construct and expands `LambdaFunction -> ElasticacheCluster` edges.

Validated with the `py-redis` sample app:

![image](https://github.com/klothoplatform/klotho/assets/110404901/db79c5ce-38e0-48cf-88a8-00f722ab1d55)
![image](https://github.com/klothoplatform/klotho/assets/110404901/2c7fa7ba-6439-4c2a-9778-6647859e2eca)
