### PR TITLE
Disable decision recording for config

### DIFF
--- a/pkg/engine/decisions.go
+++ b/pkg/engine/decisions.go
@@ -175,7 +175,9 @@ func (e *Engine) handleDecision(context *SolveContext, decision Decision) {
 				})
 				return
 			}
-			context.recordDecision(decision)
+			// Disabling recording config due to some config not easily in JSON format, and for now we just
+			// render the config values to JSON as-is.
+			// context.recordDecision(decision)
 		}
 	case ActionDelete:
 		if decision.Result.Resource != nil {


### PR DESCRIPTION
Previously, we did not record config decisions for resources (https://github.com/klothoplatform/klotho/blob/91704d3c88d8ec787db1c296f947b0e9598244cb/pkg/engine/resource_configuration.go#L33C14-L33C14). Now that edge and resource use the same path, we should disable this for now until the refactor cleans up the decisions.