### PR TITLE
add eks add on for cloudwatch

### DIFF
--- a/pkg/engine2/testdata/k8s_api.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/k8s_api.dataflow-viz.yaml
@@ -13,11 +13,13 @@ resources:
         - aws:api_method:rest_api_4:rest_api_4_integration_0_method
         - aws:api_resource:rest_api_4:api_resource-0
         - aws:api_stage:rest_api_4:api_stage-0
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_node_group:eks_node_group-0
         - aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         - aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2
@@ -46,11 +48,13 @@ resources:
         - aws:api_method:rest_api_4:rest_api_4_integration_0_method
         - aws:api_resource:rest_api_4:api_resource-0
         - aws:api_stage:rest_api_4:api_stage-0
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_node_group:eks_node_group-0
         - aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         - aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2
@@ -78,11 +82,13 @@ resources:
         - aws:api_method:rest_api_4:rest_api_4_integration_0_method
         - aws:api_resource:rest_api_4:api_resource-0
         - aws:api_stage:rest_api_4:api_stage-0
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_node_group:eks_node_group-0
         - aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         - aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2
@@ -110,11 +116,13 @@ resources:
         - aws:api_method:rest_api_4:rest_api_4_integration_0_method
         - aws:api_resource:rest_api_4:api_resource-0
         - aws:api_stage:rest_api_4:api_stage-0
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_node_group:eks_node_group-0
         - aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         - aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2
@@ -142,19 +150,18 @@ resources:
 
   eks_cluster/eks_cluster-0:
     children:
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_add_on:vpc-cni
         - aws:eks_node_group:eks_node_group-0
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
         - aws:iam_role:ClusterRole-eks_cluster-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2
         - aws:security_group:vpc-0:eks_cluster-0-security_group
         - aws:target_group:rest-api-4-integbcc77100
-        - kubernetes:config_map:fluent-bit-cluster-info
-        - kubernetes:manifest:fluent-bit
-        - kubernetes:namespace:amazon-cloudwatch
         - kubernetes:service:eks_cluster-0:restapi4integration0-pod2
         - kubernetes:service_account:eks_cluster-0:aws-load-balancer-controller
         - kubernetes:service_account:eks_cluster-0:pod2
@@ -167,11 +174,13 @@ resources:
         - aws:api_method:rest_api_4:rest_api_4_integration_0_method
         - aws:api_resource:rest_api_4:api_resource-0
         - aws:api_stage:rest_api_4:api_stage-0
+        - aws:eks_add_on:amazon-cloudwatch-observability
         - aws:eks_node_group:eks_node_group-0
         - aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         - aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         - aws:iam_oidc_provider:eks_cluster-0
         - aws:iam_policy:iam_policy-0
+        - aws:iam_role:amazon-cloudwatch-observability-iam_role
         - aws:iam_role:aws-load-balancer-controller
         - aws:iam_role:eks_node_group-0-iam_role
         - aws:iam_role:pod2

--- a/pkg/engine2/testdata/k8s_api.expect.yaml
+++ b/pkg/engine2/testdata/k8s_api.expect.yaml
@@ -3,6 +3,10 @@ resources:
         Deployment: aws:api_deployment:rest_api_4:api_deployment-0
         RestApi: aws:rest_api:rest_api_4
         StageName: stage
+    aws:eks_add_on:amazon-cloudwatch-observability:
+        AddOnName: amazon-cloudwatch-observability
+        Cluster: aws:eks_cluster:eks_cluster-0
+        Role: aws:iam_role:amazon-cloudwatch-observability-iam_role
     aws:eks_add_on:vpc-cni:
         AddOnName: vpc-cni
         Cluster: aws:eks_cluster:eks_cluster-0
@@ -47,48 +51,28 @@ resources:
                         - --region
                         - aws:region:region-0#Name
                     command: aws
-    kubernetes:manifest:fluent-bit:
-        Cluster: aws:eks_cluster:eks_cluster-0
-        FilePath: https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
     aws:api_deployment:rest_api_4:api_deployment-0:
         RestApi: aws:rest_api:rest_api_4
         Triggers:
             rest_api_4_integration_0: rest_api_4_integration_0
             rest_api_4_integration_0_method: rest_api_4_integration_0_method
-    kubernetes:config_map:fluent-bit-cluster-info:
-        Cluster: aws:eks_cluster:eks_cluster-0
-        Object:
-            apiVersion: v1
-            data:
-                cluster:
-                    name: aws:eks_cluster:eks_cluster-0#Name
-                http:
-                    port: "2020"
-                    server: "On"
-                logs:
-                    region: aws:region:region-0#Name
-                read:
-                    head: "Off"
-                    tail: "On"
-            kind: ConfigMap
-            metadata:
-                labels:
-                    k8s-app: fluent-bit
-                name: fluent-bit-cluster-info
-                namespace: kubernetes:namespace:amazon-cloudwatch
+    aws:iam_role:amazon-cloudwatch-observability-iam_role:
+        AssumeRolePolicyDoc:
+            Statement:
+                - Action:
+                    - sts:AssumeRoleWithWebIdentity
+                  Effect: Allow
+                  Principal:
+                    Federated:
+                        - aws:iam_oidc_provider:eks_cluster-0#Arn
+            Version: "2012-10-17"
+        ManagedPolicies:
+            - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+            - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
     aws:rest_api:rest_api_4:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
-    kubernetes:namespace:amazon-cloudwatch:
-        Cluster: aws:eks_cluster:eks_cluster-0
-        Object:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-                labels:
-                    name: amazon-cloudwatch
-                name: amazon-cloudwatch
     aws:api_resource:rest_api_4:api_resource-0:
         FullPath: /{proxy+}
         PathPart: '{proxy+}'
@@ -283,12 +267,12 @@ resources:
                         - ec2.amazonaws.com
             Version: "2012-10-17"
         ManagedPolicies:
+            - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+            - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
             - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
             - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
             - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
             - arn:aws:iam::aws:policy/AWSCloudMapFullAccess
-            - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
-            - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
     aws:iam_role:pod2:
         AssumeRolePolicyDoc:
             Statement:
@@ -587,22 +571,20 @@ resources:
 edges:
     aws:api_stage:rest_api_4:api_stage-0 -> aws:api_deployment:rest_api_4:api_deployment-0:
     aws:api_stage:rest_api_4:api_stage-0 -> aws:rest_api:rest_api_4:
+    aws:eks_add_on:amazon-cloudwatch-observability -> aws:eks_cluster:eks_cluster-0:
+    aws:eks_add_on:amazon-cloudwatch-observability -> aws:iam_role:amazon-cloudwatch-observability-iam_role:
     aws:eks_add_on:vpc-cni -> aws:eks_cluster:eks_cluster-0:
     aws:security_group_rule:security_group_rule-0 -> aws:vpc:vpc-0:
     kubernetes:helm_chart:eks_cluster-0:metricsserver -> aws:eks_cluster:eks_cluster-0:
     kubernetes:helm_chart:eks_cluster-0:metricsserver -> aws:eks_node_group:eks_node_group-0:
     kubernetes:kube_config:eks_cluster-0-kube_config -> aws:eks_cluster:eks_cluster-0:
-    kubernetes:manifest:fluent-bit -> aws:eks_cluster:eks_cluster-0:
-    kubernetes:manifest:fluent-bit -> kubernetes:config_map:fluent-bit-cluster-info:
     aws:api_deployment:rest_api_4:api_deployment-0 -> aws:api_integration:rest_api_4:rest_api_4_integration_0:
     aws:api_deployment:rest_api_4:api_deployment-0 -> aws:api_method:rest_api_4:rest_api_4_integration_0_method:
     aws:api_deployment:rest_api_4:api_deployment-0 -> aws:rest_api:rest_api_4:
-    kubernetes:config_map:fluent-bit-cluster-info -> aws:eks_cluster:eks_cluster-0:
-    kubernetes:config_map:fluent-bit-cluster-info -> kubernetes:namespace:amazon-cloudwatch:
+    aws:iam_role:amazon-cloudwatch-observability-iam_role -> aws:iam_oidc_provider:eks_cluster-0:
     aws:rest_api:rest_api_4 -> aws:api_integration:rest_api_4:rest_api_4_integration_0:
     aws:rest_api:rest_api_4 -> aws:api_method:rest_api_4:rest_api_4_integration_0_method:
     aws:rest_api:rest_api_4 -> aws:api_resource:rest_api_4:api_resource-0:
-    kubernetes:namespace:amazon-cloudwatch -> aws:eks_cluster:eks_cluster-0:
     aws:api_resource:rest_api_4:api_resource-0 -> aws:api_integration:rest_api_4:rest_api_4_integration_0:
     aws:api_resource:rest_api_4:api_resource-0 -> aws:api_method:rest_api_4:rest_api_4_integration_0_method:
     aws:api_method:rest_api_4:rest_api_4_integration_0_method -> aws:api_integration:rest_api_4:rest_api_4_integration_0:

--- a/pkg/engine2/testdata/k8s_api.iac-viz.yaml
+++ b/pkg/engine2/testdata/k8s_api.iac-viz.yaml
@@ -97,9 +97,6 @@ resources:
   kubernetes:pod:eks_cluster-0/pod2 -> eks_cluster/eks_cluster-0:
   kubernetes:pod:eks_cluster-0/pod2 -> eks_node_group/eks_node_group-0:
   kubernetes:pod:eks_cluster-0/pod2 -> kubernetes:service_account:eks_cluster-0/pod2:
-  kubernetes:namespace/amazon-cloudwatch:
-
-  kubernetes:namespace/amazon-cloudwatch -> eks_cluster/eks_cluster-0:
   aws:internet_gateway:vpc-0/internet_gateway-0:
 
   aws:internet_gateway:vpc-0/internet_gateway-0 -> vpc/vpc-0:
@@ -130,10 +127,6 @@ resources:
 
   kubernetes:service:eks_cluster-0/restapi4integration0-pod2 -> eks_cluster/eks_cluster-0:
   kubernetes:service:eks_cluster-0/restapi4integration0-pod2 -> kubernetes:pod:eks_cluster-0/pod2:
-  kubernetes:config_map/fluent-bit-cluster-info:
-
-  kubernetes:config_map/fluent-bit-cluster-info -> eks_cluster/eks_cluster-0:
-  kubernetes:config_map/fluent-bit-cluster-info -> kubernetes:namespace/amazon-cloudwatch:
   aws:route_table:vpc-0/subnet-3-route_table:
 
   aws:route_table:vpc-0/subnet-3-route_table -> aws:internet_gateway:vpc-0/internet_gateway-0:
@@ -152,6 +145,9 @@ resources:
   aws:route_table:vpc-0/subnet-0-route_table -> vpc/vpc-0:
   iam_policy/iam_policy-0:
 
+  iam_role/amazon-cloudwatch-observability-iam_role:
+
+  iam_role/amazon-cloudwatch-observability-iam_role -> iam_oidc_provider/eks_cluster-0:
   aws:api_deployment:rest_api_4/api_deployment-0:
 
   aws:api_deployment:rest_api_4/api_deployment-0 -> aws:api_integration:rest_api_4/rest_api_4_integration_0:
@@ -163,10 +159,6 @@ resources:
   kubernetes:target_group_binding:eks_cluster-0/restapi4integration0-pod2 -> target_group/rest-api-4-integbcc77100:
   kubernetes:target_group_binding:eks_cluster-0/restapi4integration0-pod2 -> kubernetes:helm_chart:eks_cluster-0/aws-load-balancer-controller:
   kubernetes:target_group_binding:eks_cluster-0/restapi4integration0-pod2 -> kubernetes:service:eks_cluster-0/restapi4integration0-pod2:
-  kubernetes:manifest/fluent-bit:
-
-  kubernetes:manifest/fluent-bit -> eks_cluster/eks_cluster-0:
-  kubernetes:manifest/fluent-bit -> kubernetes:config_map/fluent-bit-cluster-info:
   kubernetes:kube_config/eks_cluster-0-kube_config:
 
   kubernetes:kube_config/eks_cluster-0-kube_config -> eks_cluster/eks_cluster-0:
@@ -205,6 +197,10 @@ resources:
   eks_add_on/vpc-cni:
 
   eks_add_on/vpc-cni -> eks_cluster/eks_cluster-0:
+  eks_add_on/amazon-cloudwatch-observability:
+
+  eks_add_on/amazon-cloudwatch-observability -> eks_cluster/eks_cluster-0:
+  eks_add_on/amazon-cloudwatch-observability -> iam_role/amazon-cloudwatch-observability-iam_role:
   aws:api_stage:rest_api_4/api_stage-0:
 
   aws:api_stage:rest_api_4/api_stage-0 -> aws:api_deployment:rest_api_4/api_deployment-0:

--- a/pkg/knowledge_base2/properties/list_property.go
+++ b/pkg/knowledge_base2/properties/list_property.go
@@ -193,7 +193,6 @@ func (l *ListProperty) Validate(resource *construct.Resource, value any, ctx kno
 	validList := make([]any, len(listVal))
 	var errs error
 	hasSanitized := false
-	// validate each entry in the list
 	for i, v := range listVal {
 		if l.ItemProperty != nil {
 			err := l.ItemProperty.Validate(resource, v, ctx)
@@ -211,7 +210,7 @@ func (l *ListProperty) Validate(resource *construct.Resource, value any, ctx kno
 		} else {
 			vmap, ok := v.(map[string]any)
 			if !ok {
-				return fmt.Errorf("invalid value for list indices in sub properties validation: %v", value)
+				return fmt.Errorf("invalid value for list index %d in sub properties validation: expected map[string]any got %T", i, v)
 			}
 			validIndex := make(map[string]any)
 			for _, prop := range l.SubProperties() {

--- a/pkg/knowledge_base2/properties/list_property.go
+++ b/pkg/knowledge_base2/properties/list_property.go
@@ -189,12 +189,13 @@ func (l *ListProperty) Validate(resource *construct.Resource, value any, ctx kno
 			return fmt.Errorf("list value %v is too long. max length is %d", value, *l.MaxLength)
 		}
 	}
-	// Only validate values if its a primitive list, otherwise let the sub properties handle their own validation
-	if l.ItemProperty != nil {
-		var errs error
-		hasSanitized := false
-		validList := make([]any, len(listVal))
-		for i, v := range listVal {
+
+	validList := make([]any, len(listVal))
+	var errs error
+	hasSanitized := false
+	// validate each entry in the list
+	for i, v := range listVal {
+		if l.ItemProperty != nil {
 			err := l.ItemProperty.Validate(resource, v, ctx)
 			if err != nil {
 				var sanitizeErr *knowledgebase.SanitizeError
@@ -207,17 +208,43 @@ func (l *ListProperty) Validate(resource *construct.Resource, value any, ctx kno
 			} else {
 				validList[i] = v
 			}
-		}
-		if errs != nil {
-			return errs
-		}
-		if hasSanitized {
-			return &knowledgebase.SanitizeError{
-				Input:     listVal,
-				Sanitized: validList,
+		} else {
+			vmap, ok := v.(map[string]any)
+			if !ok {
+				return fmt.Errorf("invalid value for list indices in sub properties validation: %v", value)
 			}
+			validIndex := make(map[string]any)
+			for _, prop := range l.SubProperties() {
+				val, ok := vmap[prop.Details().Name]
+				if !ok {
+					continue
+				}
+				err := prop.Validate(resource, val, ctx)
+				if err != nil {
+					var sanitizeErr *knowledgebase.SanitizeError
+					if errors.As(err, &sanitizeErr) {
+						validIndex[prop.Details().Name] = sanitizeErr.Sanitized
+						hasSanitized = true
+					} else {
+						errs = errors.Join(errs, err)
+					}
+				} else {
+					validIndex[prop.Details().Name] = val
+				}
+			}
+			validList[i] = validIndex
 		}
 	}
+	if errs != nil {
+		return errs
+	}
+	if hasSanitized {
+		return &knowledgebase.SanitizeError{
+			Input:     listVal,
+			Sanitized: validList,
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/templates/aws/edges/eks_node_group-eks_cluster.yaml
+++ b/pkg/templates/aws/edges/eks_node_group-eks_cluster.yaml
@@ -23,85 +23,42 @@ operational_rules:
               Chart: metrics-server
               Internal: true
 
-  - if: | # check if there is an aws-cloudwatch namespace so we can install fluent bit in there
+  - if: | # check if there is an eks add on for cloudwatch so we can install observability
       {{ $needsCreation := true}}
-      {{ $namespaces := allUpstream "kubernetes:namespace" .Target }}
-      {{ range $index, $ns := $namespaces }}
-        {{- if eq (fieldValue "Object.metadata.name" $ns) "amazon-cloudwatch" }}
+      {{ $addOns := allUpstream "aws:eks_add_on" .Target }}
+      {{ range $index, $addOn := $addOns }}
+        {{- if eq (fieldValue "AddOnName" $addOn) "amazon-cloudwatch-observability" }}
           {{ $needsCreation = false}}
           {{break}}
         {{- end }}
       {{ end }}
       {{ $needsCreation }}
-    steps:
+    steps:             
       - resource: '{{ .Target }}'
         direction: upstream
         resources:
-          - selector: kubernetes:namespace:amazon-cloudwatch
+          - selector: aws:eks_add_on:amazon-cloudwatch-observability
             properties:
+              AddOnName: amazon-cloudwatch-observability
               Cluster: '{{ .Target }}'
-              Object.metadata.name: amazon-cloudwatch
-              Object.metadata.labels.name: amazon-cloudwatch
 
-  - if: | # check if there is an fluent bit config map
-      {{ $needsCreation := true}}
-      {{ $cms := allUpstream "kubernetes:config_map" .Target }}
-      {{ range $index, $cm := $cms }}
-        {{- if eq  (fieldValue "Object.metadata.name" $cm) "fluent-bit-cluster-info" }}
-          {{ $needsCreation = false }}
-          {{break}}
-        {{- end }}
-      {{ end }}
-      {{ $needsCreation }}
-    steps:
-      - resource: '{{ .Target }}'
-        direction: upstream
-        resources:
-          - selector: kubernetes:config_map:fluent-bit-cluster-info
-            properties:
-              Cluster: '{{.Target}}'
-              Object.metadata.name: fluent-bit-cluster-info
-              Object.metadata.namespace: kubernetes:namespace:{{.Target.Name}}:amazon-cloudwatch
-              'Object.metadata.labels.k8s-app': fluent-bit
-              Object.data.cluster.name: '{{ .Target }}#Name'
-              Object.data.logs.region: '{{ downstream "aws:region" .Target }}#Name'
-              Object.data.http.server: 'On'
-              Object.data.http.port: '2020'
-              Object.data.read.head: 'Off'
-              Object.data.read.tail: 'On'
-
-      - resource: kubernetes:config_map:fluent-bit-cluster-info
+      - resource: |
+          {{ $addOns := allUpstream "aws:eks_add_on" .Target }}
+          {{ range $index, $addOn := $addOns }}
+            {{- if eq (fieldValue "AddOnName" $addOn) "amazon-cloudwatch-observability" }}
+              {{ $addOn }}
+              {{break}}
+            {{- end }}
+          {{ end }}
         direction: downstream
         resources:
-          - selector: kubernetes:namespace
+          - selector: aws:iam_role
             properties:
-              Object.metadata.name: amazon-cloudwatch
-
-  - if: | # check if there is an aws-cloudwatch namespace so we can install fluent bit in there
-      {{ $needsCreation := true}}
-      {{ $manifests := allUpstream "kubernetes:manifest" .Target }}
-      {{ range $index, $manifest := $manifests }}
-        {{- if eq (fieldValue "FilePath" $manifest) "https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml" }}
-          {{ $needsCreation = false }}
-          {{break}}
-        {{- end }}
-      {{ end }}
-      {{ $needsCreation }}
-    steps:
-      - resource: '{{ .Target }}'
-        direction: upstream
-        resources:
-          - selector: kubernetes:manifest:fluent-bit
-            properties:
-              Cluster: '{{ .Target }}'
-              FilePath: https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
-
-      - resource: kubernetes:manifest:fluent-bit
-        direction: downstream
-        resources:
-          - selector: kubernetes:config_map
-            properties:
-              Object.metadata.name: fluent-bit-cluster-info
+              ManagedPolicies:
+                - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+                - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        unique: true    
+          
 
   - if: | #Check if the ami type is gpu and if so install nvidia plugin
       {{ $needsCreation := true}}


### PR DESCRIPTION
switches out the custom fluent bit implementation for the eks add on

- also fixes the validation for lists so that we validate sub properties (this was causing eks tests to fail due to not properly sanitizing the env variables names) 
- added unit tests for the validation of list properties to cover added/untested functionality

eks node s3 test
```
============================= test session starts ==============================
platform darwin -- Python 3.10.11, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/jordansinger/workspace/engine-e2e-tests/output/aws-3qrnjn
plugins: repeat-0.9.3, html-4.1.1, xdist-3.4.0, asyncio-0.21.1, metadata-3.0.0, anyio-3.7.1, check-2.2.2
asyncio: mode=strict
created: 1/1 worker
1 worker [1 item]

.                                                                        [100%]
- generated xml file: /var/folders/n_/bbppnfk179d6l4vz4qmz0chh0000gn/T/tmpq9ofvje3 -
============================== 1 passed in 1.20s ===============================
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
