### PR TITLE
Improves s3 bucket sanitization

### DIFF
--- a/pkg/infra/iac2/templates_compiler_test.go
+++ b/pkg/infra/iac2/templates_compiler_test.go
@@ -260,7 +260,7 @@ func Test_handleIaCValue(t *testing.T) {
 			resourceVarNamesById: map[core.ResourceId]string{
 				{Provider: "aws", Type: "s3_bucket", Name: "test-app-"}: "testBucket",
 			},
-			want: "testBucket.bucket",
+			want: "s3BucketTestApp.bucket",
 		},
 		{
 			name: "string value, nil resource",

--- a/pkg/sanitization/aws/s3.go
+++ b/pkg/sanitization/aws/s3.go
@@ -6,19 +6,54 @@ import (
 	"github.com/klothoplatform/klotho/pkg/sanitization"
 )
 
-// EnvVarKeySanitizer returns a sanitized environment key when applied.
 var S3BucketSanitizer = sanitization.NewSanitizer(
 	[]sanitization.Rule{
-		// replace "-" or whitespace with "_"
+		// must not contain non-alphanumeric characters other than "-" or "."
+		// uppercase characters will be converted to lowercase
 		{
-			Pattern:     regexp.MustCompile(`[^a-z0-9.-]`),
+			Pattern:     regexp.MustCompile(`[^a-zA-Z\d.-]`),
 			Replacement: "-",
+			Lowercase:   true,
+		},
+		{
+			// must not start with "xn--"
+			Pattern:     regexp.MustCompile(`^(xn--)+`),
+			Replacement: "",
+		},
+		{
+			// must start and end with a letter or number
+			Pattern:     regexp.MustCompile(`^[^a-z\d]+|[^a-z\d]+$`),
+			Replacement: "",
+		},
+		{
+			// must not contain repeated periods
+			Pattern:     regexp.MustCompile(`\.\.+`),
+			Replacement: ".",
+		},
+		{
+			// must not be formatted as an IP address (for example, 192.168.5.4)
+			Pattern:     regexp.MustCompile(`^\d{1,3}(\.)\d{1,3}(\.)\d{1,3}(\.)\d{1,3}$`),
+			Replacement: "-",
+		},
+		{
+			// must not contain hyphens adjacent to periods
+			Pattern:     regexp.MustCompile(`-+\.-+`),
+			Replacement: ".",
+		},
+		{
+			// must not contain suffix "-s3alias"
+			Pattern:     regexp.MustCompile(`(-s3alias)+$`),
+			Replacement: "",
+		},
+		{
+			// must not end with the suffix "--ol-s3"
+			Pattern:     regexp.MustCompile(`(--ol-s3)+$`),
+			Replacement: "",
 		},
 	},
 	52, // We know that we will prepend account id onto the names here, so we want to shorten this further until we do that in the iac level
 )
 
-// EnvVarKeySanitizer returns a sanitized environment key when applied.
 var S3ObjectSanitizer = sanitization.NewSanitizer(
 	[]sanitization.Rule{
 		{


### PR DESCRIPTION
Resolves #641

This PR improves sanitization for s3 bucket names and includes the following changes:
- Fixed the original issue in #641 by allowing uppercase letters and then converting the output to lowercase
- Added additional s3 bucket name validation rules
