### PR TITLE
add alb support

### DIFF
--- a/pkg/engine2/operational_eval/graph.go
+++ b/pkg/engine2/operational_eval/graph.go
@@ -171,11 +171,8 @@ func (eval *Evaluator) edgeVertices(
 
 func (eval *Evaluator) removeKey(k Key) error {
 	err := graph_addons.RemoveVertexAndEdges(eval.unevaluated, k)
-	if err == nil {
+	if err == nil || errors.Is(err, graph.ErrVertexNotFound) {
 		return graph_addons.RemoveVertexAndEdges(eval.graph, k)
-	} else if errors.Is(err, graph.ErrVertexNotFound) {
-		// the key was already evaluated, leave it in the graph for debugging purposes
-		return nil
 	}
 	return err
 }

--- a/pkg/engine2/operational_rule/operational_configuration.go
+++ b/pkg/engine2/operational_rule/operational_configuration.go
@@ -26,7 +26,7 @@ func (ctx OperationalRuleContext) HandleConfigurationRule(config knowledgebase.C
 			return err
 		}
 		prop := resTempalte.GetProperty(config.Config.Field)
-		if prop != nil && (strings.Contains(prop.Type, "list") || strings.Contains(prop.Type, "set") || strings.Contains(prop.Type, "map")) {
+		if prop != nil && (strings.HasPrefix(prop.Type, "list") || strings.HasPrefix(prop.Type, "set") || strings.HasPrefix(prop.Type, "map")) {
 			action = "add"
 		}
 	}

--- a/pkg/infra/iac3/templates/aws/acm_certificate/factory.ts
+++ b/pkg/infra/iac3/templates/aws/acm_certificate/factory.ts
@@ -1,0 +1,9 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+}
+
+function create(args: Args): aws.acm.Certificate {
+    return new aws.acm.Certificate(args.Name, {})
+}

--- a/pkg/infra/iac3/templates/aws/acm_certificate/package.json
+++ b/pkg/infra/iac3/templates/aws/acm_certificate/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "ami",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/infra/iac3/templates/aws/listener_certificate/factory.ts
+++ b/pkg/infra/iac3/templates/aws/listener_certificate/factory.ts
@@ -1,0 +1,15 @@
+import * as aws from '@pulumi/aws'
+
+interface Args {
+    Name: string
+    Listener: aws.lb.Listener
+    Certificate: aws.acm.Certificate
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.lb.LoadBalancer {
+    return new aws.lb.ListenerCertificate('exampleListenerCertificate', {
+        listenerArn: args.Listener.arn,
+        certificateArn: args.Certificate.arn,
+    })
+}

--- a/pkg/infra/iac3/templates/aws/listener_certificate/package.json
+++ b/pkg/infra/iac3/templates/aws/listener_certificate/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "load_balancer",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/infra/iac3/templates/aws/load_balancer/factory.ts
+++ b/pkg/infra/iac3/templates/aws/load_balancer/factory.ts
@@ -14,7 +14,11 @@ interface Args {
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.lb.LoadBalancer {
     return new aws.lb.LoadBalancer(args.Name, {
-        internal: args.Scheme == 'internal',
+        //TMPL {{- if eq .Scheme "internal" }}
+        internal: true,
+        //TMPL {{- else }}
+        internal: false,
+        //TMPL {{- end }}
         loadBalancerType: args.Type,
         subnets: args.Subnets.map((subnet) => subnet.id),
         //TMPL {{- if .Tags }}
@@ -29,5 +33,15 @@ function create(args: Args): aws.lb.LoadBalancer {
 function properties(object: aws.lb.LoadBalancer, args: Args) {
     return {
         NlbUri: pulumi.interpolate`http://${object.dnsName}`,
+    }
+}
+
+function infraExports(
+    object: ReturnType<typeof create>,
+    args: Args,
+    props: ReturnType<typeof properties>
+) {
+    return {
+        DomainName: object.dnsName,
     }
 }

--- a/pkg/templates/aws/edges/listener_certificate-acm_certificate.yaml
+++ b/pkg/templates/aws/edges/listener_certificate-acm_certificate.yaml
@@ -1,0 +1,11 @@
+source: aws:listener_certificate
+target: aws:acm_certificate
+operational_rules:
+  - configuration_rules:
+      - resource: '{{ .Source }}'
+        configuration:
+          field: Certificate
+          value: '{{ .Target }}'
+          
+unique:
+  source: true

--- a/pkg/templates/aws/edges/listener_certificate-acm_certificate.yaml
+++ b/pkg/templates/aws/edges/listener_certificate-acm_certificate.yaml
@@ -1,11 +1,5 @@
 source: aws:listener_certificate
 target: aws:acm_certificate
-operational_rules:
-  - configuration_rules:
-      - resource: '{{ .Source }}'
-        configuration:
-          field: Certificate
-          value: '{{ .Target }}'
           
 unique:
   source: true

--- a/pkg/templates/aws/edges/load_balancer-load_balancer_listener.yaml
+++ b/pkg/templates/aws/edges/load_balancer-load_balancer_listener.yaml
@@ -1,3 +1,16 @@
 source: aws:load_balancer
 target: aws:load_balancer_listener
 deployment_order_reversed: true
+operational_rules:
+  - if: '{{eq (fieldValue "Type" .Source) "application"}}'
+    configuration_rules:
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Protocol
+          value: HTTP
+  - if: '{{ eq (fieldValue "Type" .Source) "network" }}'
+    configuration_rules:
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Protocol
+          value: TCP

--- a/pkg/templates/aws/edges/load_balancer_listener-listener_certificate.yaml
+++ b/pkg/templates/aws/edges/load_balancer_listener-listener_certificate.yaml
@@ -1,0 +1,13 @@
+source: aws:load_balancer_listener
+target: aws:listener_certificate
+deployment_order_reversed: true
+operational_rules:
+  - configuration_rules:
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Listener
+          value: '{{ .Source }}'
+
+unique:
+  source: true
+  target: true

--- a/pkg/templates/aws/edges/load_balancer_listener-target_group.yaml
+++ b/pkg/templates/aws/edges/load_balancer_listener-target_group.yaml
@@ -2,15 +2,30 @@ source: aws:load_balancer_listener
 target: aws:target_group
 operational_rules:
   - configuration_rules:
-      - resource: '{{ .Source }}'
+      - resource: '{{ .Target }}'
         configuration:
           field: Protocol
-          value: '{{ fieldValue "Protocol" .Target }}'
+          value: '{{ fieldValue "Protocol" .Source }}'
       - resource: '{{ .Source }}'
         configuration:
           field: DefaultActions
           value:
             - TargetGroup: '{{ .Target }}'
               Type: forward
+
+  - if: '{{eq (fieldValue "Protocol" .Source) "HTTPS"}}'
+    steps:
+      - resource: '{{ .Source }}'
+        direction: downstream
+        resources:
+          - aws:listener_certificate
+          
+  - if: '{{ not (layeredDownstream "aws:listener_certificate" .Source "direct").IsZero }}'
+    steps:
+      - resource: '{{ layeredDownstream "aws:listener_certificate" .Source "direct" }}'
+        direction: downstream
+        resources:
+          - aws:acm_certificate
+          
 classification:
   - target

--- a/pkg/templates/aws/edges/load_balancer_listener-target_group.yaml
+++ b/pkg/templates/aws/edges/load_balancer_listener-target_group.yaml
@@ -19,13 +19,6 @@ operational_rules:
         direction: downstream
         resources:
           - aws:listener_certificate
-          
-  - if: '{{ not (layeredDownstream "aws:listener_certificate" .Source "direct").IsZero }}'
-    steps:
-      - resource: '{{ layeredDownstream "aws:listener_certificate" .Source "direct" }}'
-        direction: downstream
-        resources:
-          - aws:acm_certificate
-          
+
 classification:
   - target

--- a/pkg/templates/aws/edges/security_group-load_balancer.yaml
+++ b/pkg/templates/aws/edges/security_group-load_balancer.yaml
@@ -1,3 +1,16 @@
 source: aws:security_group
 target: aws:load_balancer
 deployment_order_reversed: true
+operational_rules:
+  - if: '{{ eq (fieldValue "Scheme" .Target) "internet-facing"}}'
+    configuration_rules:
+      - resource: '{{ .Source }}'
+        configuration:
+          field: IngressRules
+          value:
+            - Description: Allow ingress traffic from within the same security group
+              FromPort: 0
+              Protocol: '-1'
+              ToPort: 0
+              CidrBlocks:
+                - 0.0.0.0/0

--- a/pkg/templates/aws/resources/acm_certificate.yaml
+++ b/pkg/templates/aws/resources/acm_certificate.yaml
@@ -1,9 +1,9 @@
-qualified_type_name: aws:ami
-display_name: AMI
+qualified_type_name: aws:acm_certificate
+display_name: ACM Certificate
 
 classification:
   is:
-    - machine_image
+    - certificate
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -89,6 +89,6 @@ consumption:
       property_path: EnvironmentVariables
       
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: small

--- a/pkg/templates/aws/resources/listener_certificate.yaml
+++ b/pkg/templates/aws/resources/listener_certificate.yaml
@@ -4,12 +4,17 @@ display_name: Listener Certificate
 properties:
   Certificate:
     type: resource(aws:acm_certificate)
+    operational_rule:
+      steps:
+        - direction: downstream
+          resources:
+            - aws:acm_certificate
     required: true
   Listener:
     type: resource(aws:load_balancer_listener)
     required: true
 
-    
+
 delete_context:
   requires_no_upstream_or_downstream: true
 views:

--- a/pkg/templates/aws/resources/listener_certificate.yaml
+++ b/pkg/templates/aws/resources/listener_certificate.yaml
@@ -1,0 +1,16 @@
+qualified_type_name: aws:listener_certificate
+display_name: Listener Certificate
+
+properties:
+  Certificate:
+    type: resource(aws:acm_certificate)
+    required: true
+  Listener:
+    type: resource(aws:load_balancer_listener)
+    required: true
+
+    
+delete_context:
+  requires_no_upstream_or_downstream: true
+views:
+  dataflow: small

--- a/pkg/templates/aws/resources/load_balancer.yaml
+++ b/pkg/templates/aws/resources/load_balancer.yaml
@@ -32,9 +32,10 @@ properties:
     operational_rule:
       if: '{{ fieldValue "Scheme" .Self | eq "internet-facing" }}'
       steps:
-        - direction: downstream
+        - direction: upstream
           resources:
             - aws:security_group
+          unique: true
   Subnets:
     type: list(resource(aws:subnet))
     operational_rule:

--- a/pkg/templates/aws/resources/load_balancer.yaml
+++ b/pkg/templates/aws/resources/load_balancer.yaml
@@ -29,6 +29,12 @@ properties:
     # which is required for secure connectivity from an API Gateway VPC Link.
     # See: https://github.com/hashicorp/terraform-provider-aws/pull/33767
     type: list(resource(aws:security_group))
+    operational_rule:
+      if: '{{ fieldValue "Scheme" .Self | eq "internet-facing" }}'
+      steps:
+        - direction: downstream
+          resources:
+            - aws:security_group
   Subnets:
     type: list(resource(aws:subnet))
     operational_rule:
@@ -37,8 +43,12 @@ properties:
           resources:
             - selector: aws:subnet
               properties:
-                Type: private
-            - aws:subnet
+                Type: |
+                  {{- if eq (fieldValue "Scheme" .Self) "internet-facing"}}
+                    public
+                  {{- else}}
+                    private
+                  {{- end}}
           num_needed: 2
   Tags:
     type: map(string,string)

--- a/pkg/templates/aws/resources/load_balancer_listener.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener.yaml
@@ -7,7 +7,6 @@ properties:
     default_value: 80
   Protocol:
     type: string
-    default_value: TCP
   LoadBalancer:
     type: resource(aws:load_balancer)
     default_value: '{{ upstream "aws:load_balancer" .Self }}'

--- a/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
@@ -1,0 +1,31 @@
+qualified_type_name: aws:load_balancer_listener_rule
+display_name: Listener Rule
+
+properties:
+  Actions:
+    type: list
+    properties:
+      Type:
+        type: string
+        default_value: forward
+      TargetGroup:
+        type: resource(aws:target_group)
+        default_value: '{{ downstream "aws:target_group" .Self }}'
+  Conditions:
+    type: list
+    properties:
+      PathPattern:
+        type: list(string)
+        default_value: path-pattern
+      HttpRequestMethod:
+        type: list(string)
+  Listener:
+    type: resource(aws:load_balancer_listener)
+    default_value: '{{ upstream "aws:load_balancer" .Self }}'
+  Priority:
+    type: int
+
+delete_context:
+  requires_no_upstream_or_downstream: true
+views:
+  dataflow: small

--- a/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
@@ -21,7 +21,7 @@ properties:
         type: list(string)
   Listener:
     type: resource(aws:load_balancer_listener)
-    default_value: '{{ upstream "aws:load_balancer" .Self }}'
+    default_value: '{{ upstream "aws:load_balancer_listener" .Self }}'
   Priority:
     type: int
 

--- a/pkg/templates/aws/resources/private_dns_namespace.yaml
+++ b/pkg/templates/aws/resources/private_dns_namespace.yaml
@@ -15,7 +15,7 @@ classification:
     - service_discovery
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 
 views:
   dataflow: small

--- a/pkg/templates/aws/resources/rds_instance.yaml
+++ b/pkg/templates/aws/resources/rds_instance.yaml
@@ -34,7 +34,7 @@ properties:
           unique: true
   DatabaseName:
     type: string
-    default_value: '{{ .Self.Name }}'
+    default_value: main
   IamDatabaseAuthenticationEnabled:
     type: bool
     default_value: true

--- a/pkg/templates/aws/resources/region.yaml
+++ b/pkg/templates/aws/resources/region.yaml
@@ -2,4 +2,4 @@ qualified_type_name: aws:region
 display_name: Region
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true

--- a/pkg/templates/aws/resources/ses_email_identity.yaml
+++ b/pkg/templates/aws/resources/ses_email_identity.yaml
@@ -20,6 +20,6 @@ path_satisfaction:
     - permissions
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: big

--- a/pkg/templates/aws/resources/subnet.yaml
+++ b/pkg/templates/aws/resources/subnet.yaml
@@ -60,4 +60,4 @@ classification:
     - network
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true

--- a/pkg/templates/aws/resources/target_group.yaml
+++ b/pkg/templates/aws/resources/target_group.yaml
@@ -19,7 +19,6 @@ properties:
     default_value: 80
   Protocol:
     type: string
-    default_value: TCP
   Vpc:
     type: resource(aws:vpc)
     default_value: '{{ closestDownstream "aws:vpc" .Self }}'

--- a/pkg/templates/aws/resources/vpc_endpoint.yaml
+++ b/pkg/templates/aws/resources/vpc_endpoint.yaml
@@ -35,6 +35,6 @@ classification:
     - private_network
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: small

--- a/pkg/templates/kubernetes/resources/kustomize_directory.yaml
+++ b/pkg/templates/kubernetes/resources/kustomize_directory.yaml
@@ -16,6 +16,6 @@ properties:
     type: string
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: small

--- a/pkg/templates/kubernetes/resources/manifest.yaml
+++ b/pkg/templates/kubernetes/resources/manifest.yaml
@@ -26,6 +26,6 @@ properties:
                 - kubernetes
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: small

--- a/pkg/templates/kubernetes/resources/service_account.yaml
+++ b/pkg/templates/kubernetes/resources/service_account.yaml
@@ -43,6 +43,6 @@ classification:
     - permissions
 
 delete_context:
-  require_no_upstream: true
+  requires_no_upstream: true
 views:
   dataflow: small


### PR DESCRIPTION
adds support for configuring load balancers as application load balancers

- ensures we remove dependencies when clearing properties
- polls the ready vertices in operational eval in case the ready vertices in teh list are deleted or mutated during an earlier evaluation

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
