### PR TITLE
Resource types api

### DIFF
--- a/pkg/cli/enginemain.go
+++ b/pkg/cli/enginemain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/yaml.v3"
 )
 
 type testCase struct {
@@ -248,9 +249,11 @@ func (km *KlothoMain) ListResourceFields(cmd *cobra.Command, args []string) erro
 	}
 
 	fields := plugins.Engine.ListResourceFields(listResourceFieldsConfig.provider, listResourceFieldsConfig.resource)
-	for field, fieldType := range fields {
-		fmt.Printf("%s: %s\n", field, fieldType)
+	b, err := yaml.Marshal(fields)
+	if err != nil {
+		return err
 	}
+	fmt.Println(string(b))
 	return nil
 }
 

--- a/pkg/engine/operational_resources.go
+++ b/pkg/engine/operational_resources.go
@@ -525,6 +525,11 @@ func ConfigureField(resource core.Resource, fieldName string, value interface{})
 }
 
 func configureField(val interface{}, field reflect.Value) {
+	if !reflect.ValueOf(val).IsValid() {
+		return
+	} else if reflect.ValueOf(val).IsZero() {
+		return
+	}
 	switch field.Kind() {
 	case reflect.Slice, reflect.Array:
 		arr := field


### PR DESCRIPTION
This pr both gives the ability to act on resource constraints as well as renders a resources available configuration as a yaml document.

example constraint
```
- operator : equals
  scope: resource
  target: aws:lambda_function:lambda_01
  property: MemorySize
  value: 5000
```

example api call to get resource configuration
```
klotho ListResourceTypesFields --provider aws --resource-type cloudfront_distribution
```
output:

```
CloudfrontDefaultCertificate: bool
DefaultCacheBehavior:
    AllowedMethods:
        - string
    CachedMethods:
        - string
    DefaultTtl: int
    ForwardedValues:
        Cookies:
            Forward: string
        QueryString: bool
    MaxTtl: int
    MinTtl: int
    TargetOriginId: string
    ViewerProtocolPolicy: string
DefaultRootObject: string
Enabled: bool
Name: string
Origins:
    - CustomOriginConfig:
        HttpPort: int
        HttpsPort: int
        OriginProtocolPolicy: string
        OriginSslProtocols:
            - string
      DomainName:
        Property: string
        ResourceId:
            Name: string
            Namespace: string
            Provider: string
            Type: string
      OriginId: string
      OriginPath:
        Property: string
        ResourceId:
            Name: string
            Namespace: string
            Provider: string
            Type: string
      S3OriginConfig:
        OriginAccessIdentity:
            Property: string
            ResourceId:
                Name: string
                Namespace: string
                Provider: string
                Type: string
Restrictions:
    GeoRestriction:
        RestrictionType: string
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
