### PR TITLE
Adds additional CLI flags for skipping time-intensive stages

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -3,7 +3,6 @@ package compiler
 import (
 	"bytes"
 	"fmt"
-
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/engine"
 	"github.com/klothoplatform/klotho/pkg/engine/constraints"


### PR DESCRIPTION
Resolves #694 

- Added the following flags: 
  - `--skip-visualization` - skips diagram generation
  - `--skip-infrastructure` - skips our pulumi iac generation plugins
  - `--skip-update-check` - skips checking the server for CLI updates

- Re-enables infrastructure generation by default when a construct graph is supplied.