### PR TITLE
add iac dependencies based on properties

### DIFF
--- a/pkg/engine2/testdata/2_routes.expect.yaml
+++ b/pkg/engine2/testdata/2_routes.expect.yaml
@@ -14,8 +14,6 @@ resources:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
-        Stages:
-            - aws:api_stage:rest_api_1:api_stage-0
     aws:api_resource:rest_api_1:lambda0:
         FullPath: /lambda0
         PathPart: lambda0

--- a/pkg/engine2/testdata/2_routes.iac-viz.yaml
+++ b/pkg/engine2/testdata/2_routes.iac-viz.yaml
@@ -48,6 +48,7 @@ resources:
 
   lambda_permission/integ0-lambda_function_0:
   lambda_permission/integ0-lambda_function_0 -> lambda_function/lambda_function_0:
+  lambda_permission/integ0-lambda_function_0 -> rest_api/rest_api_1:
 
   aws:api_method:rest_api_1/integ1-api_method:
   aws:api_method:rest_api_1/integ1-api_method -> aws:api_resource:rest_api_1/api_resource-1:
@@ -55,16 +56,19 @@ resources:
 
   lambda_permission/integ1-lambda_function_1:
   lambda_permission/integ1-lambda_function_1 -> lambda_function/lambda_function_1:
+  lambda_permission/integ1-lambda_function_1 -> rest_api/rest_api_1:
 
   aws:api_integration:rest_api_1/integ0:
   aws:api_integration:rest_api_1/integ0 -> aws:api_method:rest_api_1/integ0-api_method:
   aws:api_integration:rest_api_1/integ0 -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_integration:rest_api_1/integ0 -> lambda_function/lambda_function_0:
   aws:api_integration:rest_api_1/integ0 -> lambda_permission/integ0-lambda_function_0:
   aws:api_integration:rest_api_1/integ0 -> rest_api/rest_api_1:
 
   aws:api_integration:rest_api_1/integ1:
   aws:api_integration:rest_api_1/integ1 -> aws:api_method:rest_api_1/integ1-api_method:
   aws:api_integration:rest_api_1/integ1 -> aws:api_resource:rest_api_1/api_resource-1:
+  aws:api_integration:rest_api_1/integ1 -> lambda_function/lambda_function_1:
   aws:api_integration:rest_api_1/integ1 -> lambda_permission/integ1-lambda_function_1:
   aws:api_integration:rest_api_1/integ1 -> rest_api/rest_api_1:
 

--- a/pkg/engine2/testdata/delete_namespace_resource.iac-viz.yaml
+++ b/pkg/engine2/testdata/delete_namespace_resource.iac-viz.yaml
@@ -13,4 +13,5 @@ resources:
   lambda_function/lambda_function_2:
   lambda_function/lambda_function_2 -> ecr_image/lambda_function_2-image:
   lambda_function/lambda_function_2 -> iam_role/lambda_function_2-executionrole:
+  lambda_function/lambda_function_2 -> log_group/lambda_function_2-log-group:
 

--- a/pkg/engine2/testdata/ecs_rds.iac-viz.yaml
+++ b/pkg/engine2/testdata/ecs_rds.iac-viz.yaml
@@ -86,6 +86,7 @@ resources:
   ecs_task_definition/ecs_service_0 -> ecr_image/ecs_service_0-image:
   ecs_task_definition/ecs_service_0 -> iam_role/ecs_service_0-execution-role:
   ecs_task_definition/ecs_service_0 -> log_group/ecs_service_0-log-group:
+  ecs_task_definition/ecs_service_0 -> rds_instance/rds-instance-2:
   ecs_task_definition/ecs_service_0 -> region/region-0:
 
   aws:security_group:vpc-0/ecs_service_0-security_group:

--- a/pkg/engine2/testdata/extend_graph.iac-viz.yaml
+++ b/pkg/engine2/testdata/extend_graph.iac-viz.yaml
@@ -18,6 +18,7 @@ resources:
   lambda_function/lambda_function_0:
   lambda_function/lambda_function_0 -> ecr_image/lambda_function_0-image:
   lambda_function/lambda_function_0 -> iam_role/lambda_function_0-executionrole:
+  lambda_function/lambda_function_0 -> log_group/lambda_function_0-log-group:
 
   aws:api_method:rest_api_1/rest_api_1_integration_0_method:
   aws:api_method:rest_api_1/rest_api_1_integration_0_method -> aws:api_resource:rest_api_1/api_resource-0:
@@ -25,10 +26,12 @@ resources:
 
   lambda_permission/rest_api_1_integration_0_lambda_function_0:
   lambda_permission/rest_api_1_integration_0_lambda_function_0 -> lambda_function/lambda_function_0:
+  lambda_permission/rest_api_1_integration_0_lambda_function_0 -> rest_api/rest_api_1:
 
   aws:api_integration:rest_api_1/rest_api_1_integration_0:
   aws:api_integration:rest_api_1/rest_api_1_integration_0 -> aws:api_method:rest_api_1/rest_api_1_integration_0_method:
   aws:api_integration:rest_api_1/rest_api_1_integration_0 -> aws:api_resource:rest_api_1/api_resource-0:
+  aws:api_integration:rest_api_1/rest_api_1_integration_0 -> lambda_function/lambda_function_0:
   aws:api_integration:rest_api_1/rest_api_1_integration_0 -> lambda_permission/rest_api_1_integration_0_lambda_function_0:
   aws:api_integration:rest_api_1/rest_api_1_integration_0 -> rest_api/rest_api_1:
 

--- a/pkg/engine2/testdata/k8s_api.expect.yaml
+++ b/pkg/engine2/testdata/k8s_api.expect.yaml
@@ -80,8 +80,6 @@ resources:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
-        Stages:
-            - aws:api_stage:rest_api_4:api_stage-0
     kubernetes:namespace:amazon-cloudwatch:
         Cluster: aws:eks_cluster:eks_cluster-0
         Object:

--- a/pkg/engine2/testdata/k8s_api.iac-viz.yaml
+++ b/pkg/engine2/testdata/k8s_api.iac-viz.yaml
@@ -114,10 +114,12 @@ resources:
   aws:api_integration:rest_api_4/rest_api_4_integration_0:
   aws:api_integration:rest_api_4/rest_api_4_integration_0 -> aws:api_method:rest_api_4/rest_api_4_integration_0_method:
   aws:api_integration:rest_api_4/rest_api_4_integration_0 -> aws:api_resource:rest_api_4/api_resource-0:
+  aws:api_integration:rest_api_4/rest_api_4_integration_0 -> load_balancer/rest-api-4-integbcc77100:
   aws:api_integration:rest_api_4/rest_api_4_integration_0 -> rest_api/rest_api_4:
   aws:api_integration:rest_api_4/rest_api_4_integration_0 -> vpc_link/rest_api_4_integration_0-pod2:
 
   target_group/rest-api-4-integbcc77100:
+  target_group/rest-api-4-integbcc77100 -> vpc/vpc-0:
 
   kubernetes:helm_chart:eks_cluster-0/aws-load-balancer-controller:
   kubernetes:helm_chart:eks_cluster-0/aws-load-balancer-controller -> eks_cluster/eks_cluster-0:
@@ -167,6 +169,7 @@ resources:
 
   kubernetes:kube_config/eks_cluster-0-kube_config:
   kubernetes:kube_config/eks_cluster-0-kube_config -> eks_cluster/eks_cluster-0:
+  kubernetes:kube_config/eks_cluster-0-kube_config -> region/region-0:
 
   kubernetes:helm_chart:eks_cluster-0/metricsserver:
   kubernetes:helm_chart:eks_cluster-0/metricsserver -> eks_cluster/eks_cluster-0:

--- a/pkg/engine2/testdata/namespace_pathselect.iac-viz.yaml
+++ b/pkg/engine2/testdata/namespace_pathselect.iac-viz.yaml
@@ -104,4 +104,5 @@ resources:
   lambda_function/lambda_function_0:
   lambda_function/lambda_function_0 -> ecr_image/lambda_function_0-image:
   lambda_function/lambda_function_0 -> iam_role/lambda_function_0-executionrole:
+  lambda_function/lambda_function_0 -> log_group/lambda_function_0-log-group:
 

--- a/pkg/templates/aws/edges/rest_api-api_integration.yaml
+++ b/pkg/templates/aws/edges/rest_api-api_integration.yaml
@@ -2,3 +2,9 @@ source: aws:rest_api
 target: aws:api_integration
 direct_edge_only: true
 deployment_order_reversed: true
+operational_rules:
+  - steps:
+      - resource: '{{ .Source }}'
+        direction: upstream
+        resources:
+          - aws:api_stage

--- a/pkg/templates/aws/resources/rest_api.yaml
+++ b/pkg/templates/aws/resources/rest_api.yaml
@@ -9,13 +9,6 @@ properties:
     default_value:
       - application/octet-stream
       - image/*
-  Stages:
-    type: list(resource(aws:api_stage))
-    operational_rule:
-      step:
-        direction: upstream
-        resources:
-          - aws:api_stage
   ChildResources:
     type: string
     configuration_disabled: true


### PR DESCRIPTION
closes #772 
ensures that there is always an iac dependency if a property contains another resource or property ref

modified the way api stages are created so that the edge of api -> integration creates it instead of the api itself

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
