### PR TITLE
add configuration of sub fields

### DIFF
--- a/pkg/engine/api.go
+++ b/pkg/engine/api.go
@@ -124,9 +124,10 @@ func getStructFieldFields(field reflect.Type) any {
 		arrFields = append(arrFields, getStructFieldFields(field.Elem()))
 		return arrFields
 	} else if field.Kind() == reflect.Map {
-		for _, key := range reflect.ValueOf(field).MapKeys() {
-			fields[key.String()] = field.String()
-		}
+		fields["key"] = field.Key().String()
+		fields["value"] = getStructFieldFields(field.Elem())
+
+		return fields
 	} else {
 		return field.String()
 	}

--- a/pkg/engine/operational_resources.go
+++ b/pkg/engine/operational_resources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/klothoplatform/klotho/pkg/collectionutil"
 	"github.com/klothoplatform/klotho/pkg/core"
@@ -501,20 +502,45 @@ func TemplateConfigure(resource core.Resource, template core.ResourceTemplate) e
 }
 
 func ConfigureField(resource core.Resource, fieldName string, value interface{}) error {
-	field := reflect.ValueOf(resource).Elem().FieldByName(fieldName)
+	fields := strings.Split(fieldName, ".")
+	var field reflect.Value
+	for i := 0; i < len(fields); i++ {
+		fmt.Println(field)
+		fmt.Println(fields[i])
+		if i == 0 {
+			field = reflect.ValueOf(resource).Elem().FieldByName(fields[i])
+			fmt.Println(reflect.ValueOf(resource).Elem())
+			fmt.Println(reflect.ValueOf(resource).Elem().FieldByName(fields[i]))
+			fmt.Println(field)
+		} else {
+			if field.Kind() == reflect.Ptr {
+				field = field.Elem().FieldByName(fields[i])
+			} else {
+				field = field.FieldByName(fields[i])
+			}
+		}
+		if !field.IsValid() {
+			return fmt.Errorf("unable to find field %s on resource %s", fields[i], resource.Id())
+		} else if field.IsZero() && field.Kind() == reflect.Ptr {
+			fmt.Println("it is zero")
+			fmt.Println(field.Type())
+			fmt.Println(reflect.New(field.Type().Elem()))
+			newField := reflect.New(field.Type().Elem())
+			field.Set(newField)
+			field = newField
+		}
+	}
 	switch field.Kind() {
 	case reflect.Slice, reflect.Array:
 		if reflect.ValueOf(value).Kind() != reflect.Slice {
 			return fmt.Errorf("config template is not the correct type for resource %s. expected it to be a list, but got %s", resource.Id(), reflect.TypeOf(value))
 		}
 		configureField(value, field)
-		reflect.ValueOf(resource).Elem().FieldByName(fieldName).Set(field)
 	case reflect.Pointer, reflect.Struct:
 		if reflect.ValueOf(value).Kind() != reflect.Map {
 			return fmt.Errorf("config template is not the correct type for resource %s. expected it to be a map, but got %s", resource.Id(), reflect.TypeOf(value))
 		}
 		configureField(value, field)
-		reflect.ValueOf(resource).Elem().FieldByName(fieldName).Set(field)
 	default:
 		if reflect.TypeOf(value) != field.Type() {
 			return fmt.Errorf("config template is not the correct type for resource %s. expected it to be %s, but got %s", resource.Id(), field.Type(), reflect.TypeOf(value))

--- a/pkg/engine/operational_resources_test.go
+++ b/pkg/engine/operational_resources_test.go
@@ -505,6 +505,38 @@ func Test_TemplateConfigure(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "pointer sub field",
+			resource: &enginetesting.MockResource6{},
+			template: core.ResourceTemplate{
+				Configuration: []core.Configuration{
+					{Field: "Struct2.Field1", Value: 1},
+					{Field: "Struct2.Arr1", Value: []string{"1", "2", "3"}},
+				},
+			},
+			want: &enginetesting.MockResource6{
+				Struct2: &enginetesting.TestRes1{
+					Field1: 1,
+					Arr1:   []string{"1", "2", "3"},
+				},
+			},
+		},
+		{
+			name:     "struct sub field",
+			resource: &enginetesting.MockResource6{},
+			template: core.ResourceTemplate{
+				Configuration: []core.Configuration{
+					{Field: "Struct1.Field1", Value: 1},
+					{Field: "Struct1.Arr1", Value: []string{"1", "2", "3"}},
+				},
+			},
+			want: &enginetesting.MockResource6{
+				Struct1: enginetesting.TestRes1{
+					Field1: 1,
+					Arr1:   []string{"1", "2", "3"},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/infra/iac2/templates_compiler.go
+++ b/pkg/infra/iac2/templates_compiler.go
@@ -141,6 +141,11 @@ func (tc TemplatesCompiler) RenderExports(out io.Writer) error {
 			if err != nil {
 				return err
 			}
+		case *resources.AppRunnerService:
+			_, err := out.Write([]byte("\"" + res.Name + "\": " + tc.getVarName(res) + ".serviceUrl,\n"))
+			if err != nil {
+				return err
+			}
 		}
 	}
 	_, err = out.Write([]byte("}"))


### PR DESCRIPTION
add the ability to configure sub fields without the need to configure entire structs/pointers

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
