### PR TITLE
Simplify LoadConstructIntoGraph edges

### DIFF
--- a/pkg/core/construct_graph.go
+++ b/pkg/core/construct_graph.go
@@ -150,23 +150,10 @@ func LoadConstructsIntoGraph(input OutputGraph, graph *ConstructGraph) error {
 	}
 
 	for _, edge := range input.Edges {
-		shouldAdd := true
-		src, err := getConstructFromInputId(edge.Source)
-		if err != nil {
-			joinedErr = errors.Join(joinedErr, err)
-			shouldAdd = false
-		}
-		dst, err := getConstructFromInputId(edge.Destination)
-		if err != nil {
-			joinedErr = errors.Join(joinedErr, err)
-			shouldAdd = false
-		}
-		if shouldAdd {
-			graph.AddDependency(src.Id(), dst.Id())
-		}
+		graph.AddDependency(edge.Source, edge.Destination)
 	}
 
-	return nil
+	return joinedErr
 }
 
 func getConstructFromInputId(res ResourceId) (Construct, error) {


### PR DESCRIPTION
No need to convert the Id to resource only to extract the Id again to give to AddDependency.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
