### PR TITLE
fix templates for deployment order

### DIFF
--- a/pkg/infra/iac3/templates/aws/elasticache_cluster/factory.ts
+++ b/pkg/infra/iac3/templates/aws/elasticache_cluster/factory.ts
@@ -38,5 +38,6 @@ function properties(object: aws.elasticache.Cluster, args: Args) {
     return {
         Port: object.port,
         ClusterAddress: object.clusterAddress,
+        CacheNodeAddress: object.cacheNodes.apply((nodes) => nodes[0].address),
     }
 }

--- a/pkg/templates/aws/resources/elasticache_cluster.yaml
+++ b/pkg/templates/aws/resources/elasticache_cluster.yaml
@@ -47,11 +47,16 @@ properties:
     configuration_disabled: true
     deploy_time: true
     description: The port number on which each of the cache nodes accepts connections.
+  CacheNodeAddress:
+    type: string
+    configuration_disabled: true
+    deploy_time: true
+    description: The endpoint address of a single node in the ElastiCache cluster.
   ClusterAddress:
     type: string
     configuration_disabled: true
     deploy_time: true
-    description: The endpoint address of the ElastiCache cluster.
+    description: The endpoint address of the ElastiCache cluster (memcached only).
 path_satisfaction:
   as_target:
     - network

--- a/pkg/templates/kubernetes/edges/persistent_volume-persistent_volume_claim.yaml
+++ b/pkg/templates/kubernetes/edges/persistent_volume-persistent_volume_claim.yaml
@@ -1,5 +1,6 @@
 source: kubernetes:persistent_volume
 target: kubernetes:persistent_volume_claim
+deployment_order_reversed: true
 operational_rules:
   - configuration_rules:
       - resource: '{{ .Target }}'

--- a/pkg/templates/kubernetes/edges/storage_class-persistent_volume.yaml
+++ b/pkg/templates/kubernetes/edges/storage_class-persistent_volume.yaml
@@ -1,2 +1,3 @@
 source: kubernetes:storage_class
 target: kubernetes:persistent_volume
+deployment_order_reversed: true

--- a/pkg/templates/kubernetes/edges/storage_class-persistent_volume_claim.yaml
+++ b/pkg/templates/kubernetes/edges/storage_class-persistent_volume_claim.yaml
@@ -1,2 +1,3 @@
 source: kubernetes:storage_class
 target: kubernetes:persistent_volume_claim
+deployment_order_reversed: true


### PR DESCRIPTION
this never mattered since we bundle them into helm charts, but now that we add the dependencies based on fields on the property it was causing a cycle

also fixes lambda -> elasticache by exposing the cache node address for redis nodes

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
