### PR TITLE
EKS Dataflow Visualization

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -3,7 +3,6 @@ package compiler
 import (
 	"bytes"
 	"fmt"
-
 	"github.com/klothoplatform/klotho/pkg/core"
 	"github.com/klothoplatform/klotho/pkg/engine"
 	"github.com/klothoplatform/klotho/pkg/engine/constraints"

--- a/pkg/provider/aws/resources/eks.go
+++ b/pkg/provider/aws/resources/eks.go
@@ -518,6 +518,7 @@ func (cluster *EksCluster) CreatePrerequisiteCharts(dag *core.ResourceGraph) {
 			ConstructRefs: cluster.ConstructsRef,
 			Cluster:       cluster,
 			Repo:          `https://kubernetes-sigs.github.io/metrics-server/`,
+			IsInternal:    true,
 		},
 		{
 			Name:          cluster.Name + `-cert-manager`,
@@ -533,6 +534,7 @@ func (cluster *EksCluster) CreatePrerequisiteCharts(dag *core.ResourceGraph) {
 					`timeoutSeconds`: 30,
 				},
 			},
+			IsInternal: true,
 		},
 	}
 	for _, chart := range charts {

--- a/pkg/provider/kubernetes/resources/helm_chart.go
+++ b/pkg/provider/kubernetes/resources/helm_chart.go
@@ -22,6 +22,8 @@ type HelmChart struct {
 	Version       string
 	Namespace     string
 	Values        map[string]any
+	// IsInternal is a flag used to identify charts as being included in application by Klotho itself
+	IsInternal bool
 }
 
 // BaseConstructsRef returns a slice containing the ids of any Klotho constructs is correlated to


### PR DESCRIPTION
This PR adds support for Kubernetes Pods, Deployments, and Helm Charts to the dataflow view.

Additional changes include fixes that should eliminate intermittent inclusion of resources we don't care about in the dataflow view as well as some intermittent parent/child relationship issues.

Also included are new Klotho CLI flags that were mistakenly dropped in a previous PR.