### PR TITLE
Standardize Resource Graph APIs

### DIFF
--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -121,6 +121,19 @@ func (rg *ResourceGraph) TopologicalSort() ([]Resource, error) {
 	return resources, nil
 }
 
+func (rg *ResourceGraph) ReverseTopologicalSort() ([]Resource, error) {
+	ids, err := rg.underlying.VertexIdsInTopologicalOrder()
+	if err != nil {
+		return nil, err
+	}
+	total := len(ids)
+	resources := make([]Resource, total)
+	for i := total; i > 0; i-- {
+		resources[total-i] = rg.underlying.GetVertex(ids[i-1])
+	}
+	return resources, nil
+}
+
 // AddDependenciesReflect uses reflection to inspect the fields of the resource given
 // and add dependencies for each dependency nested within the object.
 // Structs that are a type of a valid dependency, will not be recursed further as they will already have a

--- a/pkg/core/resource_graph_test.go
+++ b/pkg/core/resource_graph_test.go
@@ -129,9 +129,9 @@ func TestResourceGraph_AddDependenciesReflect(t *testing.T) {
 		"nested_arr1", "nested_arr2",
 		"nested_map1", "nested_map2",
 	} {
-		assert.NotNil(dag.GetDependencyByVertexIds(tr.Id().String(), (&testResource{Name: target}).Id().String()), "source -> %s", target)
+		assert.NotNil(dag.GetDependency(tr.Id(), (&testResource{Name: target}).Id()), "source -> %s", target)
 	}
-	assert.Nil(dag.GetDependencyByVertexIds(tr.Id().String(), (&testResource{Name: "nested_single"}).Id().String()))
+	assert.Nil(dag.GetDependency(tr.Id(), (&testResource{Name: "nested_single"}).Id()))
 }
 
 func TestResourceGraph_CreateDependencies(t *testing.T) {
@@ -254,6 +254,6 @@ func TestResourceGraph_CreateDependencies(t *testing.T) {
 		"nested_arr1", "nested_arr2",
 		"nested_map1", "nested_map2",
 	} {
-		assert.Nil(dag.GetDependencyByVertexIds(tr.Id().String(), (&testResource{Name: target}).Id().String()), "source -> %s", target)
+		assert.Nil(dag.GetDependency(tr.Id(), (&testResource{Name: target}).Id()), "source -> %s", target)
 	}
 }

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -104,12 +104,11 @@ func standardTemplatesProvider() *templatesProvider {
 
 func (tc TemplatesCompiler) RenderBody(out io.Writer) error {
 	errs := multierr.Error{}
-	res, err := tc.resourceGraph.TopologicalSort()
+	res, err := tc.resourceGraph.ReverseTopologicalSort()
 	if err != nil {
 		return err
 	}
-	for i := len(res) - 1; i >= 0; i-- {
-		resource := res[i]
+	for i, resource := range res {
 		switch resource.(type) {
 		case *resources.AccountId, *resources.Region:
 			continue // skip resources that we know are rendered outside of the body
@@ -120,7 +119,7 @@ func (tc TemplatesCompiler) RenderBody(out io.Writer) error {
 		}
 		err := tc.renderResource(out, resource)
 		errs.Append(err)
-		if i > 0 {
+		if i < len(res)-1 {
 			_, err = out.Write([]byte("\n\n"))
 			if err != nil {
 				return err

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -104,13 +104,12 @@ func standardTemplatesProvider() *templatesProvider {
 
 func (tc TemplatesCompiler) RenderBody(out io.Writer) error {
 	errs := multierr.Error{}
-	vertexIds, err := tc.resourceGraph.VertexIdsInTopologicalOrder()
+	res, err := tc.resourceGraph.TopologicalSort()
 	if err != nil {
 		return err
 	}
-	for i := len(vertexIds) - 1; i >= 0; i-- {
-		id := vertexIds[i]
-		resource := tc.resourceGraph.GetResourceByVertexId(id)
+	for i := len(res) - 1; i >= 0; i-- {
+		resource := res[i]
 		switch resource.(type) {
 		case *resources.AccountId, *resources.Region:
 			continue // skip resources that we know are rendered outside of the body

--- a/pkg/knowledge_base/edge_kb.go
+++ b/pkg/knowledge_base/edge_kb.go
@@ -230,7 +230,7 @@ func (kb EdgeKB) ExpandEdges(dag *core.ResourceGraph, appName string) (err error
 			// If the valid path is not the original direct path, we want to remove the initial direct dependency so we can fill in the new edges with intermediate nodes
 			if len(validPath) > 1 {
 				zap.S().Debugf("Removing dependency from %s -> %s", dep.Source.Id(), dep.Destination.Id())
-				err := dag.RemoveDependency(dep.Source.Id().String(), dep.Destination.Id().String())
+				err := dag.RemoveDependency(dep.Source.Id(), dep.Destination.Id())
 				if err != nil {
 					merr.Append(err)
 					continue

--- a/pkg/provider/aws/plugin_test.go
+++ b/pkg/provider/aws/plugin_test.go
@@ -184,7 +184,7 @@ func Test_CopyConstructEdgesToDag(t *testing.T) {
 				return
 			}
 			for _, dep := range tt.want {
-				edge := dag.GetDependency(dep.Source, dep.Destination)
+				edge := dag.GetDependency(dep.Source.Id(), dep.Destination.Id())
 				assert.Equal(edge, dep)
 			}
 		})

--- a/pkg/provider/aws/resources/api_gateway.go
+++ b/pkg/provider/aws/resources/api_gateway.go
@@ -102,7 +102,7 @@ func (api *RestApi) Create(dag *core.ResourceGraph, params RestApiCreateParams) 
 	api.Name = name
 	api.ConstructsRef = params.Refs
 
-	existingApi := dag.GetResourceByVertexId(api.Id().String())
+	existingApi := dag.GetResource(api.Id())
 	if existingApi != nil {
 		graphApi := existingApi.(*RestApi)
 		graphApi.ConstructsRef = core.DedupeAnnotationKeys(append(graphApi.ConstructsRef, params.Refs...))
@@ -158,7 +158,7 @@ func (resource *ApiResource) Create(dag *core.ResourceGraph, params ApiResourceC
 	resource.Name = name
 	resource.ConstructsRef = params.Refs
 
-	existingResource := dag.GetResourceByVertexId(resource.Id().String())
+	existingResource := dag.GetResource(resource.Id())
 	if existingResource != nil {
 		graphResource := existingResource.(*ApiResource)
 		graphResource.ConstructsRef = append(graphResource.ConstructsRef, params.Refs...)
@@ -204,7 +204,7 @@ func (integration *ApiIntegration) Create(dag *core.ResourceGraph, params ApiInt
 	integration.Name = name
 	integration.ConstructsRef = params.Refs
 
-	existingResource := dag.GetResourceByVertexId(integration.Id().String())
+	existingResource := dag.GetResource(integration.Id())
 	if existingResource != nil {
 		graphResource := existingResource.(*ApiIntegration)
 		graphResource.ConstructsRef = append(graphResource.ConstructsRef, params.Refs...)
@@ -301,7 +301,7 @@ func (deployment *ApiDeployment) Create(dag *core.ResourceGraph, params ApiDeplo
 	deployment.Name = name
 	deployment.ConstructsRef = params.Refs
 
-	existingDeployment := dag.GetResourceByVertexId(deployment.Id().String())
+	existingDeployment := dag.GetResource(deployment.Id())
 	if existingDeployment != nil {
 		graphDeployment := existingDeployment.(*ApiDeployment)
 		graphDeployment.ConstructsRef = append(graphDeployment.ConstructsRef, params.Refs...)
@@ -329,7 +329,7 @@ func (stage *ApiStage) Create(dag *core.ResourceGraph, params ApiStageCreatePara
 	stage.Name = name
 	stage.ConstructsRef = params.Refs
 
-	existingResource := dag.GetResourceByVertexId(stage.Id().String())
+	existingResource := dag.GetResource(stage.Id())
 	if existingResource != nil {
 		graphResource := existingResource.(*ApiStage)
 		graphResource.ConstructsRef = append(graphResource.ConstructsRef, params.Refs...)

--- a/pkg/provider/aws/resources/cloudwatch_test.go
+++ b/pkg/provider/aws/resources/cloudwatch_test.go
@@ -58,7 +58,7 @@ func Test_CloudwatchLogGroupCreate(t *testing.T) {
 
 			tt.want.Assert(t, dag)
 
-			graphLogGroup := dag.GetResourceByVertexId(logGroup.Id().String())
+			graphLogGroup := dag.GetResource(logGroup.Id())
 			logGroup = graphLogGroup.(*LogGroup)
 
 			assert.Equal(logGroup.Name, "my-app-log-group")

--- a/pkg/provider/aws/resources/iam.go
+++ b/pkg/provider/aws/resources/iam.go
@@ -192,7 +192,7 @@ type OidcCreateParams struct {
 func (oidc *OpenIdConnectProvider) Create(dag *core.ResourceGraph, params OidcCreateParams) error {
 	oidc.Name = fmt.Sprintf("%s-%s", params.AppName, params.ClusterName)
 
-	existingOidc := dag.GetResourceByVertexId(oidc.Id().String())
+	existingOidc := dag.GetResource(oidc.Id())
 	if existingOidc != nil {
 		graphOidc := existingOidc.(*OpenIdConnectProvider)
 		graphOidc.ConstructsRef = append(graphOidc.ConstructsRef, params.Refs...)

--- a/pkg/provider/aws/resources/lambda.go
+++ b/pkg/provider/aws/resources/lambda.go
@@ -51,7 +51,7 @@ func (lambda *LambdaFunction) Create(dag *core.ResourceGraph, params LambdaCreat
 	lambda.Name = name
 	lambda.ConstructsRef = params.Refs
 
-	existingLambda := dag.GetResourceByVertexId(lambda.Id().String())
+	existingLambda := dag.GetResource(lambda.Id())
 	if existingLambda != nil {
 		return fmt.Errorf("lambda with name %s already exists", name)
 	}

--- a/pkg/provider/aws/resources/securitygroup_test.go
+++ b/pkg/provider/aws/resources/securitygroup_test.go
@@ -62,7 +62,7 @@ func Test_SecurityGroupCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphSG := dag.GetResourceByVertexId(sg.Id().String())
+			graphSG := dag.GetResource(sg.Id())
 			sg = graphSG.(*SecurityGroup)
 
 			assert.Equal(sg.Name, "my-app")

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -128,7 +128,7 @@ type EipCreateParams struct {
 func (eip *ElasticIp) Create(dag *core.ResourceGraph, params EipCreateParams) error {
 	eip.Name = elasticIpSanitizer.Apply(fmt.Sprintf("%s-%s", params.AppName, params.IpName))
 	eip.ConstructsRef = params.Refs
-	existingEip := dag.GetResourceByVertexId(eip.Id().String())
+	existingEip := dag.GetResource(eip.Id())
 	if existingEip != nil {
 		graphEip := existingEip.(*ElasticIp)
 		graphEip.ConstructsRef = append(graphEip.ConstructsRef, params.Refs...)
@@ -148,7 +148,7 @@ func (igw *InternetGateway) Create(dag *core.ResourceGraph, params IgwCreatePara
 	igw.Name = igwSanitizer.Apply(fmt.Sprintf("%s-igw", params.AppName))
 	igw.ConstructsRef = params.Refs
 
-	existingIgw := dag.GetResourceByVertexId(igw.Id().String())
+	existingIgw := dag.GetResource(igw.Id())
 
 	if existingIgw != nil {
 		graphIgw := existingIgw.(*InternetGateway)
@@ -175,7 +175,7 @@ func (nat *NatGateway) Create(dag *core.ResourceGraph, params NatCreateParams) e
 	nat.Name = natGatewaySanitizer.Apply(fmt.Sprintf("%s-%s", params.AppName, params.AZ))
 	nat.ConstructsRef = params.Refs
 
-	existingNat := dag.GetResourceByVertexId(nat.Id().String())
+	existingNat := dag.GetResource(nat.Id())
 	if existingNat != nil {
 		graphNat := existingNat.(*NatGateway)
 		graphNat.ConstructsRef = append(graphNat.ConstructsRef, params.Refs...)
@@ -261,7 +261,7 @@ func (subnet *Subnet) Create(dag *core.ResourceGraph, params SubnetCreateParams)
 	dag.AddDependency(rt, subnet)
 
 	// We must check to see if there is an existent subnet after calling create dependencies because the id of the subnet has a namespace based on the vpc
-	existingSubnet := dag.GetResourceByVertexId(subnet.Id().String())
+	existingSubnet := dag.GetResource(subnet.Id())
 	if existingSubnet != nil {
 		graphSubnet := existingSubnet.(*Subnet)
 		graphSubnet.ConstructsRef = core.DedupeAnnotationKeys(append(graphSubnet.ConstructsRef, params.Refs...))
@@ -314,7 +314,7 @@ func (rt *RouteTable) Create(dag *core.ResourceGraph, params RouteTableCreatePar
 	dag.AddDependenciesReflect(rt)
 
 	// We must check to see if there is an existent route table after calling create dependencies because the id of the subnet can contain a namespace based on the vpc
-	existingRt := dag.GetResourceByVertexId(rt.Id().String())
+	existingRt := dag.GetResource(rt.Id())
 	if existingRt != nil {
 		graphRt := existingRt.(*RouteTable)
 		graphRt.ConstructsRef = core.DedupeAnnotationKeys(append(graphRt.ConstructsRef, params.Refs...))

--- a/pkg/provider/aws/resources/vpc_test.go
+++ b/pkg/provider/aws/resources/vpc_test.go
@@ -58,7 +58,7 @@ func Test_VpcCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphVpc := dag.GetResourceByVertexId(vpc.Id().String())
+			graphVpc := dag.GetResource(vpc.Id())
 			vpc = graphVpc.(*Vpc)
 			assert.Equal(vpc.Name, "my_app")
 			if tt.vpc == nil {
@@ -118,7 +118,7 @@ func Test_ElasticIpCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphEip := dag.GetResourceByVertexId(eip.Id().String())
+			graphEip := dag.GetResource(eip.Id())
 			eip = graphEip.(*ElasticIp)
 			assert.Equal(eip.Name, "my_app_ip0")
 			if tt.eip == nil {
@@ -180,7 +180,7 @@ func Test_InternetGatewayCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphIgw := dag.GetResourceByVertexId(igw.Id().String())
+			graphIgw := dag.GetResource(igw.Id())
 			igw = graphIgw.(*InternetGateway)
 			assert.Equal(igw.Name, "my_app_igw")
 			if tt.igw == nil {
@@ -255,7 +255,7 @@ func Test_NatGatewayCreate(t *testing.T) {
 				return
 			}
 			tt.want.Assert(t, dag)
-			graphNat := dag.GetResourceByVertexId(nat.Id().String())
+			graphNat := dag.GetResource(nat.Id())
 			nat = graphNat.(*NatGateway)
 
 			assert.Equal(nat.Name, "my_app_0")
@@ -437,7 +437,7 @@ func Test_SubnetCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphSubnet := dag.GetResourceByVertexId(subnet.Id().String())
+			graphSubnet := dag.GetResource(subnet.Id())
 			subnet = graphSubnet.(*Subnet)
 
 			assert.Equal(subnet.Name, fmt.Sprintf("my_app_%s%s", tt.subnet.Type, tt.subnet.AvailabilityZone.Property))
@@ -506,7 +506,7 @@ func Test_RouteTableCreate(t *testing.T) {
 			}
 			tt.want.Assert(t, dag)
 
-			graphRT := dag.GetResourceByVertexId(rt.Id().String())
+			graphRT := dag.GetResource(rt.Id())
 			rt = graphRT.(*RouteTable)
 
 			assert.Equal(rt.Name, "my_app_private0")

--- a/pkg/visualizer/file.go
+++ b/pkg/visualizer/file.go
@@ -64,16 +64,15 @@ func (f *File) WriteTo(w io.Writer) (n int64, err error) {
 	wh.Writef("  provider: %s\n", f.Provider)
 	wh.Write("  resources:\n")
 
-	resourceIds, err := f.DAG.TopologicalSort()
+	resources, err := f.DAG.TopologicalSort()
 	if err != nil {
 		return
 	}
-	for i := len(resourceIds)/2 - 1; i >= 0; i-- {
-		opp := len(resourceIds) - 1 - i
-		resourceIds[i], resourceIds[opp] = resourceIds[opp], resourceIds[i]
+	for i := len(resources)/2 - 1; i >= 0; i-- {
+		opp := len(resources) - 1 - i
+		resources[i], resources[opp] = resources[opp], resources[i]
 	}
-	for _, resourceId := range resourceIds {
-		resource := f.DAG.GetResourceByVertexId(resourceId)
+	for _, resource := range resources {
 		if resource.Id().Provider == core.InternalProvider {
 			// Don't show internal resources such as imported in the topology
 			// TODO maybe make some way of indicating imported resources in the visualizer
@@ -83,7 +82,7 @@ func (f *File) WriteTo(w io.Writer) (n int64, err error) {
 		if key == "" {
 			continue
 		}
-		wh.Writef(indent+"%s: # %s\n", key, resourceId)
+		wh.Writef(indent+"%s: # %s\n", key, resource.Id())
 		properties := propFetcher.apply(resource, f.DAG)
 		if len(properties) > 0 {
 			writeYaml(properties, 2, wh)

--- a/pkg/visualizer/file.go
+++ b/pkg/visualizer/file.go
@@ -64,13 +64,9 @@ func (f *File) WriteTo(w io.Writer) (n int64, err error) {
 	wh.Writef("  provider: %s\n", f.Provider)
 	wh.Write("  resources:\n")
 
-	resources, err := f.DAG.TopologicalSort()
+	resources, err := f.DAG.ReverseTopologicalSort()
 	if err != nil {
 		return
-	}
-	for i := len(resources)/2 - 1; i >= 0; i-- {
-		opp := len(resources) - 1 - i
-		resources[i], resources[opp] = resources[opp], resources[i]
 	}
 	for _, resource := range resources {
 		if resource.Id().Provider == core.InternalProvider {


### PR DESCRIPTION
* Remove vertex IDs from resource graph API
* Add API to resource graph for reverse topological ordering

### Standard checks

- **Unit tests**: None new required
- **Docs**: n/a - internal
- **Backwards compatibility**: purely internal
