### PR TITLE
Add docker image resource if baseimage is set

### DIFF
--- a/pkg/construct/resources.go
+++ b/pkg/construct/resources.go
@@ -122,14 +122,11 @@ func GetMapDecoder(result interface{}) *mapstructure.Decoder {
 	return decoder
 }
 
-func (s *BaseConstructSet) Add(k BaseConstruct) {
+func (s BaseConstructSet) Add(k BaseConstruct) {
 	if k == nil {
 		return
 	}
-	if *s == nil {
-		*s = make(BaseConstructSet)
-	}
-	(*s)[k.Id()] = k
+	s[k.Id()] = k
 }
 
 func (s BaseConstructSet) Has(k ResourceId) bool {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -660,9 +660,26 @@ func (e *Engine) CreateResourceFromId(id construct.ResourceId) (construct.Resour
 		return nil, err
 	}
 	if r, ok := c.(construct.Resource); ok {
+		crefs := r.BaseConstructRefs()
+		if crefs == nil {
+			err = createConstructRefs(r)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return r, nil
 	}
 	return nil, fmt.Errorf("construct %s is not a resource (was %T)", id, c)
+}
+
+func createConstructRefs(r construct.Resource) error {
+	v := reflect.ValueOf(r).Elem()
+	f := v.FieldByName("ConstructRefs")
+	if !f.IsValid() {
+		return fmt.Errorf("resource %s does not have a ConstructRefs field", r.Id())
+	}
+	f.Set(reflect.ValueOf(make(construct.BaseConstructSet)))
+	return nil
 }
 
 func (e *Engine) checkIfConstraintsAreAllowed() error {

--- a/pkg/knowledge_base/embed.go
+++ b/pkg/knowledge_base/embed.go
@@ -1,0 +1,37 @@
+package knowledgebase
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"github.com/klothoplatform/klotho/pkg/construct"
+	"gopkg.in/yaml.v2"
+)
+
+func TemplatesFromFs(dir fs.FS) (map[construct.ResourceId]*ResourceTemplate, error) {
+	templates := map[construct.ResourceId]*ResourceTemplate{}
+	err := fs.WalkDir(dir, ".", func(path string, d fs.DirEntry, nerr error) error {
+		if d.IsDir() {
+			return nil
+		}
+		f, err := dir.Open(path)
+		if err != nil {
+			return errors.Join(nerr, err)
+		}
+
+		resTemplate := &ResourceTemplate{}
+		err = yaml.NewDecoder(f).Decode(resTemplate)
+		if err != nil {
+			return errors.Join(nerr, err)
+		}
+
+		id := construct.ResourceId{Provider: resTemplate.Provider, Type: resTemplate.Type}
+		if templates[id] != nil {
+			return errors.Join(nerr, fmt.Errorf("duplicate template for %s", id))
+		}
+		templates[id] = resTemplate
+		return nil
+	})
+	return templates, err
+}

--- a/pkg/knowledge_base/operational_funcs.go
+++ b/pkg/knowledge_base/operational_funcs.go
@@ -5,6 +5,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -45,8 +46,10 @@ func (ctx *ConfigTemplateContext) Parse(tmpl string) (*template.Template, error)
 
 		"toJson": ctx.toJson,
 
-		"split":                strings.Split,
-		"join":                 strings.Join,
+		"split":    strings.Split,
+		"join":     strings.Join,
+		"basename": filepath.Base,
+
 		"filterIds":            filterIds,
 		"filterMatch":          filterMatch,
 		"mapString":            mapString,

--- a/pkg/provider/aws/edges/ecr_image-docker_image.yaml
+++ b/pkg/provider/aws/edges/ecr_image-docker_image.yaml
@@ -5,10 +5,10 @@ deployment_order_reversed: false
 deletion_dependent: false
 reuse:
 configuration:
-  - resource: docker:image
+  - resource: aws:ecr_image
     config:
       field: BaseImage
-      value: aws:ecr_image:#BaseImage
+      value: docker:image:#BaseImage
   - resource: aws:ecr_image
     config:
       field: Dockerfile

--- a/pkg/provider/aws/edges/ecr_image-docker_image.yaml
+++ b/pkg/provider/aws/edges/ecr_image-docker_image.yaml
@@ -7,9 +7,9 @@ reuse:
 configuration:
   - resource: docker:image
     config:
-      field: CreatesDockerfile
-      value: true
+      field: BaseImage
+      value: aws:ecr_image:#BaseImage
   - resource: aws:ecr_image
     config:
-      field: BaseImage
-      value: docker:image:#Name
+      field: Dockerfile
+      value: docker:image:#DockerfilePath

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -74,32 +74,13 @@ func (a *AWS) CreateConstructFromId(id construct.ResourceId, dag *construct.Cons
 	return resource, nil
 }
 
-//go:embed resources/templates/*
-var awsTempaltes embed.FS
+//go:embed resources/templates/*.yaml
+var awsTemplates embed.FS
 
 func (a *AWS) GetOperationalTemplates() map[construct.ResourceId]*knowledgebase.ResourceTemplate {
-	templates := map[construct.ResourceId]*knowledgebase.ResourceTemplate{}
-	if err := fs.WalkDir(awsTempaltes, ".", func(path string, d fs.DirEntry, nerr error) error {
-		if d.IsDir() {
-			return nil
-		}
-		content, err := awsTempaltes.ReadFile(fmt.Sprintf("resources/templates/%s", d.Name()))
-		if err != nil {
-			panic(err)
-		}
-		resTemplate := &knowledgebase.ResourceTemplate{}
-		err = yaml.Unmarshal(content, resTemplate)
-		if err != nil {
-			panic(err)
-		}
-		id := construct.ResourceId{Provider: provider.AWS, Type: resTemplate.Type}
-		if templates[id] != nil {
-			panic(fmt.Errorf("duplicate template for type %s", resTemplate.Type))
-		}
-		templates[id] = resTemplate
-		return nil
-	}); err != nil {
-		return templates
+	templates, err := knowledgebase.TemplatesFromFs(awsTemplates)
+	if err != nil {
+		panic(err)
 	}
 	return templates
 }

--- a/pkg/provider/aws/resources/templates/ecr_image.yaml
+++ b/pkg/provider/aws/resources/templates/ecr_image.yaml
@@ -8,12 +8,22 @@ rules:
     set_field: Repo
     unsatisfied_action:
       operation: create
+  - enforcement: exactly_one
+    direction: downstream
+    if: |
+      {{ eq (fieldValue "Dockerfile" .Self) "" }}
+    resources:
+      - docker:image:{{ .Self.Name }}
+    unsatisfied_action:
+      operation: create
 configuration:
   - field: ExtraOptions
     value:
       - --platform
       - linux/amd64
       - --quiet
+  - field: BaseImage
+  - field: Dockerfile
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/provider/docker/provider.go
+++ b/pkg/provider/docker/provider.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"embed"
 	"fmt"
 	"reflect"
 
@@ -10,12 +11,18 @@ import (
 	"github.com/klothoplatform/klotho/pkg/provider/docker/resources"
 )
 
+//go:embed resources/*.yaml
+var templates embed.FS
+
 type DockerProvider struct {
 }
 
 func (a *DockerProvider) GetOperationalTemplates() map[construct.ResourceId]*knowledgebase.ResourceTemplate {
-	// Not implemented
-	return map[construct.ResourceId]*knowledgebase.ResourceTemplate{}
+	templates, err := knowledgebase.TemplatesFromFs(templates)
+	if err != nil {
+		panic(err)
+	}
+	return templates
 }
 
 func (a *DockerProvider) GetEdgeTemplates() map[string]*knowledgebase.EdgeTemplate {

--- a/pkg/provider/docker/resources/image.yaml
+++ b/pkg/provider/docker/resources/image.yaml
@@ -1,0 +1,6 @@
+provider: docker
+type: image
+configuration:
+  - field: DockerfilePath
+    value_template: |
+      dockerfiles/{{ basename .Self.Name }}.Dockerfile


### PR DESCRIPTION
Note: the `BaseImage` property on the EcrImage is always copied from the docker image, so any modification should happen on the DockerImage instead. (this is to keep IaC working since it relies solely on the EcrImage)

## Test
### Input
```yaml
constraints:
  - target: docker:image:ecr_image-pets-0
    scope: resource
    operator: equals
    property: baseimage
    value: wordpress
```

### Output
```yaml
# ...
    - id: aws:ecr_image:ecr_image-pets-0
      metadata:
        name: ecr_image-pets-0
        imagename: ""
        repo:
            name: ecr_repo-0
            forcedelete: true
        context: dockerfiles
        dockerfile: dockerfiles/ecr_image-pets-0.Dockerfile # <- sync'd with the docker:image DockerfilePath
        extraoptions:
            - --platform
            - linux/amd64
            - --quiet
        baseimage: wordpress # <- sync'd with the docker:image BaseImage
    - id: docker:image:ecr_image-pets-0
      metadata:
        name: ecr_image-pets-0
        baseimage: wordpress # <- set by the constraint
        dockerfilepath: dockerfiles/ecr_image-pets-0.Dockerfile # <- derived from the resource name
# ...
```

### IaC
compiled/dockerfiles/ecr_image-pets-0.Dockerfile
```Dockerfile
FROM wordpress
```