### PR TITLE
make sub expansions only run for the classification that generated them

### DIFF
--- a/pkg/engine2/solution_context/decisions.go
+++ b/pkg/engine2/solution_context/decisions.go
@@ -74,12 +74,12 @@ func (d PropertyValidationDecision) MarshalJSON() ([]byte, error) {
 			"resource": d.Resource,
 			"property": d.Property.Details().Path,
 			"value":    d.Value,
-			"error":    d.Error,
+			"error":    d.Error.Error(),
 		})
 	}
 	return json.Marshal(map[string]any{
 		"resource": d.Resource,
 		"property": d.Property.Details().Path,
-		"error":    d.Error,
+		"error":    d.Error.Error(),
 	})
 }

--- a/pkg/infra/iac3/templates/aws/ecs_task_definition/efs_volumes.ts.tmpl
+++ b/pkg/infra/iac3/templates/aws/ecs_task_definition/efs_volumes.ts.tmpl
@@ -1,5 +1,5 @@
 [
-    {{- range $i, $volume := . }}
+    {{- range $i, $volume := .M }}
     { 
         name: "{{ $volume.Name }}",
         efsVolumeConfiguration: {

--- a/pkg/templates/aws/edges/service_api.yaml
+++ b/pkg/templates/aws/edges/service_api.yaml
@@ -11,4 +11,4 @@ targets:
   - aws:sqs_queue
   - aws:secret
 
-edge_weight_multiplier: 1.5
+edge_weight_multiplier: 1.08

--- a/pkg/templates/aws/resources/iam_policy.yaml
+++ b/pkg/templates/aws/resources/iam_policy.yaml
@@ -48,6 +48,7 @@ classification:
   is:
     - policy
     - security
+    - permissions
   gives:
     - permissions
 


### PR DESCRIPTION
makes sure tjat sub expansions only run for the classification that generated them. It also subs out the newly created names for the phantoms that were in their place in the temp graph so we can reuse the temp graph

changed the weighting of the service api to fix the lambda being placed into the vpc issue (we may not see vpc endpoint get created because of this, but thats at least hidden for now and we dont support many)

efs iac template fix

policy adds permissions classification to help weighting in path selection

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
