### PR TITLE
Bugfix/subnet id changing

### DIFF
--- a/pkg/construct/construct_graph_test.go
+++ b/pkg/construct/construct_graph_test.go
@@ -3,6 +3,7 @@ package construct
 import (
 	"testing"
 
+	orig_graph "github.com/dominikbraun/graph"
 	"github.com/klothoplatform/klotho/pkg/annotation"
 	"github.com/klothoplatform/klotho/pkg/graph"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,8 @@ func (tc *TestConstruct) Id() ResourceId {
 		Name:     tc.Name,
 	}
 }
+
+var emptyProperties = orig_graph.EdgeProperties{Attributes: make(map[string]string)}
 
 func Test_AddConstruct(t *testing.T) {
 	assert := assert.New(t)
@@ -124,6 +127,7 @@ func Test_GetDownstreamDependencies(t *testing.T) {
 				{
 					Source:      &TestConstruct{Name: "testkv"},
 					Destination: &TestConstruct{Name: "testeu"},
+					Properties:  emptyProperties,
 				},
 			},
 		},
@@ -138,10 +142,12 @@ func Test_GetDownstreamDependencies(t *testing.T) {
 				{
 					Source:      &TestConstruct{Name: "test"},
 					Destination: &TestConstruct{Name: "test1"},
+					Properties:  emptyProperties,
 				},
 				{
 					Source:      &TestConstruct{Name: "test"},
 					Destination: &TestConstruct{Name: "test2"},
+					Properties:  emptyProperties,
 				},
 			},
 		},
@@ -194,6 +200,7 @@ func Test_GetUpstreamDependencies(t *testing.T) {
 				{
 					Source:      &TestConstruct{Name: "test1"},
 					Destination: &TestConstruct{Name: "test"},
+					Properties:  emptyProperties,
 				},
 			},
 		},
@@ -208,10 +215,12 @@ func Test_GetUpstreamDependencies(t *testing.T) {
 				{
 					Source:      &TestConstruct{Name: "test1"},
 					Destination: &TestConstruct{Name: "test"},
+					Properties:  emptyProperties,
 				},
 				{
 					Source:      &TestConstruct{Name: "test2"},
 					Destination: &TestConstruct{Name: "test"},
+					Properties:  emptyProperties,
 				},
 			},
 		},

--- a/pkg/construct/resource_graph.go
+++ b/pkg/construct/resource_graph.go
@@ -493,17 +493,18 @@ func (rg *ResourceGraph) ReplaceConstruct(resource Resource, new Resource) error
 
 func (rg *ResourceGraph) ReplaceConstructId(oldId ResourceId, new Resource) error {
 	rg.AddResource(new)
+	newId := new.Id().String()
 	// Since its a construct we just assume every single edge can be removed
 	for _, edge := range rg.underlying.OutgoingEdgesById(oldId.String()) {
-		rg.AddDependency(new, edge.Destination)
-		err := rg.RemoveDependency(edge.Source.Id(), edge.Destination.Id())
+		rg.underlying.AddEdge(newId, edge.Destination, edge.Properties.Data)
+		err := rg.underlying.RemoveEdge(edge.Source, edge.Destination)
 		if err != nil {
 			return err
 		}
 	}
 	for _, edge := range rg.underlying.IncomingEdgesById(oldId.String()) {
-		rg.AddDependency(edge.Source, new)
-		err := rg.RemoveDependency(edge.Source.Id(), edge.Destination.Id())
+		rg.underlying.AddEdge(edge.Source, newId, edge.Properties.Data)
+		err := rg.underlying.RemoveEdge(edge.Source, edge.Destination)
 		if err != nil {
 			return err
 		}

--- a/pkg/engine/operational_resources.go
+++ b/pkg/engine/operational_resources.go
@@ -469,7 +469,7 @@ func (e *Engine) setField(dag *construct.ResourceGraph, resource construct.Resou
 			field.Set(fieldValue)
 		}
 	}
-	zap.S().Infof("set field %s#%s to %s", resource.Id(), rule.SetField, fieldResource.Id())
+	zap.S().Debugf("set field %s#%s to %s", resource.Id(), rule.SetField, fieldResource.Id())
 	// If this sets the field driving the namespace, for example,
 	// then the Id could change, so replace the resource in the graph
 	// to update all the edges to the new Id.

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"testing"
 
+	"github.com/dominikbraun/graph"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,6 +13,8 @@ func TestEmptyGraph(t *testing.T) {
 	assert.Empty(d.Roots())
 }
 
+var emptyProps = graph.EdgeProperties{Attributes: make(map[string]string)}
+
 func TestSimpleGraph(t *testing.T) {
 	// A ┬─➤ B
 	//   └─➤ C
@@ -20,8 +23,8 @@ func TestSimpleGraph(t *testing.T) {
 	d.AddVertex(a)
 	d.AddVertex(b)
 	d.AddVertex(c)
-	d.AddEdge(a.Id(), b.Id(), nil)
-	d.AddEdge(a.Id(), c.Id(), nil)
+	d.AddEdge(a.Id(), b.Id(), "a")
+	d.AddEdge(a.Id(), c.Id(), "b")
 
 	test(t, "roots", func(assert *assert.Assertions) {
 		assert.Equal([]DummyVertex{a}, d.Roots())
@@ -35,10 +38,18 @@ func TestSimpleGraph(t *testing.T) {
 				{
 					Source:      a,
 					Destination: b,
+					Properties: graph.EdgeProperties{
+						Attributes: make(map[string]string),
+						Data:       "a",
+					},
 				},
 				{
 					Source:      a,
 					Destination: c,
+					Properties: graph.EdgeProperties{
+						Attributes: make(map[string]string),
+						Data:       "b",
+					},
 				},
 			},
 			d.OutgoingEdges(a))
@@ -56,6 +67,7 @@ func TestCycleToSelf(t *testing.T) {
 			{
 				Source:      v,
 				Destination: v,
+				Properties:  emptyProps,
 			},
 		},
 		d.OutgoingEdges(v))
@@ -75,6 +87,7 @@ func TestCycle(t *testing.T) {
 			{
 				Source:      v1,
 				Destination: v2,
+				Properties:  emptyProps,
 			},
 		},
 		d.OutgoingEdges(v1))
@@ -83,6 +96,7 @@ func TestCycle(t *testing.T) {
 			{
 				Source:      v2,
 				Destination: v1,
+				Properties:  emptyProps,
 			},
 		},
 		d.OutgoingEdges(v2))
@@ -109,6 +123,7 @@ func TestNegativeCases(t *testing.T) {
 				{
 					Source:      v1,
 					Destination: v2,
+					Properties:  emptyProps,
 				},
 			},
 			d.OutgoingEdges(v1))


### PR DESCRIPTION
Fixes error dragging or using VPCs. Bug was caused by the subnet IDs changing.

1. Call replace if the ID changed to update all the edges
2. Update the replace method to use the edges directly instead of calling `.Id()` on the source/destination - since the ID had changed, this was giving the wrong ID.

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
