### PR TITLE
Add dependencies to all parts of the property ref path in path expand

### DIFF
--- a/compare.sh
+++ b/compare.sh
@@ -12,10 +12,13 @@ fi
 
 rm out.log out2.log
 export NO_COLOR=1
-export COLUMNS=80
-go run ./cmd/engine Run -i "$file" -o "./out/$(basename $file .yaml)" -v 2> out.log
+# Set columns really high so that the right-aligned fields that we grep for are on the same line as the message.
+export COLUMNS=1000
+KLOTHO_DEBUG_DIR="./out/$(basename $file .yaml)" \
+    go run ./cmd/engine Run -i "$file" -o "./out/$(basename $file .yaml)" -v 2> out.log
 sleep 2
-go run ./cmd/engine Run -i "$file" -o "./out/$(basename $file .yaml)2" -v 2> out2.log
+KLOTHO_DEBUG_DIR="./out/$(basename $file .yaml)2" \
+    go run ./cmd/engine Run -i "$file" -o "./out/$(basename $file .yaml)2" -v 2> out2.log
 
 rm out.queue.log out2.queue.log
 grep -E -e 'op: dequeue|eval|poll-deps' -e 'Satisfied' out.log > out.queue.log

--- a/pkg/engine2/operational_eval/dot.go
+++ b/pkg/engine2/operational_eval/dot.go
@@ -39,10 +39,10 @@ func keyAttributes(eval *Evaluator, key Key) map[string]string {
 		if key.PathSatisfication.Classification != "" {
 			extra = append(extra, fmt.Sprintf("<%s>", key.PathSatisfication.Classification))
 		}
-		if propertyReferenceInfluencesEdge(key.PathSatisfication.Target) {
+		if propertyReferenceChangesBoundary(key.PathSatisfication.Target) {
 			extra = append(extra, fmt.Sprintf("target#%s", key.PathSatisfication.Target.PropertyReference))
 		}
-		if propertyReferenceInfluencesEdge(key.PathSatisfication.Source) {
+		if propertyReferenceChangesBoundary(key.PathSatisfication.Source) {
 			extra = append(extra, fmt.Sprintf("source#%s", key.PathSatisfication.Target.PropertyReference))
 		}
 		if len(extra) > 0 {

--- a/pkg/engine2/operational_eval/evaluator.go
+++ b/pkg/engine2/operational_eval/evaluator.go
@@ -125,10 +125,10 @@ func (key Key) String() string {
 		if key.PathSatisfication.Classification != "" {
 			args = append(args, fmt.Sprintf("<%s>", key.PathSatisfication.Classification))
 		}
-		if propertyReferenceInfluencesEdge(key.PathSatisfication.Target) {
+		if propertyReferenceChangesBoundary(key.PathSatisfication.Target) {
 			args = append(args, fmt.Sprintf("target#%s", key.PathSatisfication.Target.PropertyReference))
 		}
-		if propertyReferenceInfluencesEdge(key.PathSatisfication.Source) {
+		if propertyReferenceChangesBoundary(key.PathSatisfication.Source) {
 			args = append(args, fmt.Sprintf("source#%s", key.PathSatisfication.Target.PropertyReference))
 		}
 		return fmt.Sprintf("Expand(%s)", strings.Join(args, ", "))
@@ -359,6 +359,9 @@ func (changes graphChanges) addEdge(source, target Key) {
 
 // addEdges is a convenient lower-level add for [graphChanges.edges] for multiple targets
 func (changes graphChanges) addEdges(source Key, targets set.Set[Key]) {
+	if len(targets) == 0 {
+		return
+	}
 	out, ok := changes.edges[source]
 	if !ok {
 		out = make(set.Set[Key])

--- a/pkg/engine2/operational_eval/graph.go
+++ b/pkg/engine2/operational_eval/graph.go
@@ -94,7 +94,7 @@ func (eval *Evaluator) pathVertices(source, target construct.ResourceId) (graphC
 		// We are checking to see if either of the source or target nodes will change due to property references,
 		// if there are property references we want to ensure the correct dependency ordering is in place so
 		// we cannot yet split the expansion vertex up or build the temp graph
-		if propertyReferenceInfluencesEdge(satisfication.Source) || propertyReferenceInfluencesEdge(satisfication.Target) {
+		if propertyReferenceChangesBoundary(satisfication.Source) || propertyReferenceChangesBoundary(satisfication.Target) {
 			buildTempGraph = false
 		}
 

--- a/pkg/engine2/testdata/lambda_efs.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/lambda_efs.dataflow-viz.yaml
@@ -1,0 +1,14 @@
+provider: aws
+resources:
+  efs_file_system/test-efs-fs:
+
+  vpc/vpc-0:
+
+  lambda_function/lambda_test_app:
+    children: aws:ecr_image:lambda_test_app-image,aws:iam_role:lambda_test_app-ExecutionRole,aws:log_group:lambda_test_app-log-group
+    parent: vpc/vpc-0
+
+  lambda_function/lambda_test_app -> efs_file_system/test-efs-fs:
+    path: aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs
+
+

--- a/pkg/engine2/testdata/lambda_efs.expect.yaml
+++ b/pkg/engine2/testdata/lambda_efs.expect.yaml
@@ -1,0 +1,279 @@
+resources:
+    aws:security_group:vpc-0:lambda_test_app-security_group:
+        EgressRules:
+            - CidrBlocks:
+                - 0.0.0.0/0
+              Description: Allows all outbound IPv4 traffic
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+        IngressRules:
+            - Description: Allow ingress traffic from within the same security group
+              FromPort: 0
+              Protocol: "-1"
+              Self: true
+              ToPort: 0
+        Vpc: aws:vpc:vpc-0
+    aws:lambda_function:lambda_test_app:
+        EfsAccessPoint: aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs
+        ExecutionRole: aws:iam_role:lambda_test_app-ExecutionRole
+        Image: aws:ecr_image:lambda_test_app-image
+        LogGroup: aws:log_group:lambda_test_app-log-group
+        MemorySize: 512
+        SecurityGroups:
+            - aws:security_group:vpc-0:lambda_test_app-security_group
+        Subnets:
+            - aws:subnet:vpc-0:lambda_test_app-test-efs-fs
+            - aws:subnet:vpc-0:subnet-1
+        Timeout: 180
+    aws:ecr_image:lambda_test_app-image:
+        Context: .
+        Dockerfile: lambda_test_app-image.Dockerfile
+        Repo: aws:ecr_repo:ecr_repo-0
+    aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs:
+        FileSystem: aws:efs_file_system:test-efs-fs
+        PosixUser:
+            Gid: 1000
+            Uid: 1000
+        RootDirectory:
+            CreationInfo:
+                OwnerGid: 1000
+                OwnerUid: 1000
+                Permissions: "777"
+            Path: /mnt/efs
+    aws:iam_role:lambda_test_app-ExecutionRole:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRole
+                  Effect: Allow
+                  Principal:
+                    Service:
+                        - lambda.amazonaws.com
+            Version: "2012-10-17"
+        InlinePolicies:
+            - Name: test-efs-fs-policy
+              Policy:
+                Statement:
+                    - Action:
+                        - efs:Client*
+                      Effect: Allow
+                      Resource:
+                        - aws:efs_file_system:test-efs-fs#Arn
+                Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+    aws:ecr_repo:ecr_repo-0:
+        ForceDelete: true
+    aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs:
+        FileSystem: aws:efs_file_system:test-efs-fs
+        SecurityGroups:
+            - aws:security_group:vpc-0:lambda_test_app-test-efs-fs
+        Subnet: aws:subnet:vpc-0:lambda_test_app-test-efs-fs
+    aws:subnet:vpc-0:lambda_test_app-test-efs-fs:
+        AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
+        CidrBlock: 10.0.192.0/18
+        MapPublicIpOnLaunch: false
+        RouteTable: aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table
+        Type: private
+        Vpc: aws:vpc:vpc-0
+    aws:route_table_association:lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table:
+        RouteTable: aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table
+        Subnet: aws:subnet:vpc-0:lambda_test_app-test-efs-fs
+    aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table:
+        Routes:
+            - CidrBlock: 0.0.0.0/0
+              NatGateway: aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway
+        Vpc: aws:vpc:vpc-0
+    aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway:
+        ElasticIp: aws:elastic_ip:lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip
+        Subnet: aws:subnet:vpc-0:subnet-2
+    aws:elastic_ip:lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip:
+    aws:subnet:vpc-0:subnet-2:
+        AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
+        CidrBlock: 10.0.0.0/18
+        MapPublicIpOnLaunch: false
+        RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Type: public
+        Vpc: aws:vpc:vpc-0
+    aws:route_table_association:subnet-2-subnet-2-route_table:
+        RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Subnet: aws:subnet:vpc-0:subnet-2
+    aws:route_table:vpc-0:subnet-2-route_table:
+        Routes:
+            - CidrBlock: 0.0.0.0/0
+              Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Vpc: aws:vpc:vpc-0
+    aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
+    aws:log_group:lambda_test_app-log-group:
+        LogGroupName: /aws/lambda/lambda_test_app
+        RetentionInDays: 5
+    aws:availability_zone:region-0:availability_zone-1:
+        Index: 1
+        Region: aws:region:region-0
+    aws:efs_file_system:test-efs-fs:
+        AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
+        Encrypted: true
+        PerformanceMode: generalPurpose
+        ThroughputMode: bursting
+    aws:availability_zone:region-0:availability_zone-0:
+        Index: 0
+        Region: aws:region:region-0
+    aws:region:region-0:
+    aws:efs_mount_target:test-efs-fs:subnet-1-test-efs-fs:
+        FileSystem: aws:efs_file_system:test-efs-fs
+        SecurityGroups:
+            - aws:security_group:vpc-0:subnet-1-test-efs-fs
+        Subnet: aws:subnet:vpc-0:subnet-1
+    aws:subnet:vpc-0:subnet-1:
+        AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
+        CidrBlock: 10.0.128.0/18
+        MapPublicIpOnLaunch: false
+        RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Type: private
+        Vpc: aws:vpc:vpc-0
+    aws:route_table_association:subnet-1-subnet-1-route_table:
+        RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Subnet: aws:subnet:vpc-0:subnet-1
+    aws:security_group:vpc-0:lambda_test_app-test-efs-fs:
+        EgressRules:
+            - CidrBlocks:
+                - 0.0.0.0/0
+              Description: Allows all outbound IPv4 traffic
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+        IngressRules:
+            - CidrBlocks:
+                - 10.0.192.0/18
+              Description: Allow ingress traffic from ip addresses within the subnet lambda_test_app-test-efs-fs
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+            - Description: Allow ingress traffic from within the same security group
+              FromPort: 0
+              Protocol: "-1"
+              Self: true
+              ToPort: 0
+            - CidrBlocks:
+                - 10.0.128.0/18
+              Description: Allow ingress traffic from ip addresses within the subnet subnet-1
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+        Vpc: aws:vpc:vpc-0
+    aws:security_group:vpc-0:subnet-1-test-efs-fs:
+        EgressRules:
+            - CidrBlocks:
+                - 0.0.0.0/0
+              Description: Allows all outbound IPv4 traffic
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+        IngressRules:
+            - CidrBlocks:
+                - 10.0.128.0/18
+              Description: Allow ingress traffic from ip addresses within the subnet subnet-1
+              FromPort: 0
+              Protocol: "-1"
+              ToPort: 0
+            - Description: Allow ingress traffic from within the same security group
+              FromPort: 0
+              Protocol: "-1"
+              Self: true
+              ToPort: 0
+        Vpc: aws:vpc:vpc-0
+    aws:route_table:vpc-0:subnet-1-route_table:
+        Routes:
+            - CidrBlock: 0.0.0.0/0
+              NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Vpc: aws:vpc:vpc-0
+    aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
+        ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
+        Subnet: aws:subnet:vpc-0:subnet-3
+    aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+    aws:subnet:vpc-0:subnet-3:
+        AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
+        CidrBlock: 10.0.64.0/18
+        MapPublicIpOnLaunch: false
+        RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Type: public
+        Vpc: aws:vpc:vpc-0
+    aws:route_table_association:subnet-3-subnet-3-route_table:
+        RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Subnet: aws:subnet:vpc-0:subnet-3
+    aws:route_table:vpc-0:subnet-3-route_table:
+        Routes:
+            - CidrBlock: 0.0.0.0/0
+              Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Vpc: aws:vpc:vpc-0
+    aws:internet_gateway:vpc-0:internet_gateway-0:
+        Vpc: aws:vpc:vpc-0
+    aws:vpc:vpc-0:
+        CidrBlock: 10.0.0.0/16
+        EnableDnsHostnames: true
+        EnableDnsSupport: true
+edges:
+    aws:security_group:vpc-0:lambda_test_app-security_group -> aws:lambda_function:lambda_test_app:
+    aws:security_group:vpc-0:lambda_test_app-security_group -> aws:vpc:vpc-0:
+    aws:lambda_function:lambda_test_app -> aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
+    aws:lambda_function:lambda_test_app -> aws:ecr_image:lambda_test_app-image:
+    aws:lambda_function:lambda_test_app -> aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs:
+    aws:lambda_function:lambda_test_app -> aws:iam_role:lambda_test_app-ExecutionRole:
+    aws:lambda_function:lambda_test_app -> aws:subnet:vpc-0:lambda_test_app-test-efs-fs:
+    aws:lambda_function:lambda_test_app -> aws:subnet:vpc-0:subnet-1:
+    aws:ecr_image:lambda_test_app-image -> aws:ecr_repo:ecr_repo-0:
+    aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs -> aws:efs_file_system:test-efs-fs:
+    aws:iam_role:lambda_test_app-ExecutionRole -> aws:efs_file_system:test-efs-fs:
+    aws:iam_role:lambda_test_app-ExecutionRole -> aws:log_group:lambda_test_app-log-group:
+    aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs -> aws:efs_file_system:test-efs-fs:
+    aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs -> aws:subnet:vpc-0:lambda_test_app-test-efs-fs:
+    aws:subnet:vpc-0:lambda_test_app-test-efs-fs -> aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
+    aws:subnet:vpc-0:lambda_test_app-test-efs-fs -> aws:availability_zone:region-0:availability_zone-1:
+    ? aws:subnet:vpc-0:lambda_test_app-test-efs-fs -> aws:route_table_association:lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table
+    :
+    aws:subnet:vpc-0:lambda_test_app-test-efs-fs -> aws:security_group:vpc-0:lambda_test_app-test-efs-fs:
+    aws:subnet:vpc-0:lambda_test_app-test-efs-fs -> aws:vpc:vpc-0:
+    ? aws:route_table_association:lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table -> aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table
+    :
+    ? aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table -> aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway
+    :
+    aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table -> aws:vpc:vpc-0:
+    ? aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway -> aws:elastic_ip:lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip
+    :
+    aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway -> aws:subnet:vpc-0:subnet-2:
+    aws:subnet:vpc-0:subnet-2 -> aws:availability_zone:region-0:availability_zone-0:
+    aws:subnet:vpc-0:subnet-2 -> aws:route_table_association:subnet-2-subnet-2-route_table:
+    aws:subnet:vpc-0:subnet-2 -> aws:vpc:vpc-0:
+    aws:route_table_association:subnet-2-subnet-2-route_table -> aws:route_table:vpc-0:subnet-2-route_table:
+    aws:route_table:vpc-0:subnet-2-route_table -> aws:internet_gateway:vpc-0:internet_gateway-0:
+    aws:route_table:vpc-0:subnet-2-route_table -> aws:vpc:vpc-0:
+    aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group -> aws:log_group:lambda_test_app-log-group:
+    aws:availability_zone:region-0:availability_zone-1 -> aws:region:region-0:
+    aws:efs_file_system:test-efs-fs -> aws:availability_zone:region-0:availability_zone-0:
+    aws:availability_zone:region-0:availability_zone-0 -> aws:region:region-0:
+    aws:efs_mount_target:test-efs-fs:subnet-1-test-efs-fs -> aws:efs_file_system:test-efs-fs:
+    aws:efs_mount_target:test-efs-fs:subnet-1-test-efs-fs -> aws:subnet:vpc-0:subnet-1:
+    aws:subnet:vpc-0:subnet-1 -> aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
+    aws:subnet:vpc-0:subnet-1 -> aws:availability_zone:region-0:availability_zone-0:
+    aws:subnet:vpc-0:subnet-1 -> aws:route_table_association:subnet-1-subnet-1-route_table:
+    aws:subnet:vpc-0:subnet-1 -> aws:security_group:vpc-0:lambda_test_app-test-efs-fs:
+    aws:subnet:vpc-0:subnet-1 -> aws:security_group:vpc-0:subnet-1-test-efs-fs:
+    aws:subnet:vpc-0:subnet-1 -> aws:vpc:vpc-0:
+    aws:route_table_association:subnet-1-subnet-1-route_table -> aws:route_table:vpc-0:subnet-1-route_table:
+    aws:security_group:vpc-0:lambda_test_app-test-efs-fs -> aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs:
+    aws:security_group:vpc-0:lambda_test_app-test-efs-fs -> aws:vpc:vpc-0:
+    aws:security_group:vpc-0:subnet-1-test-efs-fs -> aws:efs_mount_target:test-efs-fs:subnet-1-test-efs-fs:
+    aws:security_group:vpc-0:subnet-1-test-efs-fs -> aws:vpc:vpc-0:
+    aws:route_table:vpc-0:subnet-1-route_table -> aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
+    aws:route_table:vpc-0:subnet-1-route_table -> aws:vpc:vpc-0:
+    aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway -> aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+    aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway -> aws:subnet:vpc-0:subnet-3:
+    aws:subnet:vpc-0:subnet-3 -> aws:availability_zone:region-0:availability_zone-1:
+    aws:subnet:vpc-0:subnet-3 -> aws:route_table_association:subnet-3-subnet-3-route_table:
+    aws:subnet:vpc-0:subnet-3 -> aws:vpc:vpc-0:
+    aws:route_table_association:subnet-3-subnet-3-route_table -> aws:route_table:vpc-0:subnet-3-route_table:
+    aws:route_table:vpc-0:subnet-3-route_table -> aws:internet_gateway:vpc-0:internet_gateway-0:
+    aws:route_table:vpc-0:subnet-3-route_table -> aws:vpc:vpc-0:
+    aws:internet_gateway:vpc-0:internet_gateway-0 -> aws:vpc:vpc-0:

--- a/pkg/engine2/testdata/lambda_efs.iac-viz.yaml
+++ b/pkg/engine2/testdata/lambda_efs.iac-viz.yaml
@@ -1,0 +1,122 @@
+provider: aws
+resources:
+  region/region-0:
+
+  aws:availability_zone:region-0/availability_zone-1:
+  aws:availability_zone:region-0/availability_zone-1 -> region/region-0:
+
+  vpc/vpc-0:
+
+  aws:availability_zone:region-0/availability_zone-0:
+  aws:availability_zone:region-0/availability_zone-0 -> region/region-0:
+
+  elastic_ip/subnet-1-route_table-nat_gateway-elastic_ip:
+
+  aws:subnet:vpc-0/subnet-3:
+  aws:subnet:vpc-0/subnet-3 -> aws:availability_zone:region-0/availability_zone-1:
+  aws:subnet:vpc-0/subnet-3 -> vpc/vpc-0:
+
+  elastic_ip/lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip:
+
+  aws:subnet:vpc-0/subnet-2:
+  aws:subnet:vpc-0/subnet-2 -> aws:availability_zone:region-0/availability_zone-0:
+  aws:subnet:vpc-0/subnet-2 -> vpc/vpc-0:
+
+  aws:internet_gateway:vpc-0/internet_gateway-0:
+  aws:internet_gateway:vpc-0/internet_gateway-0 -> vpc/vpc-0:
+
+  aws:nat_gateway:subnet-3/subnet-1-route_table-nat_gateway:
+  aws:nat_gateway:subnet-3/subnet-1-route_table-nat_gateway -> elastic_ip/subnet-1-route_table-nat_gateway-elastic_ip:
+  aws:nat_gateway:subnet-3/subnet-1-route_table-nat_gateway -> aws:subnet:vpc-0/subnet-3:
+
+  aws:security_group:vpc-0/lambda_test_app-test-efs-fs:
+  aws:security_group:vpc-0/lambda_test_app-test-efs-fs -> vpc/vpc-0:
+
+  aws:security_group:vpc-0/subnet-1-test-efs-fs:
+  aws:security_group:vpc-0/subnet-1-test-efs-fs -> vpc/vpc-0:
+
+  aws:nat_gateway:subnet-2/lambda_test_app-test-efs-fs-route_table-nat_gateway:
+  aws:nat_gateway:subnet-2/lambda_test_app-test-efs-fs-route_table-nat_gateway -> elastic_ip/lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip:
+  aws:nat_gateway:subnet-2/lambda_test_app-test-efs-fs-route_table-nat_gateway -> aws:subnet:vpc-0/subnet-2:
+
+  ecr_repo/ecr_repo-0:
+
+  efs_file_system/test-efs-fs:
+  efs_file_system/test-efs-fs -> aws:availability_zone:region-0/availability_zone-0:
+
+  log_group/lambda_test_app-log-group:
+
+  aws:route_table:vpc-0/subnet-3-route_table:
+  aws:route_table:vpc-0/subnet-3-route_table -> aws:internet_gateway:vpc-0/internet_gateway-0:
+  aws:route_table:vpc-0/subnet-3-route_table -> vpc/vpc-0:
+
+  aws:route_table:vpc-0/subnet-2-route_table:
+  aws:route_table:vpc-0/subnet-2-route_table -> aws:internet_gateway:vpc-0/internet_gateway-0:
+  aws:route_table:vpc-0/subnet-2-route_table -> vpc/vpc-0:
+
+  aws:route_table:vpc-0/subnet-1-route_table:
+  aws:route_table:vpc-0/subnet-1-route_table -> aws:nat_gateway:subnet-3/subnet-1-route_table-nat_gateway:
+  aws:route_table:vpc-0/subnet-1-route_table -> vpc/vpc-0:
+
+  aws:subnet:vpc-0/subnet-1:
+  aws:subnet:vpc-0/subnet-1 -> aws:availability_zone:region-0/availability_zone-0:
+  aws:subnet:vpc-0/subnet-1 -> aws:security_group:vpc-0/lambda_test_app-test-efs-fs:
+  aws:subnet:vpc-0/subnet-1 -> aws:security_group:vpc-0/subnet-1-test-efs-fs:
+  aws:subnet:vpc-0/subnet-1 -> vpc/vpc-0:
+
+  aws:route_table:vpc-0/lambda_test_app-test-efs-fs-route_table:
+  aws:route_table:vpc-0/lambda_test_app-test-efs-fs-route_table -> aws:nat_gateway:subnet-2/lambda_test_app-test-efs-fs-route_table-nat_gateway:
+  aws:route_table:vpc-0/lambda_test_app-test-efs-fs-route_table -> vpc/vpc-0:
+
+  aws:subnet:vpc-0/lambda_test_app-test-efs-fs:
+  aws:subnet:vpc-0/lambda_test_app-test-efs-fs -> aws:availability_zone:region-0/availability_zone-1:
+  aws:subnet:vpc-0/lambda_test_app-test-efs-fs -> aws:security_group:vpc-0/lambda_test_app-test-efs-fs:
+  aws:subnet:vpc-0/lambda_test_app-test-efs-fs -> vpc/vpc-0:
+
+  ecr_image/lambda_test_app-image:
+  ecr_image/lambda_test_app-image -> ecr_repo/ecr_repo-0:
+
+  aws:efs_access_point:test-efs-fs/lambda_test_app-test-efs-fs:
+  aws:efs_access_point:test-efs-fs/lambda_test_app-test-efs-fs -> efs_file_system/test-efs-fs:
+
+  iam_role/lambda_test_app-executionrole:
+  iam_role/lambda_test_app-executionrole -> efs_file_system/test-efs-fs:
+  iam_role/lambda_test_app-executionrole -> log_group/lambda_test_app-log-group:
+
+  aws:security_group:vpc-0/lambda_test_app-security_group:
+  aws:security_group:vpc-0/lambda_test_app-security_group -> vpc/vpc-0:
+
+  route_table_association/subnet-3-subnet-3-route_table:
+  route_table_association/subnet-3-subnet-3-route_table -> aws:route_table:vpc-0/subnet-3-route_table:
+  route_table_association/subnet-3-subnet-3-route_table -> aws:subnet:vpc-0/subnet-3:
+
+  route_table_association/subnet-2-subnet-2-route_table:
+  route_table_association/subnet-2-subnet-2-route_table -> aws:route_table:vpc-0/subnet-2-route_table:
+  route_table_association/subnet-2-subnet-2-route_table -> aws:subnet:vpc-0/subnet-2:
+
+  route_table_association/subnet-1-subnet-1-route_table:
+  route_table_association/subnet-1-subnet-1-route_table -> aws:route_table:vpc-0/subnet-1-route_table:
+  route_table_association/subnet-1-subnet-1-route_table -> aws:subnet:vpc-0/subnet-1:
+
+  route_table_association/lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table:
+  route_table_association/lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table -> aws:route_table:vpc-0/lambda_test_app-test-efs-fs-route_table:
+  route_table_association/lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table -> aws:subnet:vpc-0/lambda_test_app-test-efs-fs:
+
+  lambda_function/lambda_test_app:
+  lambda_function/lambda_test_app -> ecr_image/lambda_test_app-image:
+  lambda_function/lambda_test_app -> aws:efs_access_point:test-efs-fs/lambda_test_app-test-efs-fs:
+  lambda_function/lambda_test_app -> iam_role/lambda_test_app-executionrole:
+  lambda_function/lambda_test_app -> aws:security_group:vpc-0/lambda_test_app-security_group:
+  lambda_function/lambda_test_app -> aws:subnet:vpc-0/lambda_test_app-test-efs-fs:
+  lambda_function/lambda_test_app -> aws:subnet:vpc-0/subnet-1:
+
+  aws:efs_mount_target:test-efs-fs/subnet-1-test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/subnet-1-test-efs-fs -> efs_file_system/test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/subnet-1-test-efs-fs -> aws:security_group:vpc-0/subnet-1-test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/subnet-1-test-efs-fs -> aws:subnet:vpc-0/subnet-1:
+
+  aws:efs_mount_target:test-efs-fs/lambda_test_app-test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/lambda_test_app-test-efs-fs -> efs_file_system/test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/lambda_test_app-test-efs-fs -> aws:security_group:vpc-0/lambda_test_app-test-efs-fs:
+  aws:efs_mount_target:test-efs-fs/lambda_test_app-test-efs-fs -> aws:subnet:vpc-0/lambda_test_app-test-efs-fs:
+

--- a/pkg/engine2/testdata/lambda_efs.input.yaml
+++ b/pkg/engine2/testdata/lambda_efs.input.yaml
@@ -1,0 +1,12 @@
+constraints:
+- node: aws:lambda_function:lambda_test_app
+  operator: add
+  scope: application
+- node: aws:efs_file_system:test-efs-fs
+  operator: add
+  scope: application
+- operator: must_exist
+  scope: edge
+  target:
+    source: aws:lambda_function:lambda_test_app
+    target: aws:efs_file_system:test-efs-fs

--- a/pkg/engine2/testdata/namespace_pathselect.expect.yaml
+++ b/pkg/engine2/testdata/namespace_pathselect.expect.yaml
@@ -62,8 +62,8 @@ resources:
                         - lambda.amazonaws.com
             Version: "2012-10-17"
         ManagedPolicies:
-            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
     aws:subnet:vpc_1:lambda_function_2-vpc_1:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18


### PR DESCRIPTION
Since `lambda#Subnets` had 1 value from another path expansion, the other expansion wasn't properly depending on the final resolution of the subnets, so when `Expand(aws:lambda_function:lambda_test_app -> aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs, <network>, source#Subnet#AvailabilityZone)` ran before, the lambda only had 1 subnet and wasn't properly setting up the path to mount point for the other subnet.

Pending e2e test to confirm, but resources.yaml now has 2 mount_points which it did not previously.