### PR TITLE
fix eks bugs

### DIFF
--- a/pkg/engine2/testdata/k8s_api.expect.yaml
+++ b/pkg/engine2/testdata/k8s_api.expect.yaml
@@ -452,7 +452,6 @@ resources:
         Region: aws:region:region-0
     aws:eks_cluster:eks_cluster-0:
         ClusterRole: aws:iam_role:ClusterRole-eks_cluster-0
-        KubeConfig: kubernetes:kube_config:eks_cluster-0-kube_config
         SecurityGroups:
             - aws:security_group:vpc-0:eks_cluster-0-security_group
         Subnets:

--- a/pkg/infra/iac3/plugin.go
+++ b/pkg/infra/iac3/plugin.go
@@ -145,7 +145,7 @@ func (p Plugin) Translate(ctx solution_context.SolutionContext) ([]kio.File, err
 func (p *Plugin) sanitizeConfig() error {
 	reg, err := regexp.Compile("[^a-zA-Z0-9-_]+")
 	if err != nil {
-		return fmt.Errorf("Error compiling regex: %v", err)
+		return fmt.Errorf("error compiling regex: %v", err)
 	}
 	p.Config.AppName = reg.ReplaceAllString(p.Config.AppName, "")
 	return nil

--- a/pkg/knowledge_base2/emitter.go
+++ b/pkg/knowledge_base2/emitter.go
@@ -90,24 +90,24 @@ func ConsumeFromResource(consumer, emitter *construct.Resource, ctx DynamicConte
 					addErr(consume, emit, err)
 					continue
 				}
-				val, err = sanitizeForConsumption(ctx, resource, consumeTmpl.GetProperty(consume.PropertyPath), val)
-				if err != nil {
-					addErr(consume, emit, err)
-					continue
-				}
 				pval, err := resource.GetProperty(consume.PropertyPath)
 				if err != nil {
 					addErr(consume, emit, err)
 					continue
 				}
-				if pval == nil {
-					if consume.Converter != "" {
-						val, err = consume.Convert(val, id, ctx)
-						if err != nil {
-							addErr(consume, emit, err)
-							continue
-						}
+				if consume.Converter != "" {
+					val, err = consume.Convert(val, id, ctx)
+					if err != nil {
+						addErr(consume, emit, err)
+						continue
 					}
+				}
+				val, err = sanitizeForConsumption(ctx, resource, consumeTmpl.GetProperty(consume.PropertyPath), val)
+				if err != nil {
+					addErr(consume, emit, err)
+					continue
+				}
+				if pval == nil {
 					delays = append(delays, DelayedConsumption{
 						Value:        val,
 						Resource:     id,
@@ -115,7 +115,6 @@ func ConsumeFromResource(consumer, emitter *construct.Resource, ctx DynamicConte
 					})
 					continue
 				}
-
 				err = consume.Consume(val, ctx, resource)
 				if err != nil {
 					addErr(consume, emit, err)

--- a/pkg/knowledge_base2/properties/list_property.go
+++ b/pkg/knowledge_base2/properties/list_property.go
@@ -177,7 +177,7 @@ func (l *ListProperty) Validate(resource *construct.Resource, value any, ctx kno
 
 	listVal, ok := value.([]any)
 	if !ok {
-		return fmt.Errorf("invalid map value %v", value)
+		return fmt.Errorf("invalid list value %v", value)
 	}
 	if l.MinLength != nil {
 		if len(listVal) < *l.MinLength {

--- a/pkg/templates/aws/edges/eks_cluster-vpc.yaml
+++ b/pkg/templates/aws/edges/eks_cluster-vpc.yaml
@@ -26,3 +26,8 @@ operational_rules:
             properties:
               SecurityGroupId: '{{ fieldRef "ClusterSecurityGroup" .Source }}'
               Type: ingress
+      - resource: '{{ .Source }}' # Temporarily generate the kube_config for the cluster
+        direction: upstream
+        resources:
+          - kubernetes:kube_config
+        unique: true

--- a/pkg/templates/aws/resources/eks_cluster.yaml
+++ b/pkg/templates/aws/resources/eks_cluster.yaml
@@ -39,16 +39,6 @@ properties:
           - aws:security_group
         unique: true
     description: Lists the security groups associated with the EKS cluster nodes
-  KubeConfig:
-    type: resource(kubernetes:kube_config)
-    operational_rule:
-      step:
-        direction: upstream
-        resources:
-          - kubernetes:kube_config
-        unique: true
-    description: Points to a Kubernetes kubeconfig file containing cluster access
-      information
   Name:
     type: string
     configuration_disabled: true


### PR DESCRIPTION
fixes kubeconfig circular iac dependency and emitter bug to where we try to sanitize to the wrong type since its done before convert

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
