### PR TITLE
Create an overall engine test with a few seed inputs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 gen/
 compiled*/
+pkg/engine2/testdata/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean_debug:
 
 .PHONY: engine_test
 engine_test:
-	KLOTHO_TEST_ENGINE=y go test -v -timeout 1m -run '^TestEngine$$' ./pkg/engine2
+	go test -v -timeout 1m -run '^TestEngine$$' ./pkg/engine2
 
 .PHONY: regen_tests
 regen_tests:

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,12 @@ iac: $(GO_FILES) $(IAC_TEMPLATES)
 .PHONY: clean_debug
 clean_debug:
 	find . \( -name '*.gv' -or -name '*.gv.svg' \) -delete
+
+
+.PHONY: engine_test
+engine_test:
+	KLOTHO_TEST_ENGINE=y go test -v -timeout 1m -run '^TestEngine$$' ./pkg/engine2
+
+.PHONY: regen_tests
+regen_tests:
+	find pkg/engine2/testdata -type f -name '*.input.yaml' -exec ./create_test.sh {} \;

--- a/create_test.sh
+++ b/create_test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+out_dir=$(mktemp -d)
+export KLOTHO_DEBUG_DIR=$out_dir/debug
+mkdir -p $KLOTHO_DEBUG_DIR
+
+name=$(basename $1)
+name=${name%.*}
+name=${name%.input}
+
+echo "Running $name"
+
+# Run the engine
+go run ./cmd/engine Run \
+  -i "$1" \
+  -c "$1" \
+  -o "$out_dir" > $out_dir/out.log 2> $out_dir/err.log
+
+echo "Successfully ran $name, copying results to testdata"
+
+test_dir="pkg/engine2/testdata"
+
+if [ ! "$test_dir/$name.input.yaml" -ef "$1" ]; then
+  cp $1 "$test_dir/$name.input.yaml"
+fi
+
+cp "$out_dir/resources.yaml" "$test_dir/$name.expect.yaml"
+cp "$out_dir/dataflow-topology.yaml" "$test_dir/$name.dataflow-viz.yaml"
+cp "$out_dir/iac-topology.yaml" "$test_dir/$name.iac-viz.yaml"
+
+rm -rf $out_dir

--- a/pkg/engine2/.gitignore
+++ b/pkg/engine2/.gitignore
@@ -1,0 +1,1 @@
+/test_debug/

--- a/pkg/engine2/engine_test.go
+++ b/pkg/engine2/engine_test.go
@@ -1,0 +1,137 @@
+package engine2
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestEngine(t *testing.T) {
+	os.Setenv("KLOTHO_DEBUG_DIR", "test_debug")
+	if err := os.MkdirAll("test_debug", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests, err := filepath.Glob(filepath.Join("testdata", "*.input.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range tests {
+		tc := engineTestCase{inputPath: p}
+		t.Run(filepath.Base(p), tc.Test)
+	}
+}
+
+type engineTestCase struct {
+	inputPath string
+}
+
+func (tc engineTestCase) readGraph(t *testing.T, f io.Reader) FileFormat {
+	t.Helper()
+	var ff FileFormat
+	err := yaml.NewDecoder(f).Decode(&ff)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to read graph: %w", err))
+	}
+	return ff
+}
+
+func (tc engineTestCase) Test(t *testing.T) {
+	t.Parallel()
+	inputYaml, err := os.Open(tc.inputPath)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to open input file: %w", err))
+	}
+	defer inputYaml.Close()
+	expectYaml, err := os.Open(strings.Replace(tc.inputPath, ".input.yaml", ".expect.yaml", 1))
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to open expected output file: %w", err))
+	}
+	defer expectYaml.Close()
+
+	inputFile := tc.readGraph(t, inputYaml)
+	expectContent, err := io.ReadAll(expectYaml)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to read expected output file: %w", err))
+	}
+
+	main := EngineMain{}
+	err = main.AddEngine()
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to add engine: %w", err))
+	}
+	context := &EngineContext{
+		Constraints:  inputFile.Constraints,
+		InitialState: inputFile.Graph,
+	}
+	err = main.Engine.Run(context)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to run engine: %w", err))
+	}
+
+	sol := context.Solutions[0]
+	actualContent, err := yaml.Marshal(construct.YamlGraph{Graph: sol.DataflowGraph()})
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to marshal actual output: %w", err))
+	}
+
+	assert.Equal(t, string(expectContent), string(actualContent))
+
+	// Always visualize views even if we're not testing them to make sure that it at least succeeds
+	vizFiles, err := main.Engine.VisualizeViews(sol)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to generate views: %w", err))
+	}
+
+	iacVizFile, err := os.Open(strings.Replace(tc.inputPath, ".input.yaml", ".iac-viz.yaml", 1))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(fmt.Errorf("failed to open iac viz file: %w", err))
+	}
+	if iacVizFile != nil {
+		defer iacVizFile.Close()
+	}
+
+	dataflowVizFile, err := os.Open(strings.Replace(tc.inputPath, ".input.yaml", ".dataflow-viz.yaml", 1))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(fmt.Errorf("failed to open dataflow viz file: %w", err))
+	}
+	if dataflowVizFile != nil {
+		defer dataflowVizFile.Close()
+	}
+	if iacVizFile == nil && dataflowVizFile == nil {
+		return
+	}
+
+	buf := new(bytes.Buffer)
+
+	for _, f := range vizFiles {
+		buf.Reset()
+		_, err := f.WriteTo(buf)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed to write viz file %s: %w", f.Path(), err))
+		}
+		if strings.HasPrefix(f.Path(), "iac-") && iacVizFile != nil {
+			iacExpect, err := io.ReadAll(iacVizFile)
+			if err != nil {
+				t.Error(fmt.Errorf("failed to read iac viz file: %w", err))
+			} else {
+				assert.Equal(t, string(iacExpect), buf.String(), "IaC topology")
+			}
+		} else if strings.HasPrefix(f.Path(), "dataflow-") && dataflowVizFile != nil {
+			dataflowExpect, err := io.ReadAll(dataflowVizFile)
+			if err != nil {
+				t.Error(fmt.Errorf("failed to read dataflow viz file: %w", err))
+			} else {
+				assert.Equal(t, string(dataflowExpect), buf.String(), "dataflow topology")
+			}
+		}
+	}
+}

--- a/pkg/engine2/operational_eval/debug.go
+++ b/pkg/engine2/operational_eval/debug.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/dominikbraun/graph"
@@ -38,6 +39,9 @@ func PrintGraph(g Graph) {
 }
 
 func (eval *Evaluator) writeGraph(prefix string) {
+	if debugDir := os.Getenv("KLOTHO_DEBUG_DIR"); debugDir != "" {
+		prefix = filepath.Join(debugDir, prefix)
+	}
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {

--- a/pkg/engine2/operational_eval/dot.go
+++ b/pkg/engine2/operational_eval/dot.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"strings"
 
-	construct "github.com/klothoplatform/klotho/pkg/construct2"
 	"github.com/klothoplatform/klotho/pkg/dot"
-	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base2"
 )
 
 const (
@@ -21,14 +19,21 @@ const (
 func keyAttributes(eval *Evaluator, key Key) map[string]string {
 	attribs := make(map[string]string)
 	var style []string
-	if !key.Ref.Resource.IsZero() {
+	switch key.keyType() {
+	case keyTypeProperty:
 		attribs["label"] = fmt.Sprintf(`%s\n#%s`, key.Ref.Resource, key.Ref.Property)
 		attribs["shape"] = "box"
-	} else if key.GraphState != "" {
+
+	case keyTypeEdge:
+		attribs["label"] = fmt.Sprintf(`%s\n→ %s`, key.Edge.Source, key.Edge.Target)
+		attribs["shape"] = "parallelogram"
+
+	case keyTypeGraphState:
 		attribs["label"] = string(key.GraphState)
 		attribs["shape"] = "box"
 		style = append(style, "dashed")
-	} else if key.PathSatisfication != (knowledgebase.EdgePathSatisfaction{}) {
+
+	case keyTypePathExpand:
 		attribs["label"] = fmt.Sprintf(`%s\n→ %s`, key.Edge.Source, key.Edge.Target)
 		var extra []string
 		if key.PathSatisfication.Classification != "" {
@@ -46,13 +51,7 @@ func keyAttributes(eval *Evaluator, key Key) map[string]string {
 
 		attribs["shape"] = "parallelogram"
 		style = append(style, "dashed")
-	} else if key.Edge != (construct.SimpleEdge{}) {
-		attribs["label"] = fmt.Sprintf(`%s\n→ %s`, key.Edge.Source, key.Edge.Target)
-		attribs["shape"] = "parallelogram"
-	} else if key.Internal != "" {
-		attribs["label"] = fmt.Sprintf(`|%s|`, key.Internal)
-		attribs["shape"] = "polygon"
-	} else {
+	default:
 		attribs["label"] = fmt.Sprintf(`%s\n(UNKOWN)`, key)
 		attribs["color"] = "#fc8803"
 	}

--- a/pkg/engine2/path_selection/debug.go
+++ b/pkg/engine2/path_selection/debug.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	construct "github.com/klothoplatform/klotho/pkg/construct2"
@@ -20,14 +21,19 @@ import (
 var seenFiles = make(set.Set[string])
 
 func writeGraph(input ExpansionInput, working, result construct.Graph) {
-	err := os.Mkdir("selection", 0755)
+	dir := "selection"
+	if debugDir := os.Getenv("KLOTHO_DEBUG_DIR"); debugDir != "" {
+		dir = filepath.Join(debugDir, "selection")
+	}
+	err := os.MkdirAll(dir, 0755)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		zap.S().Warnf("Could not create folder for selection diagram: %v", err)
 		return
 	}
 
-	fprefix := fmt.Sprintf("selection/%s-%s", input.Dep.Source.ID, input.Dep.Target.ID)
+	fprefix := fmt.Sprintf("%s-%s", input.Dep.Source.ID, input.Dep.Target.ID)
 	fprefix = strings.ReplaceAll(fprefix, ":", "_") // some filesystems (NTFS) don't like colons in filenames
+	fprefix = filepath.Join(dir, fprefix)
 
 	f, err := os.OpenFile(fprefix+".gv", os.O_RDWR|os.O_CREATE, 0755)
 	if err != nil {

--- a/pkg/engine2/testdata/2_routes.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/2_routes.dataflow-viz.yaml
@@ -1,0 +1,26 @@
+provider: aws
+resources:
+  lambda_function/lambda_function_1:
+    children: aws:ecr_image:lambda_function_1-image,aws:iam_role:lambda_function_1-ExecutionRole,aws:log_group:lambda_function_1-log-group
+
+
+  lambda_function/lambda_function_0:
+    children: aws:ecr_image:lambda_function_0-image,aws:iam_role:lambda_function_0-ExecutionRole,aws:log_group:lambda_function_0-log-group
+
+
+  rest_api/rest_api_1:
+
+  aws:api_integration:rest_api_1/integ1:
+    parent: rest_api/rest_api_1
+
+  aws:api_integration:rest_api_1/integ1 -> lambda_function/lambda_function_1:
+    path: aws:lambda_permission:integ1-lambda_function_1
+
+
+  aws:api_integration:rest_api_1/integ0:
+    parent: rest_api/rest_api_1
+
+  aws:api_integration:rest_api_1/integ0 -> lambda_function/lambda_function_0:
+    path: aws:lambda_permission:integ0-lambda_function_0
+
+

--- a/pkg/engine2/testdata/2_routes.expect.yaml
+++ b/pkg/engine2/testdata/2_routes.expect.yaml
@@ -1,0 +1,171 @@
+resources:
+    aws:api_stage:rest_api_1:api_stage-0:
+        Deployment: aws:api_deployment:rest_api_1:api_deployment-0
+        RestApi: aws:rest_api:rest_api_1
+        StageName: stage
+    aws:api_deployment:rest_api_1:api_deployment-0:
+        RestApi: aws:rest_api:rest_api_1
+        Triggers:
+            api_method-0: api_method-0
+            api_method-1: api_method-1
+            integ0: integ0
+            integ1: integ1
+    aws:rest_api:rest_api_1:
+        BinaryMediaTypes:
+            - application/octet-stream
+            - image/*
+        Stages:
+            - aws:api_stage:rest_api_1:api_stage-0
+    aws:api_resource:rest_api_1:lambda0:
+        FullPath: /lambda0
+        PathPart: lambda0
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_resource:rest_api_1:lambda1:
+        FullPath: /lambda1
+        PathPart: lambda1
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_resource:rest_api_1:api_resource-0:
+        FullPath: /lambda0/api
+        ParentResource: aws:api_resource:rest_api_1:lambda0
+        PathPart: api
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_resource:rest_api_1:api_resource-1:
+        FullPath: /lambda1/api
+        ParentResource: aws:api_resource:rest_api_1:lambda1
+        PathPart: api
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_method:rest_api_1:api_method-0:
+        Authorization: NONE
+        HttpMethod: ANY
+        RequestParameters: {}
+        Resource: aws:api_resource:rest_api_1:api_resource-0
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_method:rest_api_1:api_method-1:
+        Authorization: NONE
+        HttpMethod: ANY
+        RequestParameters: {}
+        Resource: aws:api_resource:rest_api_1:api_resource-1
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_integration:rest_api_1:integ0:
+        IntegrationHttpMethod: POST
+        Method: aws:api_method:rest_api_1:api_method-0
+        RequestParameters: {}
+        Resource: aws:api_resource:rest_api_1:api_resource-0
+        RestApi: aws:rest_api:rest_api_1
+        Route: /lambda0/api
+        Target: aws:lambda_function:lambda_function_0
+        Type: AWS_PROXY
+        Uri: aws:lambda_function:lambda_function_0#LambdaIntegrationUri
+    aws:api_integration:rest_api_1:integ1:
+        IntegrationHttpMethod: POST
+        Method: aws:api_method:rest_api_1:api_method-1
+        RequestParameters: {}
+        Resource: aws:api_resource:rest_api_1:api_resource-1
+        RestApi: aws:rest_api:rest_api_1
+        Route: /lambda1/api
+        Target: aws:lambda_function:lambda_function_1
+        Type: AWS_PROXY
+        Uri: aws:lambda_function:lambda_function_1#LambdaIntegrationUri
+    aws:lambda_permission:integ0-lambda_function_0:
+        Action: lambda:InvokeFunction
+        Function: aws:lambda_function:lambda_function_0
+        Principal: apigateway.amazonaws.com
+        Source: aws:rest_api:rest_api_1#ChildResources
+    aws:lambda_permission:integ1-lambda_function_1:
+        Action: lambda:InvokeFunction
+        Function: aws:lambda_function:lambda_function_1
+        Principal: apigateway.amazonaws.com
+        Source: aws:rest_api:rest_api_1#ChildResources
+    aws:lambda_function:lambda_function_0:
+        ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
+        Image: aws:ecr_image:lambda_function_0-image
+        LogGroup: aws:log_group:lambda_function_0-log-group
+        MemorySize: 512
+        Timeout: 180
+    aws:lambda_function:lambda_function_1:
+        ExecutionRole: aws:iam_role:lambda_function_1-ExecutionRole
+        Image: aws:ecr_image:lambda_function_1-image
+        LogGroup: aws:log_group:lambda_function_1-log-group
+        MemorySize: 512
+        Timeout: 180
+    aws:ecr_image:lambda_function_0-image:
+        Context: .
+        Dockerfile: lambda_function_0-image.Dockerfile
+        Repo: aws:ecr_repo:ecr_repo-0
+    aws:iam_role:lambda_function_0-ExecutionRole:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Principal:
+                    Service:
+                        - lambda.amazonaws.com
+            Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
+    aws:ecr_image:lambda_function_1-image:
+        Context: .
+        Dockerfile: lambda_function_1-image.Dockerfile
+        Repo: aws:ecr_repo:ecr_repo-0
+    aws:iam_role:lambda_function_1-ExecutionRole:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Principal:
+                    Service:
+                        - lambda.amazonaws.com
+            Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    aws:log_group:lambda_function_0-log-group:
+        LogGroupName: /aws/lambda/lambda_function_0
+        RetentionInDays: 5
+    aws:ecr_repo:ecr_repo-0:
+        ForceDelete: true
+    aws:log_group:lambda_function_1-log-group:
+        LogGroupName: /aws/lambda/lambda_function_1
+        RetentionInDays: 5
+edges:
+    aws:api_stage:rest_api_1:api_stage-0 -> aws:api_deployment:rest_api_1:api_deployment-0:
+    aws:api_stage:rest_api_1:api_stage-0 -> aws:rest_api:rest_api_1:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_integration:rest_api_1:integ0:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_integration:rest_api_1:integ1:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_method:rest_api_1:api_method-0:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_method:rest_api_1:api_method-1:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:rest_api:rest_api_1:
+    aws:rest_api:rest_api_1 -> aws:api_integration:rest_api_1:integ0:
+    aws:rest_api:rest_api_1 -> aws:api_integration:rest_api_1:integ1:
+    aws:rest_api:rest_api_1 -> aws:api_method:rest_api_1:api_method-0:
+    aws:rest_api:rest_api_1 -> aws:api_method:rest_api_1:api_method-1:
+    aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:api_resource-0:
+    aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:api_resource-1:
+    aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:lambda0:
+    aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:lambda1:
+    aws:api_resource:rest_api_1:lambda0 -> aws:api_resource:rest_api_1:api_resource-0:
+    aws:api_resource:rest_api_1:lambda1 -> aws:api_resource:rest_api_1:api_resource-1:
+    aws:api_resource:rest_api_1:api_resource-0 -> aws:api_integration:rest_api_1:integ0:
+    aws:api_resource:rest_api_1:api_resource-0 -> aws:api_method:rest_api_1:api_method-0:
+    aws:api_resource:rest_api_1:api_resource-1 -> aws:api_integration:rest_api_1:integ1:
+    aws:api_resource:rest_api_1:api_resource-1 -> aws:api_method:rest_api_1:api_method-1:
+    aws:api_method:rest_api_1:api_method-0 -> aws:api_integration:rest_api_1:integ0:
+    aws:api_method:rest_api_1:api_method-1 -> aws:api_integration:rest_api_1:integ1:
+    aws:api_integration:rest_api_1:integ0 -> aws:lambda_permission:integ0-lambda_function_0:
+    aws:api_integration:rest_api_1:integ1 -> aws:lambda_permission:integ1-lambda_function_1:
+    aws:lambda_permission:integ0-lambda_function_0 -> aws:lambda_function:lambda_function_0:
+    aws:lambda_permission:integ1-lambda_function_1 -> aws:lambda_function:lambda_function_1:
+    aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
+    aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:
+    aws:lambda_function:lambda_function_0 -> aws:iam_role:lambda_function_0-ExecutionRole:
+    aws:lambda_function:lambda_function_1 -> aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
+    aws:lambda_function:lambda_function_1 -> aws:ecr_image:lambda_function_1-image:
+    aws:lambda_function:lambda_function_1 -> aws:iam_role:lambda_function_1-ExecutionRole:
+    aws:ecr_image:lambda_function_0-image -> aws:ecr_repo:ecr_repo-0:
+    aws:iam_role:lambda_function_0-ExecutionRole -> aws:log_group:lambda_function_0-log-group:
+    aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group -> aws:log_group:lambda_function_0-log-group:
+    aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group -> aws:log_group:lambda_function_1-log-group:
+    aws:ecr_image:lambda_function_1-image -> aws:ecr_repo:ecr_repo-0:
+    aws:iam_role:lambda_function_1-ExecutionRole -> aws:log_group:lambda_function_1-log-group:

--- a/pkg/engine2/testdata/2_routes.iac-viz.yaml
+++ b/pkg/engine2/testdata/2_routes.iac-viz.yaml
@@ -1,0 +1,81 @@
+provider: aws
+resources:
+  rest_api/rest_api_1:
+
+  ecr_repo/ecr_repo-0:
+
+  log_group/lambda_function_0-log-group:
+
+  log_group/lambda_function_1-log-group:
+
+  aws:api_resource:rest_api_1/lambda0:
+  aws:api_resource:rest_api_1/lambda0 -> rest_api/rest_api_1:
+
+  ecr_image/lambda_function_0-image:
+  ecr_image/lambda_function_0-image -> ecr_repo/ecr_repo-0:
+
+  iam_role/lambda_function_0-executionrole:
+  iam_role/lambda_function_0-executionrole -> log_group/lambda_function_0-log-group:
+
+  aws:api_resource:rest_api_1/lambda1:
+  aws:api_resource:rest_api_1/lambda1 -> rest_api/rest_api_1:
+
+  ecr_image/lambda_function_1-image:
+  ecr_image/lambda_function_1-image -> ecr_repo/ecr_repo-0:
+
+  iam_role/lambda_function_1-executionrole:
+  iam_role/lambda_function_1-executionrole -> log_group/lambda_function_1-log-group:
+
+  aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_resource:rest_api_1/api_resource-0 -> aws:api_resource:rest_api_1/lambda0:
+  aws:api_resource:rest_api_1/api_resource-0 -> rest_api/rest_api_1:
+
+  lambda_function/lambda_function_0:
+  lambda_function/lambda_function_0 -> ecr_image/lambda_function_0-image:
+  lambda_function/lambda_function_0 -> iam_role/lambda_function_0-executionrole:
+
+  aws:api_resource:rest_api_1/api_resource-1:
+  aws:api_resource:rest_api_1/api_resource-1 -> aws:api_resource:rest_api_1/lambda1:
+  aws:api_resource:rest_api_1/api_resource-1 -> rest_api/rest_api_1:
+
+  lambda_function/lambda_function_1:
+  lambda_function/lambda_function_1 -> ecr_image/lambda_function_1-image:
+  lambda_function/lambda_function_1 -> iam_role/lambda_function_1-executionrole:
+
+  aws:api_method:rest_api_1/api_method-0:
+  aws:api_method:rest_api_1/api_method-0 -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_method:rest_api_1/api_method-0 -> rest_api/rest_api_1:
+
+  lambda_permission/integ0-lambda_function_0:
+  lambda_permission/integ0-lambda_function_0 -> lambda_function/lambda_function_0:
+
+  aws:api_method:rest_api_1/api_method-1:
+  aws:api_method:rest_api_1/api_method-1 -> aws:api_resource:rest_api_1/api_resource-1:
+  aws:api_method:rest_api_1/api_method-1 -> rest_api/rest_api_1:
+
+  lambda_permission/integ1-lambda_function_1:
+  lambda_permission/integ1-lambda_function_1 -> lambda_function/lambda_function_1:
+
+  aws:api_integration:rest_api_1/integ0:
+  aws:api_integration:rest_api_1/integ0 -> aws:api_method:rest_api_1/api_method-0:
+  aws:api_integration:rest_api_1/integ0 -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_integration:rest_api_1/integ0 -> lambda_permission/integ0-lambda_function_0:
+  aws:api_integration:rest_api_1/integ0 -> rest_api/rest_api_1:
+
+  aws:api_integration:rest_api_1/integ1:
+  aws:api_integration:rest_api_1/integ1 -> aws:api_method:rest_api_1/api_method-1:
+  aws:api_integration:rest_api_1/integ1 -> aws:api_resource:rest_api_1/api_resource-1:
+  aws:api_integration:rest_api_1/integ1 -> lambda_permission/integ1-lambda_function_1:
+  aws:api_integration:rest_api_1/integ1 -> rest_api/rest_api_1:
+
+  aws:api_deployment:rest_api_1/api_deployment-0:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_integration:rest_api_1/integ0:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_integration:rest_api_1/integ1:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_method:rest_api_1/api_method-0:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_method:rest_api_1/api_method-1:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> rest_api/rest_api_1:
+
+  aws:api_stage:rest_api_1/api_stage-0:
+  aws:api_stage:rest_api_1/api_stage-0 -> aws:api_deployment:rest_api_1/api_deployment-0:
+  aws:api_stage:rest_api_1/api_stage-0 -> rest_api/rest_api_1:
+

--- a/pkg/engine2/testdata/2_routes.input.yaml
+++ b/pkg/engine2/testdata/2_routes.input.yaml
@@ -1,0 +1,48 @@
+constraints:
+  - node: aws:rest_api:rest_api_1
+    operator: add
+    scope: application
+  # lambda 0
+  - node: aws:lambda_function:lambda_function_0
+    operator: add
+    scope: application
+  - node: aws:api_integration:rest_api_1:integ0
+    operator: add
+    scope: application
+  - operator: must_exist
+    scope: edge
+    target:
+      source: aws:rest_api:rest_api_1
+      target: aws:api_integration:rest_api_1:integ0
+  - operator: equals
+    property: Route
+    scope: resource
+    target: aws:api_integration:rest_api_1:integ0
+    value: /lambda0/api
+  - operator: must_exist
+    scope: edge
+    target:
+      source: aws:api_integration:rest_api_1:integ0
+      target: aws:lambda_function:lambda_function_0
+  # lambda 1
+  - node: aws:lambda_function:lambda_function_1
+    operator: add
+    scope: application
+  - node: aws:api_integration:rest_api_1:integ1
+    operator: add
+    scope: application
+  - operator: must_exist
+    scope: edge
+    target:
+      source: aws:rest_api:rest_api_1
+      target: aws:api_integration:rest_api_1:integ1
+  - operator: equals
+    property: Route
+    scope: resource
+    target: aws:api_integration:rest_api_1:integ1
+    value: /lambda1/api
+  - operator: must_exist
+    scope: edge
+    target:
+      source: aws:api_integration:rest_api_1:integ1
+      target: aws:lambda_function:lambda_function_1

--- a/pkg/engine2/testdata/extend_graph.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/extend_graph.dataflow-viz.yaml
@@ -1,0 +1,17 @@
+provider: aws
+resources:
+  lambda_function/lambda_function_0:
+    children: aws:ecr_image:lambda_function_0-image,aws:iam_role:lambda_function_0-ExecutionRole,aws:log_group:lambda_function_0-log-group
+
+
+  rest_api/rest_api_1:
+
+  dynamodb_table/dynamodb_table_3:
+
+  aws:api_integration:rest_api_1/rest_api_1_integration_0:
+    parent: rest_api/rest_api_1
+
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> lambda_function/lambda_function_0:
+    path: aws:lambda_permission:rest_api_1_integration_0_lambda_function_0
+
+

--- a/pkg/engine2/testdata/extend_graph.expect.yaml
+++ b/pkg/engine2/testdata/extend_graph.expect.yaml
@@ -1,0 +1,97 @@
+resources:
+    aws:api_stage:rest_api_1:api_stage-0:
+        Deployment: aws:api_deployment:rest_api_1:api_deployment-0
+        RestApi: aws:rest_api:rest_api_1
+        StageName: stage
+    aws:dynamodb_table:dynamodb_table_3:
+        Attributes:
+            - Name: id
+              Type: S
+        BillingMode: PAY_PER_REQUEST
+        HashKey: id
+    aws:api_deployment:rest_api_1:api_deployment-0:
+        RestApi: aws:rest_api:rest_api_1
+        Triggers:
+            rest_api_1_integration_0: rest_api_1_integration_0
+            rest_api_1_integration_0_method: rest_api_1_integration_0_method
+    aws:rest_api:rest_api_1:
+        BinaryMediaTypes:
+            - application/octet-stream
+            - image/*
+        Stages:
+            - aws:api_stage:rest_api_1:api_stage-0
+    aws:api_resource:rest_api_1:api_resource-0:
+        FullPath: /{proxy+}
+        PathPart: '{proxy+}'
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+        Authorization: NONE
+        HttpMethod: ANY
+        RequestParameters:
+            method.request.path.proxy: true
+        Resource: aws:api_resource:rest_api_1:api_resource-0
+        RestApi: aws:rest_api:rest_api_1
+    aws:api_integration:rest_api_1:rest_api_1_integration_0:
+        IntegrationHttpMethod: POST
+        Method: aws:api_method:rest_api_1:rest_api_1_integration_0_method
+        RequestParameters:
+            integration.request.path.proxy: method.request.path.proxy
+        Resource: aws:api_resource:rest_api_1:api_resource-0
+        RestApi: aws:rest_api:rest_api_1
+        Route: /{proxy+}
+        Target: aws:lambda_function:lambda_function_0
+        Type: AWS_PROXY
+        Uri: aws:lambda_function:lambda_function_0#LambdaIntegrationUri
+    aws:lambda_permission:rest_api_1_integration_0_lambda_function_0:
+        Action: lambda:InvokeFunction
+        Function: aws:lambda_function:lambda_function_0
+        Principal: apigateway.amazonaws.com
+        Source: aws:rest_api:rest_api_1#ChildResources
+    aws:lambda_function:lambda_function_0:
+        ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
+        Image: aws:ecr_image:lambda_function_0-image
+        LogGroup: aws:log_group:lambda_function_0-log-group
+        MemorySize: 512
+        Timeout: 180
+    aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group:
+    aws:ecr_image:lambda_function_0-image:
+        Context: .
+        Dockerfile: lambda_function_0-image.Dockerfile
+        Repo: aws:ecr_repo:ecr_repo-0
+    aws:iam_role:lambda_function_0-ExecutionRole:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Principal:
+                    Service:
+                        - lambda.amazonaws.com
+            Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    aws:ecr_repo:ecr_repo-0:
+        ForceDelete: true
+    aws:log_group:lambda_function_0-log-group:
+        LogGroupName: /aws/lambda/lambda_function_0
+        RetentionInDays: 5
+edges:
+    aws:api_stage:rest_api_1:api_stage-0 -> aws:api_deployment:rest_api_1:api_deployment-0:
+    aws:api_stage:rest_api_1:api_stage-0 -> aws:rest_api:rest_api_1:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+    aws:api_deployment:rest_api_1:api_deployment-0 -> aws:rest_api:rest_api_1:
+    aws:rest_api:rest_api_1 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+    aws:rest_api:rest_api_1 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+    aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:api_resource-0:
+    aws:api_resource:rest_api_1:api_resource-0 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+    aws:api_resource:rest_api_1:api_resource-0 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+    aws:api_method:rest_api_1:rest_api_1_integration_0_method -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+    aws:api_integration:rest_api_1:rest_api_1_integration_0 -> aws:lambda_permission:rest_api_1_integration_0_lambda_function_0:
+    aws:lambda_permission:rest_api_1_integration_0_lambda_function_0 -> aws:lambda_function:lambda_function_0:
+    aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group:
+    aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:
+    aws:lambda_function:lambda_function_0 -> aws:iam_role:lambda_function_0-ExecutionRole:
+    aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group -> aws:log_group:lambda_function_0-log-group:
+    aws:ecr_image:lambda_function_0-image -> aws:ecr_repo:ecr_repo-0:
+    aws:iam_role:lambda_function_0-ExecutionRole -> aws:log_group:lambda_function_0-log-group:

--- a/pkg/engine2/testdata/extend_graph.iac-viz.yaml
+++ b/pkg/engine2/testdata/extend_graph.iac-viz.yaml
@@ -1,0 +1,45 @@
+provider: aws
+resources:
+  ecr_repo/ecr_repo-0:
+
+  log_group/lambda_function_0-log-group:
+
+  rest_api/rest_api_1:
+
+  ecr_image/lambda_function_0-image:
+  ecr_image/lambda_function_0-image -> ecr_repo/ecr_repo-0:
+
+  iam_role/lambda_function_0-executionrole:
+  iam_role/lambda_function_0-executionrole -> log_group/lambda_function_0-log-group:
+
+  aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_resource:rest_api_1/api_resource-0 -> rest_api/rest_api_1:
+
+  lambda_function/lambda_function_0:
+  lambda_function/lambda_function_0 -> ecr_image/lambda_function_0-image:
+  lambda_function/lambda_function_0 -> iam_role/lambda_function_0-executionrole:
+
+  aws:api_method:rest_api_1/rest_api_1_integration_0_method:
+  aws:api_method:rest_api_1/rest_api_1_integration_0_method -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_method:rest_api_1/rest_api_1_integration_0_method -> rest_api/rest_api_1:
+
+  lambda_permission/rest_api_1_integration_0_lambda_function_0:
+  lambda_permission/rest_api_1_integration_0_lambda_function_0 -> lambda_function/lambda_function_0:
+
+  aws:api_integration:rest_api_1/rest_api_1_integration_0:
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> aws:api_method:rest_api_1/rest_api_1_integration_0_method:
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> lambda_permission/rest_api_1_integration_0_lambda_function_0:
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> rest_api/rest_api_1:
+
+  aws:api_deployment:rest_api_1/api_deployment-0:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_integration:rest_api_1/rest_api_1_integration_0:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> aws:api_method:rest_api_1/rest_api_1_integration_0_method:
+  aws:api_deployment:rest_api_1/api_deployment-0 -> rest_api/rest_api_1:
+
+  dynamodb_table/dynamodb_table_3:
+
+  aws:api_stage:rest_api_1/api_stage-0:
+  aws:api_stage:rest_api_1/api_stage-0 -> aws:api_deployment:rest_api_1/api_deployment-0:
+  aws:api_stage:rest_api_1/api_stage-0 -> rest_api/rest_api_1:
+

--- a/pkg/engine2/testdata/extend_graph.input.yaml
+++ b/pkg/engine2/testdata/extend_graph.input.yaml
@@ -1,0 +1,95 @@
+constraints:
+  - node: aws:dynamodb_table:dynamodb_table_3
+    operator: add
+    scope: application
+resources:
+  aws:api_stage:rest_api_1:api_stage-0:
+    Deployment: aws:api_deployment:rest_api_1:api_deployment-0
+    RestApi: aws:rest_api:rest_api_1
+    StageName: stage
+  aws:api_deployment:rest_api_1:api_deployment-0:
+    RestApi: aws:rest_api:rest_api_1
+    Triggers:
+      rest_api_1_integration_0: rest_api_1_integration_0
+      rest_api_1_integration_0_method: rest_api_1_integration_0_method
+  aws:rest_api:rest_api_1:
+    BinaryMediaTypes:
+      - application/octet-stream
+      - image/*
+    Stages:
+      - aws:api_stage:rest_api_1:api_stage-0
+  aws:api_resource:rest_api_1:api_resource-0:
+    FullPath: /{proxy+}
+    PathPart: '{proxy+}'
+    RestApi: aws:rest_api:rest_api_1
+  aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+    Authorization: NONE
+    HttpMethod: ANY
+    RequestParameters:
+      method.request.path.proxy: true
+    Resource: aws:api_resource:rest_api_1:api_resource-0
+    RestApi: aws:rest_api:rest_api_1
+  aws:api_integration:rest_api_1:rest_api_1_integration_0:
+    IntegrationHttpMethod: POST
+    Method: aws:api_method:rest_api_1:rest_api_1_integration_0_method
+    RequestParameters:
+      integration.request.path.proxy: method.request.path.proxy
+    Resource: aws:api_resource:rest_api_1:api_resource-0
+    RestApi: aws:rest_api:rest_api_1
+    Route: /{proxy+}
+    Target: aws:lambda_function:lambda_function_0
+    Type: AWS_PROXY
+    Uri: aws:lambda_function:lambda_function_0#LambdaIntegrationUri
+  aws:lambda_permission:rest_api_1_integration_0_lambda_function_0:
+    Action: lambda:InvokeFunction
+    Function: aws:lambda_function:lambda_function_0
+    Principal: apigateway.amazonaws.com
+    Source: aws:rest_api:rest_api_1#ChildResources
+  aws:lambda_function:lambda_function_0:
+    ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
+    Image: aws:ecr_image:lambda_function_0-image
+    LogGroup: aws:log_group:lambda_function_0-log-group
+    MemorySize: 512
+    Timeout: 180
+  aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group:
+  aws:ecr_image:lambda_function_0-image:
+    Context: .
+    Dockerfile: lambda_function_0-image.Dockerfile
+    Repo: aws:ecr_repo:ecr_repo-0
+  aws:iam_role:lambda_function_0-ExecutionRole:
+    AssumeRolePolicyDoc:
+      Statement:
+        - Action:
+            - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+              - lambda.amazonaws.com
+      Version: '2012-10-17'
+    ManagedPolicies:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  aws:ecr_repo:ecr_repo-0:
+    ForceDelete: true
+  aws:log_group:lambda_function_0-log-group:
+    LogGroupName: /aws/lambda/lambda_function_0
+    RetentionInDays: 5
+edges:
+  aws:api_stage:rest_api_1:api_stage-0 -> aws:api_deployment:rest_api_1:api_deployment-0:
+  aws:api_stage:rest_api_1:api_stage-0 -> aws:rest_api:rest_api_1:
+  aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+  aws:api_deployment:rest_api_1:api_deployment-0 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+  aws:api_deployment:rest_api_1:api_deployment-0 -> aws:rest_api:rest_api_1:
+  aws:rest_api:rest_api_1 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+  aws:rest_api:rest_api_1 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+  aws:rest_api:rest_api_1 -> aws:api_resource:rest_api_1:api_resource-0:
+  aws:api_resource:rest_api_1:api_resource-0 -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+  aws:api_resource:rest_api_1:api_resource-0 -> aws:api_method:rest_api_1:rest_api_1_integration_0_method:
+  aws:api_method:rest_api_1:rest_api_1_integration_0_method -> aws:api_integration:rest_api_1:rest_api_1_integration_0:
+  aws:api_integration:rest_api_1:rest_api_1_integration_0 -> aws:lambda_permission:rest_api_1_integration_0_lambda_function_0:
+  aws:lambda_permission:rest_api_1_integration_0_lambda_function_0 -> aws:lambda_function:lambda_function_0:
+  aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group:
+  aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:
+  aws:lambda_function:lambda_function_0 -> aws:iam_role:lambda_function_0-ExecutionRole:
+  aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group -> aws:log_group:lambda_function_0-log-group:
+  aws:ecr_image:lambda_function_0-image -> aws:ecr_repo:ecr_repo-0:
+  aws:iam_role:lambda_function_0-ExecutionRole -> aws:log_group:lambda_function_0-log-group:

--- a/pkg/engine2/testdata/single_lambda.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/single_lambda.dataflow-viz.yaml
@@ -1,0 +1,6 @@
+provider: aws
+resources:
+  lambda_function/lambda_function_0:
+    children: aws:ecr_image:lambda_function_0-image,aws:iam_role:lambda_function_0-ExecutionRole,aws:log_group:lambda_function_0-log-group
+
+

--- a/pkg/engine2/testdata/single_lambda.expect.yaml
+++ b/pkg/engine2/testdata/single_lambda.expect.yaml
@@ -1,0 +1,36 @@
+resources:
+    aws:lambda_function:lambda_function_0:
+        ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
+        Image: aws:ecr_image:lambda_function_0-image
+        LogGroup: aws:log_group:lambda_function_0-log-group
+        MemorySize: 512
+        Timeout: 180
+    aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
+    aws:ecr_image:lambda_function_0-image:
+        Context: .
+        Dockerfile: lambda_function_0-image.Dockerfile
+        Repo: aws:ecr_repo:ecr_repo-0
+    aws:iam_role:lambda_function_0-ExecutionRole:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Principal:
+                    Service:
+                        - lambda.amazonaws.com
+            Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    aws:ecr_repo:ecr_repo-0:
+        ForceDelete: true
+    aws:log_group:lambda_function_0-log-group:
+        LogGroupName: /aws/lambda/lambda_function_0
+        RetentionInDays: 5
+edges:
+    aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
+    aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:
+    aws:lambda_function:lambda_function_0 -> aws:iam_role:lambda_function_0-ExecutionRole:
+    aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group -> aws:log_group:lambda_function_0-log-group:
+    aws:ecr_image:lambda_function_0-image -> aws:ecr_repo:ecr_repo-0:
+    aws:iam_role:lambda_function_0-ExecutionRole -> aws:log_group:lambda_function_0-log-group:

--- a/pkg/engine2/testdata/single_lambda.iac-viz.yaml
+++ b/pkg/engine2/testdata/single_lambda.iac-viz.yaml
@@ -1,0 +1,16 @@
+provider: aws
+resources:
+  ecr_repo/ecr_repo-0:
+
+  log_group/lambda_function_0-log-group:
+
+  ecr_image/lambda_function_0-image:
+  ecr_image/lambda_function_0-image -> ecr_repo/ecr_repo-0:
+
+  iam_role/lambda_function_0-executionrole:
+  iam_role/lambda_function_0-executionrole -> log_group/lambda_function_0-log-group:
+
+  lambda_function/lambda_function_0:
+  lambda_function/lambda_function_0 -> ecr_image/lambda_function_0-image:
+  lambda_function/lambda_function_0 -> iam_role/lambda_function_0-executionrole:
+

--- a/pkg/engine2/testdata/single_lambda.input.yaml
+++ b/pkg/engine2/testdata/single_lambda.input.yaml
@@ -1,0 +1,4 @@
+constraints:
+  - node: aws:lambda_function:lambda_function_0
+    operator: add
+    scope: application

--- a/pkg/templates/aws/edges/api_method-api_integration.yaml
+++ b/pkg/templates/aws/edges/api_method-api_integration.yaml
@@ -14,3 +14,4 @@ operational_rules:
                 keysToMapWithDefault true |
                 toJson
             }}
+unique: one-to-one

--- a/pkg/templates/aws/edges/api_resource-api_method.yaml
+++ b/pkg/templates/aws/edges/api_resource-api_method.yaml
@@ -1,3 +1,4 @@
 source: aws:api_resource
 target: aws:api_method
 deployment_order_reversed: true
+unique: one-to-one

--- a/pkg/templates/aws/resources/api_integration.yaml
+++ b/pkg/templates/aws/resources/api_integration.yaml
@@ -15,7 +15,7 @@ properties:
   Resource:
     type: resource(aws:api_resource)
     operational_rule:
-      if: | 
+      if: |
         {{ ne (fieldValue "Route" .Self) "/" }}
       steps:
         - direction: upstream
@@ -31,6 +31,9 @@ properties:
         - direction: upstream
           resources:
             - selector: aws:api_method
+              properties:
+                RestApi: '{{ fieldValue "RestApi" .Self }}'
+                Resource: '{{ fieldValue "Resource" .Self }}'
   RequestParameters:
     type: map(string,string)
     operational_rule:


### PR DESCRIPTION
Also fixes a few errors found while running:
- Operational action now considers edge uniqueness before reusing resources
- Op Eval keys should sort properly
- Fix path selection debug graphs

```
go test -v -timeout 1m -run '^TestEngine$' ./pkg/engine2
=== RUN   TestEngine
=== RUN   TestEngine/2_routes.input.yaml
=== PAUSE TestEngine/2_routes.input.yaml
=== RUN   TestEngine/extend_graph.input.yaml
=== PAUSE TestEngine/extend_graph.input.yaml
=== RUN   TestEngine/single_lambda.input.yaml
=== PAUSE TestEngine/single_lambda.input.yaml
=== CONT  TestEngine/2_routes.input.yaml
=== CONT  TestEngine/single_lambda.input.yaml
=== CONT  TestEngine/extend_graph.input.yaml
--- PASS: TestEngine (0.00s)
    --- PASS: TestEngine/single_lambda.input.yaml (0.17s)
    --- PASS: TestEngine/extend_graph.input.yaml (0.35s)
    --- PASS: TestEngine/2_routes.input.yaml (1.38s)
PASS
ok      github.com/klothoplatform/klotho/pkg/engine2    1.389s
```
