### PR TITLE
be able to load and export resource dag

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -146,6 +146,11 @@ func (c *Compiler) LoadConstructGraphFromFile(path string) error {
 		return err
 	}
 
+	err = core.LoadConstructsIntoGraph(input, c.Document.Constructs)
+	if err != nil {
+		return err
+	}
+
 	c.AnalysisAndTransformationPlugins = nil
 	for _, provider := range c.ProviderPlugins {
 		err := provider.LoadGraph(input, c.Document.Constructs)

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/validation"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 type (
@@ -26,6 +28,7 @@ type (
 	ProviderPlugin interface {
 		Plugin
 		Translate(result *core.ConstructGraph, dag *core.ResourceGraph) error
+		LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error
 	}
 
 	IaCPlugin interface {
@@ -104,6 +107,10 @@ func (c *Compiler) Compile() error {
 		}
 		c.Document.OutputFiles = append(c.Document.OutputFiles, files...)
 	}
+	err = c.Document.OutputGraph(c.Document.Configuration.OutDir)
+	if err != nil {
+		return errors.Wrap(err, "Unable to output graph")
+	}
 	err = c.createConfigOutputFile()
 	if err != nil {
 		return errors.Wrap(err, "Unable to output Klotho configuration file")
@@ -122,5 +129,29 @@ func (c *Compiler) createConfigOutputFile() error {
 		FPath:   fmt.Sprintf("klotho.%s", c.Document.Configuration.Format),
 		Content: buf.Bytes(),
 	})
+	return nil
+}
+
+func (c *Compiler) LoadConstructGraphFromFile(path string) error {
+
+	input := core.OutputGraph{}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close() // nolint:errcheck
+
+	err = yaml.NewDecoder(f).Decode(&input)
+	if err != nil {
+		return err
+	}
+
+	c.AnalysisAndTransformationPlugins = nil
+	for _, provider := range c.ProviderPlugins {
+		err := provider.LoadGraph(input, c.Document.Constructs)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/core/construct_graph.go
+++ b/pkg/core/construct_graph.go
@@ -1,18 +1,23 @@
 package core
 
 import (
-	"os"
-
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/graph"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v2"
 )
 
 type (
 	ConstructGraph struct {
 		underlying *graph.Directed[BaseConstruct]
+	}
+
+	OutputEdge struct {
+		Source      ResourceId `yaml:"source"`
+		Destination ResourceId `yaml:"destination"`
+	}
+	OutputGraph struct {
+		Resources []ResourceId `yaml:"resources"`
+		Edges     []OutputEdge `yaml:"edges"`
 	}
 )
 
@@ -129,93 +134,41 @@ func (cg *ConstructGraph) FindUpstreamGateways(unit *ExecutionUnit) []*Gateway {
 	return gateways
 }
 
-func CreateConstructGraphFromFile(path string) (*ConstructGraph, error) {
+func LoadConstructsIntoGraph(input OutputGraph, graph *ConstructGraph) error {
 
-	type ConstructRepresentation struct {
-		Kind string `yaml:"kind"`
-	}
-
-	type EdgeRepresentation struct {
-		Source      string `yaml:"source"`
-		Destination string `yaml:"destination"`
-	}
-
-	type ConstructGraphRepresentation struct {
-		Nodes map[string]ConstructRepresentation `yaml:"nodes"`
-		Edges []EdgeRepresentation               `yaml:"edges"`
-	}
-
-	graph := NewConstructGraph()
-	input := ConstructGraphRepresentation{
-		Nodes: map[string]ConstructRepresentation{},
-	}
-	keys := map[string]AnnotationKey{}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return graph, err
-	}
-	defer f.Close() // nolint:errcheck
-
-	err = yaml.NewDecoder(f).Decode(&input)
-	if err != nil {
-		return graph, err
-	}
-
-	for id, construct := range input.Nodes {
-		switch construct.Kind {
+	for _, res := range input.Resources {
+		switch res.Type {
 		case "execution_unit":
-			unit := &ExecutionUnit{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.ExecutionUnitCapability}}
+			unit := &ExecutionUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExecutionUnitCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "static_unit":
-			unit := &StaticUnit{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.StaticUnitCapability}}
+			unit := &StaticUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.StaticUnitCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "orm":
-			unit := &Orm{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.PersistCapability}}
+			unit := &Orm{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "kv":
-			unit := &Kv{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.PersistCapability}}
+			unit := &Kv{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "redis_node":
-			unit := &RedisNode{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.PersistCapability}}
+			unit := &RedisNode{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "fs":
-			unit := &Fs{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.PersistCapability}}
+			unit := &Fs{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "secret":
-			unit := &Config{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.PersistCapability}, Secret: true}
+			unit := &Config{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}, Secret: true}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
 		case "expose":
-			unit := &Gateway{AnnotationKey: AnnotationKey{ID: id, Capability: annotation.ExposeCapability}}
+			unit := &Gateway{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExposeCapability}}
 			graph.AddConstruct(unit)
-			keys[id] = unit.AnnotationKey
-		default:
-			return graph, errors.Errorf("Unsupported kind %s in construct graph creation", construct.Kind)
+
 		}
 	}
 
 	for _, edge := range input.Edges {
-		src, dst := keys[edge.Source], keys[edge.Destination]
-		graph.AddDependency(
-			ResourceId{
-				Provider: AbstractConstructProvider,
-				Type:     src.Capability,
-				Name:     src.ID,
-			},
-			ResourceId{
-				Provider: AbstractConstructProvider,
-				Type:     dst.Capability,
-				Name:     dst.ID,
-			},
-		)
+		graph.AddDependency(edge.Source, edge.Destination)
 	}
 
-	return graph, err
+	return nil
 }

--- a/pkg/core/construct_graph.go
+++ b/pkg/core/construct_graph.go
@@ -137,38 +137,42 @@ func (cg *ConstructGraph) FindUpstreamGateways(unit *ExecutionUnit) []*Gateway {
 func LoadConstructsIntoGraph(input OutputGraph, graph *ConstructGraph) error {
 
 	for _, res := range input.Resources {
-		switch res.Type {
-		case "execution_unit":
-			unit := &ExecutionUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExecutionUnitCapability}}
-			graph.AddConstruct(unit)
-		case "static_unit":
-			unit := &StaticUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.StaticUnitCapability}}
-			graph.AddConstruct(unit)
-		case "orm":
-			unit := &Orm{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
-			graph.AddConstruct(unit)
-		case "kv":
-			unit := &Kv{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
-			graph.AddConstruct(unit)
-		case "redis_node":
-			unit := &RedisNode{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
-			graph.AddConstruct(unit)
-		case "fs":
-			unit := &Fs{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
-			graph.AddConstruct(unit)
-		case "secret":
-			unit := &Config{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}, Secret: true}
-			graph.AddConstruct(unit)
-		case "expose":
-			unit := &Gateway{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExposeCapability}}
-			graph.AddConstruct(unit)
-
-		}
+		graph.AddConstruct(getConstructFromInputId(res))
 	}
 
 	for _, edge := range input.Edges {
-		graph.AddDependency(edge.Source, edge.Destination)
+		graph.AddDependency(getConstructFromInputId(edge.Source).Id(), getConstructFromInputId(edge.Destination).Id())
 	}
 
+	return nil
+}
+
+func getConstructFromInputId(res ResourceId) Construct {
+	switch res.Type {
+	case "execution_unit":
+		unit := &ExecutionUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExecutionUnitCapability}}
+		return unit
+	case "static_unit":
+		unit := &StaticUnit{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.StaticUnitCapability}}
+		return unit
+	case "orm":
+		unit := &Orm{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
+		return unit
+	case "kv":
+		unit := &Kv{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
+		return unit
+	case "redis_node":
+		unit := &RedisNode{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
+		return unit
+	case "fs":
+		unit := &Fs{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.PersistCapability}}
+		return unit
+	case "secret":
+		unit := &Config{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ConfigCapability}, Secret: true}
+		return unit
+	case "expose":
+		unit := &Gateway{AnnotationKey: AnnotationKey{ID: res.Name, Capability: annotation.ExposeCapability}}
+		return unit
+	}
 	return nil
 }

--- a/pkg/core/construct_graph_test.go
+++ b/pkg/core/construct_graph_test.go
@@ -361,7 +361,10 @@ func Test_LoadConstructsIntoGraph(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
 			graph := NewConstructGraph()
-			LoadConstructsIntoGraph(tt.constructs, graph)
+			err := LoadConstructsIntoGraph(tt.constructs, graph)
+			if !assert.NoError(err) {
+				return
+			}
 			assert.ElementsMatch(tt.want.nodes, ListConstructs[BaseConstruct](graph))
 			assert.ElementsMatch(tt.want.edges, graph.ListDependencies())
 		})

--- a/pkg/core/resource_graph.go
+++ b/pkg/core/resource_graph.go
@@ -62,11 +62,15 @@ func (rg *ResourceGraph) AddDependencyWithData(deployedSecond Resource, deployed
 	}
 	rg.AddResource(deployedSecond)
 	rg.AddResource(deployedFirst)
-	if cycle, _ := rg.underlying.CreatesCycle(deployedSecond.Id().String(), deployedFirst.Id().String()); cycle {
-		zap.S().Errorf("Not Adding Dependency, Cycle would be created from edge %s -> %s", deployedSecond.Id(), deployedFirst.Id())
+	rg.AddDependencyById(deployedSecond.Id(), deployedFirst.Id(), data)
+}
+
+func (rg *ResourceGraph) AddDependencyById(deployedSecond ResourceId, deployedFirst ResourceId, data any) {
+	if cycle, _ := rg.underlying.CreatesCycle(deployedSecond.String(), deployedFirst.String()); cycle {
+		zap.S().Errorf("Not Adding Dependency, Cycle would be created from edge %s -> %s", deployedSecond, deployedFirst)
 	} else {
-		rg.underlying.AddEdge(deployedSecond.Id().String(), deployedFirst.Id().String(), data)
-		zap.S().Debugf("adding %s -> %s", deployedSecond.Id(), deployedFirst.Id())
+		rg.underlying.AddEdge(deployedSecond.String(), deployedFirst.String(), data)
+		zap.S().Debugf("adding %s -> %s", deployedSecond, deployedFirst)
 	}
 }
 

--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -41,13 +41,13 @@ type (
 	}
 
 	ResourceId struct {
-		Provider string
-		Type     string
+		Provider string `yaml:"provider" toml:"provider"`
+		Type     string `yaml:"type" toml:"type"`
 		// Namespace is optional and is used to disambiguate resources that might have
 		// the same name. It can also be used to associate an imported resource with
 		// a specific namespace such as a subnet to a VPC.
-		Namespace string
-		Name      string
+		Namespace string `yaml:"namespace" toml:"namespace"`
+		Name      string `yaml:"name" toml:"name"`
 	}
 
 	// IaCValue is a struct that defines a value we need to grab from a specific resource. It is up to the plugins to make the determination of how to retrieve the value

--- a/pkg/infra/kubernetes/plugin.go
+++ b/pkg/infra/kubernetes/plugin.go
@@ -28,6 +28,10 @@ type Kubernetes struct {
 	helmHelper *helm.HelmHelper
 }
 
+func (p Kubernetes) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error {
+	return nil
+}
+
 func (p Kubernetes) Name() string { return "kubernetes" }
 
 func (p Kubernetes) Translate(constructGraph *core.ConstructGraph, dag *core.ResourceGraph) error {

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -47,8 +47,8 @@ func (a *AWS) MapResourceDirectlyToConstruct(resource core.Resource, construct c
 }
 
 func (a *AWS) GetResourcesDirectlyTiedToConstruct(construct core.BaseConstruct) ([]core.Resource, bool) {
-	resources, found := a.constructIdToResources[construct.Id()]
-	return resources, found
+	awsResources, found := a.constructIdToResources[construct.Id()]
+	return awsResources, found
 }
 
 func (a *AWS) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error {
@@ -94,8 +94,8 @@ func (a *AWS) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error 
 
 	// For anything namespaced, we will call the Load Method with the namespace and dag as the argument.
 	// This will allow the resource to be loaded into the graph since its id relies on the namespaced object
-	for namespace, resources := range namespacedResources {
-		for _, res := range resources {
+	for namespace, awsResources := range namespacedResources {
+		for _, res := range awsResources {
 			method := reflect.ValueOf(res).MethodByName("Load")
 			if method.IsValid() {
 				var callArgs []reflect.Value

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -71,7 +71,7 @@ func (a *AWS) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error 
 		newResource := reflect.New(reflect.TypeOf(res).Elem()).Interface()
 		resource, ok := newResource.(core.Resource)
 		if !ok {
-			errors.Join(joinedErr, fmt.Errorf("item %s of type %T is not of type core.Resource", node, newResource))
+			joinedErr = errors.Join(joinedErr, fmt.Errorf("item %s of type %T is not of type core.Resource", node, newResource))
 			continue
 		}
 		reflect.ValueOf(resource).Elem().FieldByName("Name").SetString(node.Name)

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -47,8 +47,8 @@ func (a *AWS) MapResourceDirectlyToConstruct(resource core.Resource, construct c
 }
 
 func (a *AWS) GetResourcesDirectlyTiedToConstruct(construct core.BaseConstruct) ([]core.Resource, bool) {
-	awsResources, found := a.constructIdToResources[construct.Id()]
-	return awsResources, found
+	constructsResources, found := a.constructIdToResources[construct.Id()]
+	return constructsResources, found
 }
 
 func (a *AWS) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error {
@@ -94,8 +94,8 @@ func (a *AWS) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error 
 
 	// For anything namespaced, we will call the Load Method with the namespace and dag as the argument.
 	// This will allow the resource to be loaded into the graph since its id relies on the namespaced object
-	for namespace, awsResources := range namespacedResources {
-		for _, res := range awsResources {
+	for namespace, namespaceResources := range namespacedResources {
+		for _, res := range namespaceResources {
 			method := reflect.ValueOf(res).MethodByName("Load")
 			if method.IsValid() {
 				var callArgs []reflect.Value

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/klothoplatform/klotho/pkg/config"
 	"github.com/klothoplatform/klotho/pkg/core"
 	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
+	"github.com/klothoplatform/klotho/pkg/provider/aws/resources"
 )
 
 type AWS struct {

--- a/pkg/provider/aws/resources/vpc.go
+++ b/pkg/provider/aws/resources/vpc.go
@@ -640,6 +640,20 @@ func (subnet *Subnet) Id() core.ResourceId {
 	return id
 }
 
+func (subnet *Subnet) Load(namespace string, dag *core.ConstructGraph) error {
+	namespacedVpc := &Vpc{Name: namespace}
+	vpc := dag.GetConstruct(namespacedVpc.Id())
+	if vpc == nil {
+		return fmt.Errorf("cannot load subnet with name %s because namespace vpc %s does not exist", subnet.Name, namespace)
+	}
+	if vpc, ok := vpc.(*Vpc); !ok {
+		return fmt.Errorf("cannot load subnet with name %s because namespace vpc %s is not a vpc", subnet.Name, namespace)
+	} else {
+		subnet.Vpc = vpc
+	}
+	return nil
+}
+
 func (subnet *Subnet) SetTypeFromId(id core.ResourceId) error {
 	if id.Provider != AWS_PROVIDER || !strings.HasPrefix(id.Type, VPC_SUBNET_TYPE_PREFIX) {
 		return fmt.Errorf("invalid id '%s' for partial subnet '%s'", id, subnet.Name)

--- a/pkg/provider/imports/plugin.go
+++ b/pkg/provider/imports/plugin.go
@@ -30,3 +30,7 @@ func (p Plugin) Translate(result *core.ConstructGraph, dag *core.ResourceGraph) 
 	}
 	return nil
 }
+
+func (p Plugin) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error {
+	return nil
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -83,6 +83,9 @@ func (p TestProvider) GetDefaultConfig() config.Defaults {
 	return config.Defaults{}
 
 }
+func (p TestProvider) LoadGraph(graph core.OutputGraph, dag *core.ConstructGraph) error {
+	return nil
+}
 func (a TestProvider) GetKindTypeMappings(construct core.Construct) []string {
 	switch construct.(type) {
 	case *core.ExecutionUnit:


### PR DESCRIPTION
• Does any part of it require special attention?
• Does it relate to or fix any issue? closes https://github.com/klothoplatform/klotho-pro/issues/88

The ability to load a BaseConstruct graph by calling all the providers load graph method.

Theres also a loadConstructs method for our higher level constructs

We also need to ensure that namespaced resources get loaded and added after their parent resource so we use reflection to call a load method (only subnets at the moment)

We will also output the graph as resources.yaml on compilation

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
