### PR TITLE
Engine Edge Lookup Performance Fix

### DIFF
--- a/pkg/engine/constraints/application_constraint_test.go
+++ b/pkg/engine/constraints/application_constraint_test.go
@@ -1,6 +1,7 @@
 package constraints
 
 import (
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -174,7 +175,7 @@ func Test_ApplicationConstraint_IsSatisfied(t *testing.T) {
 				dag.AddResource(res)
 			}
 			for _, constraint := range tt.constraint {
-				result := constraint.IsSatisfied(dag, nil, make(map[core.ResourceId][]core.Resource), nil)
+				result := constraint.IsSatisfied(dag, knowledgebase.EdgeKB{}, make(map[core.ResourceId][]core.Resource), nil)
 				assert.Equalf(tt.want, result, "constraint %s is not satisfied", constraint)
 			}
 		})

--- a/pkg/engine/constraints/construct_constraint_test.go
+++ b/pkg/engine/constraints/construct_constraint_test.go
@@ -1,6 +1,7 @@
 package constraints
 
 import (
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -81,7 +82,7 @@ func Test_ConstructConstraint_IsSatisfied(t *testing.T) {
 			for _, res := range tt.resources {
 				dag.AddResource(res)
 			}
-			result := tt.constraint.IsSatisfied(dag, nil, make(map[core.ResourceId][]core.Resource), nil)
+			result := tt.constraint.IsSatisfied(dag, knowledgebase.EdgeKB{}, make(map[core.ResourceId][]core.Resource), nil)
 			assert.Equal(tt.want, result)
 		})
 	}

--- a/pkg/engine/constraints/edge_constraint_test.go
+++ b/pkg/engine/constraints/edge_constraint_test.go
@@ -1,6 +1,7 @@
 package constraints
 
 import (
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -470,7 +471,7 @@ func Test_EdgeConstraint_IsSatisfied(t *testing.T) {
 			for _, edge := range tt.edges {
 				dag.AddDependencyById(edge.Source, edge.Target, nil)
 			}
-			result := tt.constraint.IsSatisfied(dag, nil, tt.mappedResources, nil)
+			result := tt.constraint.IsSatisfied(dag, knowledgebase.EdgeKB{}, tt.mappedResources, nil)
 			assert.Equal(tt.want, result)
 		})
 	}

--- a/pkg/engine/constraints/resource_constraint_test.go
+++ b/pkg/engine/constraints/resource_constraint_test.go
@@ -1,6 +1,7 @@
 package constraints
 
 import (
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base"
 	"testing"
 
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -85,7 +86,7 @@ func Test_NodeConstraint_IsSatisfied(t *testing.T) {
 			for _, res := range tt.resources {
 				dag.AddResource(res)
 			}
-			result := tt.constraint.IsSatisfied(dag, nil, make(map[core.ResourceId][]core.Resource), nil)
+			result := tt.constraint.IsSatisfied(dag, knowledgebase.EdgeKB{}, make(map[core.ResourceId][]core.Resource), nil)
 			assert.Equal(tt.want, result)
 		})
 	}

--- a/pkg/engine/deployment_order.go
+++ b/pkg/engine/deployment_order.go
@@ -10,7 +10,7 @@ func (e *Engine) GetDeploymentOrderGraph(dataflow *core.ResourceGraph) *core.Res
 		deploymentOrderGraph.AddResource(resource)
 	}
 	for _, dep := range dataflow.ListDependencies() {
-		edge, _ := e.KnowledgeBase.GetEdge(dep.Source, dep.Destination)
+		edge, _ := e.KnowledgeBase.GetResourceEdge(dep.Source, dep.Destination)
 		if edge.DeploymentOrderReversed {
 			deploymentOrderGraph.AddDependency(dep.Destination, dep.Source)
 		} else {

--- a/pkg/engine/reconciler.go
+++ b/pkg/engine/reconciler.go
@@ -21,7 +21,7 @@ DEP:
 				}
 				if dep == res {
 					found = true
-					det, _ := e.KnowledgeBase.GetEdge(resource, dep)
+					det, _ := e.KnowledgeBase.GetResourceEdge(resource, dep)
 					if !det.DeletetionDependent {
 						return false
 					}
@@ -34,7 +34,7 @@ DEP:
 				}
 				if dep == res {
 					found = true
-					det, _ := e.KnowledgeBase.GetEdge(dep, resource)
+					det, _ := e.KnowledgeBase.GetResourceEdge(dep, resource)
 					if !det.DeletetionDependent {
 						return false
 					}

--- a/pkg/knowledge_base/edge_builders.go
+++ b/pkg/knowledge_base/edge_builders.go
@@ -50,9 +50,9 @@ func (e EdgeBuilder[S, D]) Details() EdgeDetails {
 }
 
 func Build(edges ...edgeBuilder) EdgeKB {
-	result := make(EdgeKB)
+	result := make(EdgeMap)
 	for _, builder := range edges {
 		result[builder.Edge()] = builder.Details()
 	}
-	return result
+	return NewEdgeKB(result)
 }

--- a/pkg/provider/providers/provider.go
+++ b/pkg/provider/providers/provider.go
@@ -30,5 +30,5 @@ func GetKnowledgeBase(cfg *config.Application) (knowledgebase.EdgeKB, error) {
 	case "aws":
 		return awsknowledgebase.GetAwsKnowledgeBase()
 	}
-	return nil, fmt.Errorf("could not get provider: %v", cfg.Provider)
+	return knowledgebase.EdgeKB{}, fmt.Errorf("could not get provider: %v", cfg.Provider)
 }


### PR DESCRIPTION
Makes the EdgeKB into a struct containing 2 maps to improve lookup speed of edges for a given resource.