### PR TITLE
model consumption in path expansion

### DIFF
--- a/pkg/engine2/engine.go
+++ b/pkg/engine2/engine.go
@@ -30,7 +30,7 @@ func NewEngine(kb knowledgebase.TemplateKB) *Engine {
 
 func (e *Engine) Run(context *EngineContext) error {
 	solutionCtx := NewSolutionContext(e.Kb)
-	solutionCtx.constraints = context.Constraints
+	solutionCtx.constraints = &context.Constraints
 	err := solutionCtx.LoadGraph(context.InitialState)
 	if err != nil {
 		return err

--- a/pkg/engine2/solution_context.go
+++ b/pkg/engine2/solution_context.go
@@ -19,7 +19,7 @@ type (
 		decisions       solution_context.DecisionRecords
 		stack           []solution_context.KV
 		mappedResources map[construct.ResourceId]construct.ResourceId
-		constraints     constraints.Constraints
+		constraints     *constraints.Constraints
 		propertyEval    *property_eval.Evaluator
 	}
 )
@@ -70,7 +70,7 @@ func (ctx solutionContext) KnowledgeBase() knowledgebase.TemplateKB {
 }
 
 func (ctx solutionContext) Constraints() *constraints.Constraints {
-	return &ctx.constraints
+	return ctx.constraints
 }
 
 func (ctx solutionContext) LoadGraph(graph construct.Graph) error {

--- a/pkg/infra/iac3/templates/aws/cloudfront_distribution/factory.ts
+++ b/pkg/infra/iac3/templates/aws/cloudfront_distribution/factory.ts
@@ -26,3 +26,13 @@ function create(args: Args): aws.cloudfront.Distribution {
         //TMPL {{- end }}
     })
 }
+
+function infraExports(
+    object: ReturnType<typeof create>,
+    args: Args,
+    props: ReturnType<typeof properties>
+) {
+    return {
+        Domain: object.domainName,
+    }
+}

--- a/pkg/infra/iac3/templates/aws/s3_bucket/factory.ts
+++ b/pkg/infra/iac3/templates/aws/s3_bucket/factory.ts
@@ -41,3 +41,13 @@ function properties(object: aws.s3.Bucket, args: Args) {
         BucketName: object.bucket,
     }
 }
+
+function infraExports(
+    object: ReturnType<typeof create>,
+    args: Args,
+    props: ReturnType<typeof properties>
+) {
+    return {
+        BucketName: object.bucket,
+    }
+}

--- a/pkg/knowledge_base2/emitter.go
+++ b/pkg/knowledge_base2/emitter.go
@@ -1,0 +1,170 @@
+package knowledgebase2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+)
+
+type (
+	Consumption struct {
+		Emitted  []ConsumptionObject `json:"emitted" yaml:"emitted"`
+		Consumed []ConsumptionObject `json:"consumed" yaml:"consumed"`
+	}
+
+	ConsumptionObject struct {
+		Model        string `json:"model" yaml:"model"`
+		Value        any    `json:"value" yaml:"value"`
+		Resource     string `json:"resource" yaml:"resource"`
+		PropertyPath string `json:"property_path" yaml:"property_path"`
+		Converter    string `json:"converter" yaml:"converter"`
+	}
+
+	DelayedConsumption struct {
+		Value        any
+		Resource     construct.ResourceId
+		PropertyPath string
+	}
+)
+
+func ConsumeFromResource(consumer, emitter *construct.Resource, ctx DynamicValueContext) ([]DelayedConsumption, error) {
+	consumerTemplate, err := ctx.KnowledgeBase.GetResourceTemplate(consumer.ID)
+	if err != nil {
+		return nil, err
+	}
+	emitterTemplate, err := ctx.KnowledgeBase.GetResourceTemplate(emitter.ID)
+	if err != nil {
+		return nil, err
+	}
+	var errs error
+	delays := []DelayedConsumption{}
+	for _, consume := range consumerTemplate.Consumption.Consumed {
+		for _, emit := range emitterTemplate.Consumption.Emitted {
+			if consume.Model == emit.Model {
+				val, err := emit.Emit(ctx, emitter.ID)
+				if err != nil {
+					errs = errors.Join(errs, err)
+					continue
+				}
+
+				pval, _ := consumer.GetProperty(consume.PropertyPath)
+				if pval == nil {
+					id := consumer.ID
+					if consume.Resource != "" {
+						data := DynamicValueData{Resource: consumer.ID}
+						err = ctx.ExecuteDecode(consume.Resource, data, &id)
+						if err != nil {
+							errs = errors.Join(errs, err)
+							continue
+						}
+					}
+					if consume.Converter != "" {
+						val, err = consume.Convert(val, id, ctx)
+						if err != nil {
+							errs = errors.Join(errs, err)
+							continue
+						}
+					}
+					delays = append(delays, DelayedConsumption{
+						Value:        val,
+						Resource:     id,
+						PropertyPath: consume.PropertyPath,
+					})
+					continue
+				}
+
+				err = consume.Consume(val, ctx, consumer)
+				if err != nil {
+					errs = errors.Join(errs, err)
+					continue
+				}
+			}
+		}
+	}
+	return delays, errs
+}
+
+func (c *ConsumptionObject) Convert(value any, res construct.ResourceId, ctx DynamicValueContext) (any, error) {
+	if c.Converter == "" {
+		return value, fmt.Errorf("no converter specified")
+	}
+	if c.PropertyPath == "" {
+		return value, fmt.Errorf("no property path specified")
+	}
+	t, err := template.New("config").Funcs(template.FuncMap{
+		"sub": func(a int, b int) int {
+			return a - b
+		},
+	},
+	).Parse(c.Converter)
+	if err != nil {
+		return value, err
+	}
+	buf := new(bytes.Buffer)
+	if err := t.Execute(buf, value); err != nil {
+		return value, err
+	}
+	bstr := strings.TrimSpace(buf.String())
+	val, err := TransformToPropertyValue(res, c.PropertyPath, bstr, ctx, DynamicValueData{Resource: res})
+	if err == nil {
+		return val, nil
+	}
+	return val, nil
+}
+
+func (c *ConsumptionObject) Emit(ctx DynamicValueContext, resource construct.ResourceId) (any, error) {
+	if c.Value == "" {
+		return nil, fmt.Errorf("no value specified")
+	}
+	if c.Model == "" {
+		return nil, fmt.Errorf("no property path specified")
+	}
+	if c.Resource != "" {
+		data := DynamicValueData{Resource: resource}
+		err := ctx.ExecuteDecode(c.Resource, data, resource)
+		if err != nil {
+			return nil, err
+		}
+	}
+	model := ctx.KnowledgeBase.GetModel(c.Model)
+	data := DynamicValueData{Resource: resource}
+	val, err := model.GetObjectValue(c.Value, ctx, data)
+	if err != nil {
+		return nil, err
+	}
+	if err != nil {
+		return val, err
+	}
+	return val, nil
+}
+
+func (c *ConsumptionObject) Consume(val any, ctx DynamicValueContext, resource *construct.Resource) error {
+	var err error
+	if c.Resource != "" {
+		newId := construct.ResourceId{}
+		data := DynamicValueData{Resource: resource.ID}
+		err = ctx.ExecuteDecode(c.Resource, data, &newId)
+		if err != nil {
+			return err
+		}
+		resource, err = ctx.Graph.Vertex(newId)
+		if err != nil {
+			return err
+		}
+	}
+	if c.Converter != "" {
+		val, err = c.Convert(val, resource.ID, ctx)
+		if err != nil {
+			return err
+		}
+	}
+	err = resource.SetProperty(c.PropertyPath, val)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/knowledge_base2/model.go
+++ b/pkg/knowledge_base2/model.go
@@ -8,6 +8,7 @@ type (
 	Model struct {
 		Name       string     `json:"name" yaml:"name"`
 		Properties Properties `json:"properties" yaml:"properties"`
+		Property   *Property  `json:"property" yaml:"property"`
 	}
 )
 
@@ -24,6 +25,9 @@ func updateModels(property *Property, properties Properties, models map[string]*
 			}
 			// We know that this means we want the properties to be spread onto the resource
 			if p.Name == *modelType {
+				if model.Property != nil {
+					return fmt.Errorf("model %s as property can not be spread into properties", *modelType)
+				}
 				delete(properties, name)
 				for name, prop := range model.Properties {
 					// since properties are pointers and models can be reused, we need to clone the property from the model itself
@@ -46,15 +50,20 @@ func updateModels(property *Property, properties Properties, models map[string]*
 					}
 				}
 			} else {
-				p.Properties = models[*modelType].Properties.Clone()
-				modelString := fmt.Sprintf("model(%s)", *modelType)
-				if p.Type == modelString {
-					p.Type = "map"
-				} else if p.Type == fmt.Sprintf("list(%s)", modelString) {
-					p.Type = "list"
-				}
-				if err := updateModelPaths(p); err != nil {
-					return err
+				m := models[*modelType]
+				if m.Properties != nil {
+					p.Properties = models[*modelType].Properties.Clone()
+					modelString := fmt.Sprintf("model(%s)", *modelType)
+					if p.Type == modelString {
+						p.Type = "map"
+					} else if p.Type == fmt.Sprintf("list(%s)", modelString) {
+						p.Type = "list"
+					}
+					if err := updateModelPaths(p); err != nil {
+						return err
+					}
+				} else if m.Property != nil {
+					p = m.Property.Clone()
 				}
 			}
 		}
@@ -75,4 +84,59 @@ func updateModelPaths(p *Property) error {
 		}
 	}
 	return nil
+}
+
+// GetObjectValue returns the value of the object as the model type
+func (m *Model) GetObjectValue(val any, ctx DynamicValueContext, data DynamicValueData) (any, error) {
+
+	GetVal := func(p *Property, val map[string]any) (any, error) {
+		pType, err := p.PropertyType()
+		if err != nil {
+			return nil, err
+		}
+		propVal, found := val[p.Name]
+		if !found {
+			if p.DefaultValue != nil {
+				return p.DefaultValue, nil
+			}
+			return nil, fmt.Errorf("property %s not found", p.Name)
+		}
+
+		return pType.Parse(propVal, ctx, data)
+	}
+	if m.Properties != nil && m.Property != nil {
+		return nil, fmt.Errorf("model has both properties and a property")
+	}
+	if m.Properties == nil && m.Property == nil {
+		return nil, fmt.Errorf("model has neither properties nor a property")
+	}
+
+	var errs error
+	if m.Properties != nil {
+		obj := map[string]any{}
+		for name, prop := range m.Properties {
+			valMap, ok := val.(map[string]any)
+			if !ok {
+				errs = fmt.Errorf("%s\n%s", errs, fmt.Errorf("value for model object is not a map"))
+				continue
+			}
+			val, err := GetVal(prop, valMap)
+			if err != nil {
+				errs = fmt.Errorf("%s\n%s", errs, err.Error())
+				continue
+			}
+			obj[name] = val
+		}
+		return obj, errs
+	} else {
+		pType, err := m.Property.PropertyType()
+		if err != nil {
+			return nil, err
+		}
+		value, err := pType.Parse(val, ctx, data)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
 }

--- a/pkg/knowledge_base2/path_satisfaction.go
+++ b/pkg/knowledge_base2/path_satisfaction.go
@@ -1,0 +1,96 @@
+package knowledgebase2
+
+import (
+	"strings"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	PathSatisfaction struct {
+		AsTarget []PathSatisfactionRoute `json:"as_target" yaml:"as_target"`
+		AsSource []PathSatisfactionRoute `json:"as_source" yaml:"as_source"`
+	}
+
+	PathSatisfactionRoute struct {
+		Classification    string                            `json:"classification" yaml:"classification"`
+		PropertyReference string                            `json:"property_reference" yaml:"property_reference"`
+		Validity          PathSatisfactionValidityOperation `json:"validity" yaml:"validity"`
+	}
+
+	PathSatisfactionValidityOperation string
+)
+
+const (
+	DownstreamOperation PathSatisfactionValidityOperation = "downstream"
+)
+
+func (p *PathSatisfactionRoute) UnmarshalYAML(n *yaml.Node) error {
+	type h PathSatisfactionRoute
+	var p2 h
+	err := n.Decode(&p2)
+	if err != nil {
+		routeString := n.Value
+		routeParts := strings.Split(routeString, "#")
+		p2.Classification = routeParts[0]
+		if len(routeParts) > 1 {
+			p2.PropertyReference = strings.Join(routeParts[1:], "#")
+		}
+		*p = PathSatisfactionRoute(p2)
+		return nil
+	}
+	p2.Validity = PathSatisfactionValidityOperation(strings.ToLower(string(p2.Validity)))
+	*p = PathSatisfactionRoute(p2)
+	return nil
+}
+
+func (kb *KnowledgeBase) GetPathSatisfactionsFromEdge(source, target construct.ResourceId) ([]EdgePathSatisfaction, error) {
+	srcTempalte, err := kb.GetResourceTemplate(source)
+	if err != nil {
+		return nil, err
+	}
+	targetTemplate, err := kb.GetResourceTemplate(target)
+	if err != nil {
+		return nil, err
+	}
+	pathSatisfications := []EdgePathSatisfaction{}
+	trgtsAdded := map[PathSatisfactionRoute]struct{}{}
+
+	for _, src := range srcTempalte.PathSatisfaction.AsSource {
+		srcClassificationHandled := false
+		for _, trgt := range targetTemplate.PathSatisfaction.AsTarget {
+			if trgt.Classification == src.Classification {
+				useSrc := src
+				useTrgt := trgt
+				pathSatisfications = append(pathSatisfications, EdgePathSatisfaction{
+					Classification: src.Classification,
+					Source:         useSrc,
+					Target:         useTrgt,
+				})
+				srcClassificationHandled = true
+				trgtsAdded[trgt] = struct{}{}
+			}
+		}
+		if !srcClassificationHandled {
+			useSrc := src
+			pathSatisfications = append(pathSatisfications, EdgePathSatisfaction{
+				Classification: src.Classification,
+				Source:         useSrc,
+			})
+		}
+	}
+	for _, trgt := range targetTemplate.PathSatisfaction.AsTarget {
+		if _, ok := trgtsAdded[trgt]; !ok {
+			useTrgt := trgt
+			pathSatisfications = append(pathSatisfications, EdgePathSatisfaction{
+				Classification: trgt.Classification,
+				Target:         useTrgt,
+			})
+		}
+	}
+	if len(pathSatisfications) == 0 {
+		pathSatisfications = append(pathSatisfications, EdgePathSatisfaction{})
+	}
+	return pathSatisfications, nil
+}

--- a/pkg/knowledge_base2/path_satisfaction_test.go
+++ b/pkg/knowledge_base2/path_satisfaction_test.go
@@ -1,0 +1,61 @@
+package knowledgebase2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_PathSatisfactionRouteUnmarshalYaml(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected PathSatisfactionRoute
+	}{
+		{
+			name: "as struct with prop ref",
+			yaml: `classification: network
+property_reference: Subnet#AvailabilityZone`,
+			expected: PathSatisfactionRoute{
+				Classification:    "network",
+				PropertyReference: "Subnet#AvailabilityZone",
+			},
+		},
+		{
+			name: "as struct with validity",
+			yaml: `classification: network
+property_reference: Subnet#AvailabilityZone
+validity: downstream`,
+			expected: PathSatisfactionRoute{
+				Classification:    "network",
+				PropertyReference: "Subnet#AvailabilityZone",
+				Validity:          "downstream",
+			},
+		},
+		{
+			name: "as string",
+			yaml: `network#Subnet#AvailabilityZone`,
+			expected: PathSatisfactionRoute{
+				Classification:    "network",
+				PropertyReference: "Subnet#AvailabilityZone",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			p := PathSatisfactionRoute{}
+			node := &yaml.Node{}
+			err := yaml.Unmarshal([]byte(test.yaml), node)
+			assert.NoError(err, "Expected no error")
+			if node.Content[0].Kind == yaml.ScalarNode {
+				err = p.UnmarshalYAML(node.Content[0])
+			} else {
+				err = p.UnmarshalYAML(node)
+			}
+			assert.NoError(err, "Expected no error")
+			assert.Equal(p, test.expected, "Expected unmarshalled yaml to equal expected")
+		})
+	}
+}

--- a/pkg/knowledge_base2/resource_template.go
+++ b/pkg/knowledge_base2/resource_template.go
@@ -31,6 +31,8 @@ type (
 
 		PathSatisfaction PathSatisfaction `json:"path_satisfaction" yaml:"path_satisfaction"`
 
+		Consumption Consumption `json:"consumption" yaml:"consumption"`
+
 		// DeleteContext defines the context in which a resource can be deleted
 		DeleteContext DeleteContext `json:"delete_context" yaml:"delete_context"`
 		// Views defines the views that the resource should be added to as a distinct node
@@ -85,19 +87,6 @@ type (
 		RequiresNoUpstreamOrDownstream bool `yaml:"requires_no_upstream_or_downstream" toml:"requires_no_upstream_or_downstream"`
 	}
 
-	PathSatisfaction struct {
-		AsTarget []PathSatisfactionRoute `json:"as_target" yaml:"as_target"`
-		AsSource []PathSatisfactionRoute `json:"as_source" yaml:"as_source"`
-	}
-
-	PathSatisfactionRoute struct {
-		Classification    string                            `json:"classification" yaml:"classification"`
-		PropertyReference string                            `json:"property_reference" yaml:"property_reference"`
-		Validity          PathSatisfactionValidityOperation `json:"validity" yaml:"validity"`
-	}
-
-	PathSatisfactionValidityOperation string
-
 	Functionality string
 )
 
@@ -108,28 +97,7 @@ const (
 	Api       Functionality = "api"
 	Messaging Functionality = "messaging"
 	Unknown   Functionality = "Unknown"
-
-	DownstreamOperation PathSatisfactionValidityOperation = "downstream"
 )
-
-func (p *PathSatisfactionRoute) UnmarshalYAML(n *yaml.Node) error {
-	type h PathSatisfactionRoute
-	var p2 h
-	err := n.Decode(&p2)
-	if err != nil {
-		routeString := n.Value
-		routeParts := strings.Split(routeString, "#")
-		p2.Classification = routeParts[0]
-		if len(routeParts) > 1 {
-			p2.PropertyReference = strings.Join(routeParts[1:], "#")
-		}
-		*p = PathSatisfactionRoute(p2)
-		return nil
-	}
-	p2.Validity = PathSatisfactionValidityOperation(strings.ToLower(string(p2.Validity)))
-	*p = PathSatisfactionRoute(p2)
-	return nil
-}
 
 func (p *Properties) UnmarshalYAML(n *yaml.Node) error {
 	type h Properties

--- a/pkg/knowledge_base2/resource_template_test.go
+++ b/pkg/knowledge_base2/resource_template_test.go
@@ -22,59 +22,6 @@ var testTemplate = ResourceTemplate{
 	},
 }
 
-func Test_PathSatisfactionRouteUnmarshalYaml(t *testing.T) {
-	tests := []struct {
-		name     string
-		yaml     string
-		expected PathSatisfactionRoute
-	}{
-		{
-			name: "as struct with prop ref",
-			yaml: `classification: network
-property_reference: Subnet#AvailabilityZone`,
-			expected: PathSatisfactionRoute{
-				Classification:    "network",
-				PropertyReference: "Subnet#AvailabilityZone",
-			},
-		},
-		{
-			name: "as struct with validity",
-			yaml: `classification: network
-property_reference: Subnet#AvailabilityZone
-validity: downstream`,
-			expected: PathSatisfactionRoute{
-				Classification:    "network",
-				PropertyReference: "Subnet#AvailabilityZone",
-				Validity:          "downstream",
-			},
-		},
-		{
-			name: "as string",
-			yaml: `network#Subnet#AvailabilityZone`,
-			expected: PathSatisfactionRoute{
-				Classification:    "network",
-				PropertyReference: "Subnet#AvailabilityZone",
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
-			p := PathSatisfactionRoute{}
-			node := &yaml.Node{}
-			err := yaml.Unmarshal([]byte(test.yaml), node)
-			assert.NoError(err, "Expected no error")
-			if node.Content[0].Kind == yaml.ScalarNode {
-				err = p.UnmarshalYAML(node.Content[0])
-			} else {
-				err = p.UnmarshalYAML(node)
-			}
-			assert.NoError(err, "Expected no error")
-			assert.Equal(p, test.expected, "Expected unmarshalled yaml to equal expected")
-		})
-	}
-}
-
 func Test_PropertiesUnmarshalYaml(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/templates/aws/resources/api_stage.yaml
+++ b/pkg/templates/aws/resources/api_stage.yaml
@@ -26,6 +26,9 @@ properties:
     deploy_time: true
 
 classification:
+  is:
+    - cloudfront_origin
+    - api_stage
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -89,6 +89,10 @@ properties:
   DefaultRootObject:
     type: string
 
+path_satisfaction:
+  as_source:
+    - cloudfront_origin
+
 classification:
   is:
     - cdn

--- a/pkg/templates/aws/resources/dynamodb_table.yaml
+++ b/pkg/templates/aws/resources/dynamodb_table.yaml
@@ -63,7 +63,12 @@ classification:
     - high-availability
     - scalable
 
-
+consumption:
+  emitted:
+    - model: EnvironmentVariables
+      value:
+        '{{ .Self.Name }}_TABLE_NAME': '{{ fieldRef "Name" .Self }}'
+    
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -65,6 +65,12 @@ properties:
             - aws:ecs_task_definition:{{ .Self.Name }}
           unique: true
 
+consumption:
+  consumed:
+    - model: EnvironmentVariables
+      property_path: EnvironmentVariables
+      resource: '{{ fieldValue "TaskDefinition" .Self }}'
+
 path_satisfaction:
   as_target:
     - network

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -83,6 +83,11 @@ properties:
           Iam:
             type: string
 
+consumption:
+  consumed:
+    - model: EnvironmentVariables
+      property_path: EnvironmentVariables
+      
 delete_context:
   require_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/lambda_function.yaml
+++ b/pkg/templates/aws/resources/lambda_function.yaml
@@ -79,6 +79,11 @@ path_satisfaction:
     - network#Subnets
     - network    # This is required as well in case the lambda does not already exist in a vpc, we need the path evaluation done in 2 steps
 
+consumption:
+  consumed:
+    - model: EnvironmentVariables
+      property_path: EnvironmentVariables
+
 classification:
   is:
     - serverless

--- a/pkg/templates/aws/resources/rest_api.yaml
+++ b/pkg/templates/aws/resources/rest_api.yaml
@@ -24,6 +24,8 @@ properties:
 path_satisfaction:
   as_source:
     - api_route
+  as_target:
+    - api_stage
 
 classification:
   is:

--- a/pkg/templates/aws/resources/s3_bucket.yaml
+++ b/pkg/templates/aws/resources/s3_bucket.yaml
@@ -1,5 +1,22 @@
 qualified_type_name: aws:s3_bucket
 display_name: S3 Bucket
+sanitize_name:
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+  # Identifiers have these naming constraints:
+  # - Must contain 1–63 alphanumeric characters or hyphens (55 since we reserve 8 for an IaC-appended suffix).
+  # - First character must be a letter.
+  # - Can't end with a hyphen or contain two consecutive hyphens.
+  # - Names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).
+  |
+  {{ . 
+    | replace `^[^[:alpha:]]+` "" 
+    | replace `--+` "-" 
+    | replace `-$` ""
+    | replace `_` "-"
+    | replace `[^[:alnum:]-]+` "-"
+    | length 1 55
+  }}
+
 
 properties:
   ForceDestroy:

--- a/pkg/templates/aws/resources/s3_bucket.yaml
+++ b/pkg/templates/aws/resources/s3_bucket.yaml
@@ -37,6 +37,7 @@ classification:
   is:
     - storage
     - blob
+    - cloudfront_origin
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/kubernetes/models/object_meta.yaml
+++ b/pkg/templates/kubernetes/models/object_meta.yaml
@@ -8,6 +8,6 @@ properties:
   labels:
     type: map(string,string)
     default_value:
-      KLOTHO_ID_LABEL: '{{ .Self.String | replace `[^a-zA-Z0-9-]+` "" | replace `^[-]+` "" | replace `[-]+$` ""   }}'
+      KLOTHO_ID_LABEL: '{{ .Self.Name | replace `[^a-zA-Z0-9-]+` "" | replace `^[-]+` "" | replace `[-]+$` ""   }}'
   annotations:
     type: map(string,string)

--- a/pkg/templates/kubernetes/resources/pod.yaml
+++ b/pkg/templates/kubernetes/resources/pod.yaml
@@ -35,6 +35,22 @@ properties:
       spec:
         type: model(kubernetes:PodSpec)
 
+
+consumption:
+  consumed:
+    - model: EnvironmentVariables
+      property_path: Object.spec.containers[0].env
+      converter: |
+        [
+        {{ $i := 0}}
+        {{ range $key, $value := . }}
+          {
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+          }{{if ne $i (sub (len $) 1)}},{{end}}
+        {{ end }}
+        ]
+
 path_satisfaction:
   as_target:
     - service

--- a/pkg/templates/models/environment_variables.yaml
+++ b/pkg/templates/models/environment_variables.yaml
@@ -1,0 +1,3 @@
+name: EnvironmentVariables
+property:
+  type: map(string,string)

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -8,5 +8,5 @@ var ResourceTemplates embed.FS
 //go:embed */edges/*.yaml
 var EdgeTemplates embed.FS
 
-//go:embed */models/*.yaml  
+//go:embed */models/*.yaml  models/*.yaml
 var Models embed.FS


### PR DESCRIPTION
Adds as source to cloudront and as dest to rest api for correct resolution and topology yaml

visualization fixes to only consider parent(groups) for namespace resources and clusters/network resources

-----------
Introduces emitter and consumer for construct expansion and path selection

kb now stores models to be used for emissions

during path expansion we consume anything from the target which is available and wanted by the src



example for emissions


sample inputs 
```
constraints:
  - node: aws:lambda_function:pets
    operator: add
    scope: application 
  - node: aws:ecs_service:pets2
    operator: add
    scope: application 
  - node: kubernetes:pod:pets3
    operator: add
    scope: application 
  - node: aws:dynamodb_table:store
    operator: add
    scope: application
  - scope: edge
    operator: must_exist
    target:
      source: aws:ecs_service:pets2
      target: aws:dynamodb_table:store
  - scope: edge
    operator: must_exist
    target:
      source: aws:lambda_function:pets
      target: aws:dynamodb_table:store
  - scope: edge
    operator: must_exist
    target:
      source: kubernetes:pod:pets3
      target: aws:dynamodb_table:store
```

sample outputs for relevant consumers
```
    kubernetes:pod:eks_cluster-0:pets3:
        Cluster: aws:eks_cluster:eks_cluster-0
        Object:
            apiVersion: v1
            kind: Pod
            metadata:
                labels:
                    KLOTHO_ID_LABEL: pets3
                name: pets3
            spec:
                automountServiceAccountToken: true
                containers:
                    - env:
                        - name: store_TABLE_NAME
                          value: aws:dynamodb_table:store#Name
                      image: aws:ecr_image:ecr_image-pets3-2#ImageName
                      name: pets3
                      ports:
                        - containerPort: 80
                          hostPort: 80
                          name: default-tcp
                          protocol: TCP
                serviceAccountName: kubernetes:service_account:eks_cluster-0:pets3
    aws:lambda_function:pets:
        EnvironmentVariables:
            store_TABLE_NAME: aws:dynamodb_table:store#Name
        ExecutionRole: aws:iam_role:pets-ExecutionRole
        Image: aws:ecr_image:pets-image
        LogGroup: aws:log_group:pets-log-group
        MemorySize: 512
        SecurityGroups:
            - aws:security_group:vpc-0:security_group-pets-3
        Subnets:
            - aws:subnet:vpc-0:subnet-1
            - aws:subnet:vpc-0:subnet-0
        Timeout: 180
 aws:ecs_task_definition:pets2:
        Cpu: "256"
        EnvironmentVariables:
            store_TABLE_NAME: aws:dynamodb_table:store#Name
        ExecutionRole: aws:iam_role:pets2-execution-role
        Image: aws:ecr_image:pets2-image
        LogGroup: aws:log_group:pets2-log-group
        Memory: "512"
        NetworkMode: awsvpc
        PortMappings:
            - ContainerPort: 80
              HostPort: 80
              Protocol: TCP
        Region: aws:region:region-0
        RequiresCompatibilities:
            - FARGATE
        TaskRole: aws:iam_role:pets2-execution-role
```
### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
