### PR TITLE
add post-compile hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/lithammer/dedent v1.1.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pborman/ansi v1.0.0
 	github.com/pelletier/go-toml/v2 v2.0.8-0.20230509155657-d34104d49374
 	github.com/pkg/errors v0.9.1
@@ -42,7 +43,6 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect
@@ -87,7 +87,7 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/pkg/cli/cli_options.go
+++ b/pkg/cli/cli_options.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/klothoplatform/klotho/pkg/cli_config"
+	"github.com/klothoplatform/klotho/pkg/compiler"
 	"github.com/klothoplatform/klotho/pkg/yaml_util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -17,8 +18,9 @@ const configFileName = "options.yaml"
 
 type (
 	Options struct {
-		Update UpdateOptions `yaml:",omitempty"`
-		UI     UIOptions     `yaml:",omitempty"`
+		Update UpdateOptions          `yaml:",omitempty"`
+		UI     UIOptions              `yaml:",omitempty"`
+		Output compiler.OutputOptions `yaml:",omitempty"`
 	}
 
 	UpdateOptions struct {

--- a/pkg/cli/klothomain.go
+++ b/pkg/cli/klothomain.go
@@ -417,6 +417,7 @@ func (km KlothoMain) run(cmd *cobra.Command, args []string) (err error) {
 		Constructs:       constructs,
 		Configuration:    &appCfg,
 		Resources:        core.NewResourceGraph(),
+		OutputOptions:    options.Output,
 	}
 
 	compiler := compiler.Compiler{

--- a/pkg/collectionutil/maps.go
+++ b/pkg/collectionutil/maps.go
@@ -18,3 +18,21 @@ func GetOneEntry[K comparable, V any](m map[K]V) (K, V) {
 	var v V
 	return k, v
 }
+
+type ExtendingMap[K comparable, V any] map[K]V
+
+func Extend[K comparable, V any](m map[K]V) ExtendingMap[K, V] {
+	return ExtendingMap[K, V](m)
+}
+
+func (source ExtendingMap[K, V]) Into(target map[K]V) {
+	for k, v := range source {
+		target[k] = v
+	}
+}
+
+func CopyMap[K comparable, V any](m map[K]V) map[K]V {
+	cp := make(map[K]V, len(m))
+	Extend(m).Into(cp)
+	return cp
+}

--- a/pkg/compiler/compilation_document.go
+++ b/pkg/compiler/compilation_document.go
@@ -78,10 +78,7 @@ func (doc *CompilationDocument) OutputTo(dest string) error {
 				if hook, found := postWriteHooks[fileExt]; found {
 					hookErr := postCompileHook(dest, f, hook)
 					if hookErr != nil {
-						zap.S().With(zap.Error(hookErr), logging.FileField(f)).Warnf(
-							`failed to apply post-output hook to %s: %s`,
-							f.Path(),
-							hookErr.Error())
+						zap.S().Warnf(`failed to apply post-output hook to %s/%s: %s`, dest, f.Path(), hookErr.Error())
 					}
 				}
 			}


### PR DESCRIPTION
These are on a file extension basis. They let you do something like:

    klotho --set-option output.post-write-hooks.ts='npx prettier -w {}'

## Example

### Initially

~Out of the box, we don't~ Previously, we wouldn't do any formatting.

```
$ cat ~/.klotho/options.yaml
ui:
    disable-logo: true
```

```
$ klotho -c klotho.yaml
Adding resource internal:InternalKlothoPayloads
Adding resource execution_unit:main
searching for http imports in main.go
main.go: Found 2 route(s) on app 'r'
main.go: Found 3 route(s) on mounted router 'routes.ExtraRoutes'
Adding resource expose:app
```

The output is pretty ugly:

```typescript
// $ cat compiled/index.ts| tail -n 15
cachedMethods: [`HEAD`,`GET`],
targetOriginId: `app`,
forwardedValues: {queryString: true,
cookies: {forward: `none`,
},
},
defaultTtl: 3600,
maxTtl: 86400,
viewerProtocolPolicy: `allow-all`,
},
        restrictions: {geoRestriction: {restrictionType: `none`,
},
},
        defaultRootObject: ``,
    })
```

### Add a formatter

Now, we do apply formatting. Optionally, you can use `--set-option` to change it:

```
$ klotho --set-option output.post-write-hooks.ts='npx prettier -w {}'
$ cat ~/.klotho/options.yaml
ui:
    disable-logo: true
output:
    post-write-hooks:
        ts: npx prettier -w {}
```

Now, when we compile, we get a notification about the hook:

```
klotho -c klotho.yaml
Adding resource internal:InternalKlothoPayloads
Adding resource execution_unit:main
searching for http imports in main.go
main.go: Found 2 route(s) on app 'r'
main.go: Found 3 route(s) on mounted router 'routes.ExtraRoutes'
Adding resource expose:app
index.ts: running post-output hook: npx prettier -w index.ts        # <--- HERE
```

And the output is a lot nicer:

```typescript
// $ cat compiled/index.ts| tail -n 15
        `OPTIONS`,
        `PATCH`,
        `POST`,
        `PUT`,
      ],
      cachedMethods: [`HEAD`, `GET`],
      targetOriginId: `app`,
      forwardedValues: { queryString: true, cookies: { forward: `none` } },
      defaultTtl: 3600,
      maxTtl: 86400,
      viewerProtocolPolicy: `allow-all`,
    },
    restrictions: { geoRestriction: { restrictionType: `none` } },
    defaultRootObject: ``,
  });
```

### Negative path case

```
$ klotho --set-option output.post-write-hooks.ts='npx yuvalisblah -w {}'

$ klotho -c klotho.yaml
Adding resource internal:InternalKlothoPayloads
Adding resource execution_unit:main
searching for http imports in main.go
main.go: Found 2 route(s) on app 'r'
main.go: Found 3 route(s) on mounted router 'routes.ExtraRoutes'
Adding resource expose:app
index.ts: running post-output hook: npx yuvalisblah -w index.ts
index.ts: failed to apply post-output hook to index.ts: exit status 1

$ echo $?
0
```

The failure comes out as a warning, and does not cause the compilation to fail.

## Standard checks

- **Unit tests**: not added
- **Docs**: not documented
- **Backwards compatibility**: no issues
