### PR TITLE
allow ability to add imported resources via constraints

### DIFF
--- a/pkg/construct2/resource.go
+++ b/pkg/construct2/resource.go
@@ -3,6 +3,7 @@ package construct2
 type Resource struct {
 	ID         ResourceId
 	Properties Properties
+	Imported   bool
 }
 
 // Id is a temporary bridge to the old Resource interface.

--- a/pkg/engine2/constraints.go
+++ b/pkg/engine2/constraints.go
@@ -57,6 +57,10 @@ func applyApplicationConstraint(ctx solution_context.SolutionContext, constraint
 	case constraints.AddConstraintOperator:
 		return ctx.OperationalView().AddVertex(res)
 
+	case constraints.ImportConstraintOperator:
+		res.Imported = true
+		return ctx.OperationalView().AddVertex(res)
+
 	case constraints.RemoveConstraintOperator:
 		return reconciler.RemoveResource(ctx, res.ID, true)
 

--- a/pkg/engine2/constraints/application_constraint.go
+++ b/pkg/engine2/constraints/application_constraint.go
@@ -87,6 +87,9 @@ func (constraint *ApplicationConstraint) Validate() error {
 	if constraint.Operator == RemoveConstraintOperator && (constraint.Node == construct.ResourceId{}) {
 		return errors.New("remove constraint must have a node defined")
 	}
+	if constraint.Operator == ImportConstraintOperator && (constraint.Node == construct.ResourceId{}) {
+		return errors.New("import constraint must have a node defined")
+	}
 	return nil
 }
 

--- a/pkg/engine2/constraints/constraint.go
+++ b/pkg/engine2/constraints/constraint.go
@@ -69,6 +69,7 @@ const (
 	MustExistConstraintOperator    ConstraintOperator = "must_exist"
 	MustNotExistConstraintOperator ConstraintOperator = "must_not_exist"
 	AddConstraintOperator          ConstraintOperator = "add"
+	ImportConstraintOperator       ConstraintOperator = "import"
 	RemoveConstraintOperator       ConstraintOperator = "remove"
 	ReplaceConstraintOperator      ConstraintOperator = "replace"
 	EqualsConstraintOperator       ConstraintOperator = "equals"

--- a/pkg/engine2/constraints_test.go
+++ b/pkg/engine2/constraints_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestApplyConstraints(t *testing.T) {
 	tests := []struct {
-		name        string
-		init        []any
-		constraints constraints.Constraints
-		want        enginetesting.ExpectedGraphs
-		wantErr     bool
+		name           string
+		init           []any
+		constraints    constraints.Constraints
+		want           enginetesting.ExpectedGraphs
+		resourceChecks func(t *testing.T, ctx *enginetesting.TestSolution)
+		wantErr        bool
 	}{
 		{
 			name: "add resource",
@@ -30,6 +31,23 @@ func TestApplyConstraints(t *testing.T) {
 			want: enginetesting.ExpectedGraphs{
 				Dataflow:   []any{"p:t:test"},
 				Deployment: []any{"p:t:test"},
+			},
+		},
+		{
+			name: "import resource",
+			constraints: constraints.Constraints{
+				Application: []constraints.ApplicationConstraint{
+					{Operator: constraints.ImportConstraintOperator, Node: graphtest.ParseId(t, "p:t:test")},
+				},
+			},
+			want: enginetesting.ExpectedGraphs{
+				Dataflow:   []any{"p:t:test"},
+				Deployment: []any{"p:t:test"},
+			},
+			resourceChecks: func(t *testing.T, ctx *enginetesting.TestSolution) {
+				res, err := ctx.RawView().Vertex(graphtest.ParseId(t, "p:t:test"))
+				require.NoError(t, err)
+				require.True(t, res.Imported)
 			},
 		},
 		{

--- a/pkg/engine2/operational_eval/vertex_path_expand.go
+++ b/pkg/engine2/operational_eval/vertex_path_expand.go
@@ -60,7 +60,7 @@ func expansionResultString(result construct.Graph, dep construct.ResourceEdge) (
 
 	path, err := graph.ShortestPathStable(result, dep.Source.ID, dep.Target.ID, construct.ResourceIdLess)
 	if err != nil {
-		return "", fmt.Errorf("expansion result does not contain path from %s to %s: %w", dep.Source, dep.Target, err)
+		return "", fmt.Errorf("expansion result does not contain path from %s to %s: %w", dep.Source.ID, dep.Target.ID, err)
 	}
 	for i, res := range path {
 		if i == 0 {

--- a/pkg/engine2/path_selection/candidate_validity.go
+++ b/pkg/engine2/path_selection/candidate_validity.go
@@ -246,7 +246,7 @@ func (d downstreamChecker) makeValid(resource, operationResource *construct.Reso
 		var errs error
 		rt, err := d.ctx.KnowledgeBase().GetResourceTemplate(r)
 		if err != nil || rt == nil {
-			return false, fmt.Errorf("error getting resource template for resource %s: %w", resource, err)
+			return false, fmt.Errorf("error getting resource template for resource %s: %w", resource.ID, err)
 		}
 		p := rt.Properties[property]
 		for _, downstream := range downstreams {
@@ -263,7 +263,7 @@ func (d downstreamChecker) makeValid(resource, operationResource *construct.Reso
 			} else {
 				currRes, err = d.ctx.RawView().Vertex(r)
 				if err != nil {
-					errs = errors.Join(errs, fmt.Errorf("error getting resource %s: %w", resource, err))
+					errs = errors.Join(errs, fmt.Errorf("error getting resource %s: %w", resource.ID, err))
 					continue
 				}
 			}

--- a/pkg/engine2/path_selection/edge_validity.go
+++ b/pkg/engine2/path_selection/edge_validity.go
@@ -87,7 +87,7 @@ func checkProperties(ctx solution_context.SolutionContext, resource, toCheck *co
 			match, err := selector.CanUse(solution_context.DynamicCtx(ctx), knowledgebase.DynamicValueData{Resource: resource.ID},
 				toCheck)
 			if err != nil {
-				return fmt.Errorf("error checking if resource %s matches selector %s: %w", toCheck, selector.Selector, err)
+				return fmt.Errorf("error checking if resource %s matches selector %s: %w", toCheck.ID, selector.Selector, err)
 			}
 			// if its a match for the selectors, lets ensure that it has a dependency and exists in the properties of the rul
 			if !match {
@@ -95,7 +95,7 @@ func checkProperties(ctx solution_context.SolutionContext, resource, toCheck *co
 			}
 			property, err := resource.GetProperty(details.Path)
 			if err != nil {
-				return fmt.Errorf("error getting property %s for resource %s: %w", details.Path, toCheck, err)
+				return fmt.Errorf("error getting property %s for resource %s: %w", details.Path, toCheck.ID, err)
 			}
 			if property != nil {
 				if checkIfPropertyContainsResource(property, toCheck.ID) {
@@ -261,7 +261,7 @@ func checkIfCreatedAsUniqueValidity(ctx solution_context.SolutionContext, resour
 				match, err := selector.CanUse(solution_context.DynamicCtx(ctx), knowledgebase.DynamicValueData{Resource: currRes.ID},
 					resource)
 				if err != nil {
-					return fmt.Errorf("error checking if resource %s matches selector %s: %w", other, selector.Selector, err)
+					return fmt.Errorf("error checking if resource %s matches selector %s: %w", other.ID, selector.Selector, err)
 				}
 				// if its a match for the selectors, lets ensure that it has a dependency and exists in the properties of the rul
 				if !match {

--- a/pkg/engine2/path_selection/path_expansion.go
+++ b/pkg/engine2/path_selection/path_expansion.go
@@ -320,7 +320,7 @@ func expandPath(
 		}
 		valid, err := checkNamespaceValidity(ctx, resource, input.Dep.Target.ID)
 		if err != nil {
-			return errors.Join(nerr, fmt.Errorf("error checking namespace validity of %s: %w", resource, err))
+			return errors.Join(nerr, fmt.Errorf("error checking namespace validity of %s: %w", resource.ID, err))
 		}
 		if !valid {
 			return nerr


### PR DESCRIPTION
adds the import constraint which currently just adds the imported resource and flags it as being imported.

This pr does not affect any of the graph solving or protect the imported resource from mutations

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
