### PR TITLE
Sanitize environment variable names when added via consumer logic

### DIFF
--- a/pkg/engine2/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine2/testdata/ecs_rds.expect.yaml
@@ -30,10 +30,10 @@ resources:
     aws:ecs_task_definition:ecs_service_0:
         Cpu: "256"
         EnvironmentVariables:
-            rds-instance-2_RDS_CONNECTION_ARN: aws:rds_instance:rds-instance-2#RdsConnectionArn
-            rds-instance-2_RDS_ENDPOINT: aws:rds_instance:rds-instance-2#Endpoint
-            rds-instance-2_RDS_PASSWORD: aws:rds_instance:rds-instance-2#Password
-            rds-instance-2_RDS_USERNAME: aws:rds_instance:rds-instance-2#Username
+            RDS_INSTANCE_2_RDS_CONNECTION_ARN: aws:rds_instance:rds-instance-2#RdsConnectionArn
+            RDS_INSTANCE_2_RDS_ENDPOINT: aws:rds_instance:rds-instance-2#Endpoint
+            RDS_INSTANCE_2_RDS_PASSWORD: aws:rds_instance:rds-instance-2#Password
+            RDS_INSTANCE_2_RDS_USERNAME: aws:rds_instance:rds-instance-2#Username
         ExecutionRole: aws:iam_role:ecs_service_0-execution-role
         Image: aws:ecr_image:ecs_service_0-image
         LogGroup: aws:log_group:ecs_service_0-log-group

--- a/pkg/engine2/testdata/ecs_rds.input.yaml
+++ b/pkg/engine2/testdata/ecs_rds.input.yaml
@@ -2,11 +2,11 @@ constraints:
   - node: aws:ecs_service:ecs_service_0
     operator: add
     scope: application
-  - node: aws:rds_instance:rds-instance-2
+  - node: aws:rds_instance:rds_instance_2 # deliberately use underscores to run name sanitization
     operator: add
     scope: application
   - operator: must_exist
     scope: edge
     target:
       source: aws:ecs_service:ecs_service_0
-      target: aws:rds_instance:rds-instance-2
+      target: aws:rds_instance:rds_instance_2

--- a/pkg/engine2/testdata/ecs_rds.input.yaml
+++ b/pkg/engine2/testdata/ecs_rds.input.yaml
@@ -2,7 +2,7 @@ constraints:
   - node: aws:ecs_service:ecs_service_0
     operator: add
     scope: application
-  - node: aws:rds_instance:rds_instance_2
+  - node: aws:rds_instance:rds-instance-2
     operator: add
     scope: application
   - operator: must_exist

--- a/pkg/knowledge_base2/model.go
+++ b/pkg/knowledge_base2/model.go
@@ -13,7 +13,7 @@ type (
 )
 
 // GetObjectValue returns the value of the object as the model type
-func (m *Model) GetObjectValue(val any, ctx DynamicValueContext, data DynamicValueData) (any, error) {
+func (m *Model) GetObjectValue(val any, ctx DynamicContext, data DynamicValueData) (any, error) {
 
 	GetVal := func(p Property, val map[string]any) (any, error) {
 		propVal, found := val[p.Details().Name]

--- a/pkg/knowledge_base2/properties/string_property.go
+++ b/pkg/knowledge_base2/properties/string_property.go
@@ -123,14 +123,7 @@ func (s *StringProperty) Validate(resource *construct.Resource, value any, ctx k
 	}
 
 	if s.SanitizeTmpl != nil {
-		oldVal := stringVal
-		stringVal, err := s.SanitizeTmpl.Execute(stringVal)
-		if err != nil {
-			return err
-		}
-		if oldVal != stringVal {
-			return fmt.Errorf("value %s did not pass sanitization rules. suggested value: %s", oldVal, stringVal)
-		}
+		return s.SanitizeTmpl.Check(stringVal)
 	}
 	return nil
 }

--- a/pkg/knowledge_base2/resource_template.go
+++ b/pkg/knowledge_base2/resource_template.go
@@ -79,15 +79,18 @@ type (
 		Clone() Property
 		// Type returns the string representation of the type of the property, as it should appear in the resource template
 		Type() string
-		// GetDefaultValue returns the default value for the property, pertaining to the specific data being passed in for execution
+		// GetDefaultValue returns the default value for the property,
+		// pertaining to the specific data being passed in for execution
 		GetDefaultValue(ctx DynamicContext, data DynamicValueData) (any, error)
-		// Validate ensures the value is valid for the property and returns an error if it is not
+		// Validate ensures the value is valid for the property to `Set` (not `Append` for collection types)
+		// and returns an error if it is not
 		Validate(resource *construct.Resource, value any, ctx DynamicContext) error
-		// SubProperties returns the sub properties of the property, if any. This is used for properties that are complex structures,
-		// such as lists, sets, or maps
+		// SubProperties returns the sub properties of the property, if any.
+		// This is used for properties that are complex structures, such as lists, sets, or maps
 		SubProperties() Properties
-		// Parse parses a given value to ensure it is the correct type for the property. If the given value cannot be converted
-		// to the respective property type an error is returned. The returned value will always be the correct type for the property
+		// Parse parses a given value to ensure it is the correct type for the property.
+		// If the given value cannot be converted to the respective property type an error is returned.
+		// The returned value will always be the correct type for the property
 		Parse(value any, ctx DynamicContext, data DynamicValueData) (any, error)
 		// ZeroValue returns the zero value for the property type
 		ZeroValue() any

--- a/pkg/templates/aws/resources/app_runer_service.yaml
+++ b/pkg/templates/aws/resources/app_runer_service.yaml
@@ -35,6 +35,13 @@ properties:
     type: map(string,string)
     description: Key-value pairs of environment variables that are provided to the
       App Runner service
+    key_property:
+      sanitize: |
+        {{ .
+          | replace `[^[:alnum:]_]+` "_"
+          | replace `^[^a-zA-Z]+` ""
+          | upper
+        }}
   Port:
     type: int
     default_value: 8080

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -28,6 +28,13 @@ properties:
   EnvironmentVariables:
     type: map(string,string)
     description: A map of the environment variables to pass to the container
+    key_property:
+      sanitize: |
+        {{ .
+          | replace `[^[:alnum:]_]+` "_"
+          | replace `^[^a-zA-Z]+` ""
+          | upper
+        }}
   Cpu:
     type: string
     default_value: '256'

--- a/pkg/templates/aws/resources/lambda_function.yaml
+++ b/pkg/templates/aws/resources/lambda_function.yaml
@@ -20,6 +20,13 @@ properties:
         unique: true
   EnvironmentVariables:
     type: map(string,string)
+    key_property:
+      sanitize: |
+        {{ .
+          | replace `[^[:alnum:]_]+` "_"
+          | replace `^[^a-zA-Z]+` ""
+          | upper
+        }}
   SecurityGroups:
     type: list(resource(aws:security_group))
     operational_rule:
@@ -80,7 +87,7 @@ path_satisfaction:
     - permissions
   as_source:
     - network#Subnets
-    - network    # This is required as well in case the lambda does not already exist in a vpc, we need the path evaluation done in 2 step
+    - network # This is required as well in case the lambda does not already exist in a vpc, we need the path evaluation done in 2 step
 
 consumption:
   consumed:

--- a/pkg/templates/kubernetes/models/env_var.yaml
+++ b/pkg/templates/kubernetes/models/env_var.yaml
@@ -2,5 +2,11 @@ name: kubernetes:EnvVar
 properties:
   name:
     type: string
+    sanitize: |
+      {{ .
+        | replace `[^[:alnum:]_]+` "_"
+        | replace `^[^a-zA-Z]+` ""
+        | upper
+      }}
   value:
     type: string


### PR DESCRIPTION
Note: we should probably also sanitize for other automatically generated things (ie, that don't come from user constraints), but that's left for later.