### PR TITLE
dont have default since it might not exist

### DIFF
--- a/pkg/templates/aws/resources/security_group_rule.yaml
+++ b/pkg/templates/aws/resources/security_group_rule.yaml
@@ -22,7 +22,7 @@ properties:
       security group rule
   SecurityGroupId:
     type: string # Not resource type because we need deploy time properties to be able to exist here
-    default_value: '{{ upstream "aws:security_group" .Self }}#Id'
+    required: true
     description: The ID of the security group to which this rule should be attached
   Type:
     type: string


### PR DESCRIPTION
closes #851 

we cant rely on a default here, for eks case the cluster security group doesnt exist in our graph, but is what we create a rule against so it just needs to be set. Making the field required should ensure it always has a value

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
