### PR TITLE
all factories use same version of node dependencies

### DIFF
--- a/pkg/infra/iac2/templates/account_id/package.json
+++ b/pkg/infra/iac2/templates/account_id/package.json
@@ -2,6 +2,6 @@
     "name": "account_id",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/api_deployment/package.json
+++ b/pkg/infra/iac2/templates/api_deployment/package.json
@@ -2,6 +2,6 @@
     "name": "api_deployment",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/api_integration/package.json
+++ b/pkg/infra/iac2/templates/api_integration/package.json
@@ -2,6 +2,6 @@
     "name": "api_integration",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/availability_zones/package.json
+++ b/pkg/infra/iac2/templates/availability_zones/package.json
@@ -2,6 +2,6 @@
     "name": "availability_zones",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/cloudfront_distribution/package.json
+++ b/pkg/infra/iac2/templates/cloudfront_distribution/package.json
@@ -2,6 +2,6 @@
     "name": "cloudfront_distribution",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/dynamodb_table/package.json
+++ b/pkg/infra/iac2/templates/dynamodb_table/package.json
@@ -2,6 +2,6 @@
     "name": "dynamodb_table",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/ecr_image/package.json
+++ b/pkg/infra/iac2/templates/ecr_image/package.json
@@ -2,7 +2,7 @@
     "name": "ecr_image",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/docker": "^4.1.2",
         "@pulumi/command": "^0.7.2"
     }

--- a/pkg/infra/iac2/templates/eks_addon/package.json
+++ b/pkg/infra/iac2/templates/eks_addon/package.json
@@ -2,6 +2,6 @@
     "name": "eks_addon",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/eks_fargate_profile/package.json
+++ b/pkg/infra/iac2/templates/eks_fargate_profile/package.json
@@ -2,6 +2,6 @@
     "name": "eks_fargate_profile",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/factories_test.go
+++ b/pkg/infra/iac2/templates/factories_test.go
@@ -14,22 +14,22 @@ import (
 var packageJsonsFs embed.FS
 
 func Test_SameVersionOfDeps(t *testing.T) {
+	topLevelAssert := assert.New(t)
 	// Find all of the versions across all jsons
 	versionsByName := make(map[string]map[string]struct{})
-	fs.WalkDir(packageJsonsFs, ".", func(path string, d fs.DirEntry, err error) error {
-		assert := assert.New(t)
-		if !assert.NoError(err) {
+	err := fs.WalkDir(packageJsonsFs, ".", func(path string, d fs.DirEntry, err error) error {
+		if !topLevelAssert.NoError(err) {
 			return err
 		}
 		if d.IsDir() {
 			return nil
 		}
 		contents, err := fs.ReadFile(packageJsonsFs, path)
-		if !assert.NoError(err) {
+		if !topLevelAssert.NoError(err) {
 			return err
 		}
 		var jsonObj packageJson
-		if err = json.Unmarshal(contents, &jsonObj); !assert.NoError(err) {
+		if err = json.Unmarshal(contents, &jsonObj); !topLevelAssert.NoError(err) {
 			return err
 		}
 		for name, version := range jsonObj.Dependencies {
@@ -42,7 +42,10 @@ func Test_SameVersionOfDeps(t *testing.T) {
 		}
 		return nil
 	})
-	assert.New(t).NotEmpty(versionsByName)
+	if !topLevelAssert.NoError(err) {
+		return
+	}
+	topLevelAssert.NotEmpty(versionsByName)
 
 	for name, versions := range versionsByName {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/infra/iac2/templates/factories_test.go
+++ b/pkg/infra/iac2/templates/factories_test.go
@@ -1,0 +1,58 @@
+package templates
+
+import (
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/collectionutil"
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed **/package.json
+var packageJsonsFs embed.FS
+
+func Test_SameVersionOfDeps(t *testing.T) {
+	// Find all of the versions across all jsons
+	versionsByName := make(map[string]map[string]struct{})
+	fs.WalkDir(packageJsonsFs, ".", func(path string, d fs.DirEntry, err error) error {
+		assert := assert.New(t)
+		if !assert.NoError(err) {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		contents, err := fs.ReadFile(packageJsonsFs, path)
+		if !assert.NoError(err) {
+			return err
+		}
+		var jsonObj packageJson
+		if err = json.Unmarshal(contents, &jsonObj); !assert.NoError(err) {
+			return err
+		}
+		for name, version := range jsonObj.Dependencies {
+			existing := versionsByName[name]
+			if existing == nil {
+				existing = make(map[string]struct{})
+				versionsByName[name] = existing
+			}
+			existing[version] = struct{}{}
+		}
+		return nil
+	})
+	assert.New(t).NotEmpty(versionsByName)
+
+	for name, versions := range versionsByName {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(1, len(versions), `found multiple versions: %v`, collectionutil.Keys(versions))
+		})
+
+	}
+}
+
+type packageJson struct {
+	Dependencies map[string]string `json:"dependencies"`
+}

--- a/pkg/infra/iac2/templates/helm_chart/package.json
+++ b/pkg/infra/iac2/templates/helm_chart/package.json
@@ -2,6 +2,6 @@
     "name": "helm_chart",
     "dependencies": {
         "@pulumi/kubernetes": "^3.21.4",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/iam_role/package.json
+++ b/pkg/infra/iac2/templates/iam_role/package.json
@@ -1,7 +1,7 @@
 {
     "name": "iam_role",
     "dependencies": {
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/aws": "^5.37.0"
     }
 }

--- a/pkg/infra/iac2/templates/kms_key/package.json
+++ b/pkg/infra/iac2/templates/kms_key/package.json
@@ -2,6 +2,6 @@
     "name": "kms_key",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "3.69.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/kms_replica_key/package.json
+++ b/pkg/infra/iac2/templates/kms_replica_key/package.json
@@ -2,6 +2,6 @@
     "name": "kms_key_replica",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "3.69.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/kubeconfig/package.json
+++ b/pkg/infra/iac2/templates/kubeconfig/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kubeconfig",
     "dependencies": {
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/kubernetes_provider/package.json
+++ b/pkg/infra/iac2/templates/kubernetes_provider/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kubernetes_provider",
     "dependencies": {
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/kubernetes": "^3.21.4"
     }
 }

--- a/pkg/infra/iac2/templates/kustomize_directory/package.json
+++ b/pkg/infra/iac2/templates/kustomize_directory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kustomize_directory",
     "dependencies": {
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/kubernetes": "^3.21.4"
     }
 }

--- a/pkg/infra/iac2/templates/lambda_function/package.json
+++ b/pkg/infra/iac2/templates/lambda_function/package.json
@@ -2,7 +2,7 @@
     "name": "lambda_function",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/docker": "^4.1.2"
     }
 }

--- a/pkg/infra/iac2/templates/lambda_permission/package.json
+++ b/pkg/infra/iac2/templates/lambda_permission/package.json
@@ -2,6 +2,6 @@
     "name": "lambda_permission",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/manifest/package.json
+++ b/pkg/infra/iac2/templates/manifest/package.json
@@ -2,6 +2,6 @@
     "name": "manifest",
     "dependencies": {
         "@pulumi/kubernetes": "^3.21.4",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/open_id_connect_provider/package.json
+++ b/pkg/infra/iac2/templates/open_id_connect_provider/package.json
@@ -2,7 +2,7 @@
     "name": "open_id_connect_provider",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/eks": "^0.42.0"
     }
 }

--- a/pkg/infra/iac2/templates/rds_proxy/package.json
+++ b/pkg/infra/iac2/templates/rds_proxy/package.json
@@ -2,6 +2,6 @@
     "name": "rds_proxy",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/region/package.json
+++ b/pkg/infra/iac2/templates/region/package.json
@@ -2,6 +2,6 @@
     "name": "region",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/route53_record/package.json
+++ b/pkg/infra/iac2/templates/route53_record/package.json
@@ -2,6 +2,6 @@
     "name": "route53_record",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "3.68.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/s3_object/package.json
+++ b/pkg/infra/iac2/templates/s3_object/package.json
@@ -3,6 +3,6 @@
     "dependencies": {
         "mime": "^2.0.0",
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/security_group_rule/package.json
+++ b/pkg/infra/iac2/templates/security_group_rule/package.json
@@ -1,7 +1,7 @@
 {
     "name": "security_group_rule",
     "dependencies": {
-        "@pulumi/pulumi": "^3.65.0",
+        "@pulumi/pulumi": "^3.69.0",
         "@pulumi/aws": "^5.37.0"
     }
 }

--- a/pkg/infra/iac2/templates/subnet/package.json
+++ b/pkg/infra/iac2/templates/subnet/package.json
@@ -2,6 +2,6 @@
     "name": "subnet",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }

--- a/pkg/infra/iac2/templates/vpc_endpoint/package.json
+++ b/pkg/infra/iac2/templates/vpc_endpoint/package.json
@@ -2,6 +2,6 @@
     "name": "vpc_endpoint",
     "dependencies": {
         "@pulumi/aws": "^5.37.0",
-        "@pulumi/pulumi": "^3.65.0"
+        "@pulumi/pulumi": "^3.69.0"
     }
 }


### PR DESCRIPTION
* update all `@pulumi/pulumi` to `^3.69.0`
* add a unit test to prevent drift in the future

This resolves #461 

### Standard checks

- **Unit tests**: added
- **Docs**: none needed
- **Backwards compatibility**: I don't think there'll be any issues, but I haven't checked
