### PR TITLE
Use RawNode for deferred unmarshaling of resource metadata

### DIFF
--- a/pkg/yaml_util/raw_node.go
+++ b/pkg/yaml_util/raw_node.go
@@ -1,0 +1,10 @@
+package yaml_util
+
+import "gopkg.in/yaml.v3"
+
+type RawNode struct{ *yaml.Node }
+
+func (n *RawNode) UnmarshalYAML(value *yaml.Node) error {
+	n.Node = value
+	return nil
+}


### PR DESCRIPTION
This fixes binary data in resource metadata in new `!!binary` format from not being able to be unmarshalled (since unmarshal -> marshal -> unmarshal was losing some information).

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
