### PR TITLE
dont check validity if theres already an edge

### DIFF
--- a/pkg/engine2/path_selection/path_expansion.go
+++ b/pkg/engine2/path_selection/path_expansion.go
@@ -437,11 +437,18 @@ func expandPath(
 			return
 		}
 
-		valid, err := checkUniquenessValidity(ctx, source.id, target.id)
-		if err != nil {
+		// if the edge doesnt exist in the actual graph we need to check uniqueness validity
+		_, err := ctx.RawView().Edge(source.id, target.id)
+		if errors.Is(err, graph.ErrEdgeNotFound) {
+			valid, err := checkUniquenessValidity(ctx, source.id, target.id)
+			if err != nil {
+				errs = errors.Join(errs, err)
+			}
+			if !valid {
+				return
+			}
+		} else if err != nil {
 			errs = errors.Join(errs, err)
-		}
-		if !valid {
 			return
 		}
 

--- a/pkg/engine2/path_selection/path_expansion.go
+++ b/pkg/engine2/path_selection/path_expansion.go
@@ -443,6 +443,7 @@ func expandPath(
 			valid, err := checkUniquenessValidity(ctx, source.id, target.id)
 			if err != nil {
 				errs = errors.Join(errs, err)
+				return
 			}
 			if !valid {
 				return

--- a/pkg/engine2/testdata/k8s_api.expect.yaml
+++ b/pkg/engine2/testdata/k8s_api.expect.yaml
@@ -135,7 +135,6 @@ resources:
             Enabled: true
             HealthyThreshold: 5
             Interval: 30
-            Matcher: 200-299
             Protocol: TCP
             Timeout: 5
             UnhealthyThreshold: 2

--- a/pkg/templates/aws/resources/target_group.yaml
+++ b/pkg/templates/aws/resources/target_group.yaml
@@ -59,7 +59,6 @@ properties:
         default_value: 2
       Matcher:
         type: string
-        default_value: 200-299
   Arn:
     type: string
     configuration_disabled: true


### PR DESCRIPTION
updates matcher to not have a default since it cant have a default for tcp

only run edge validity checks if theres no existing edge

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
