### PR TITLE
Rm map items

### DIFF
--- a/pkg/engine2/operational_eval/eval.go
+++ b/pkg/engine2/operational_eval/eval.go
@@ -3,7 +3,6 @@ package operational_eval
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -213,9 +212,6 @@ func (eval *Evaluator) RecalculateUnevaluated() error {
 }
 
 func (eval *Evaluator) cleanupPropertiesSubVertices(ref construct.PropertyRef, val any) error {
-	if reflect.ValueOf(val).Kind() != reflect.Array && reflect.ValueOf(val).Kind() != reflect.Slice {
-		return fmt.Errorf("error while cleaning up properties sub verticies: expected array or slice, got %T", val)
-	}
 	topo, err := graph.TopologicalSort(eval.unevaluated)
 	if err != nil {
 		return err

--- a/pkg/engine2/operational_eval/vertex_property.go
+++ b/pkg/engine2/operational_eval/vertex_property.go
@@ -158,7 +158,7 @@ func (v *propertyVertex) Evaluate(eval *Evaluator) error {
 				}
 			}
 
-			err = eval.cleanupPropertiesSubVertices(v.Ref, property)
+			err = eval.cleanupPropertiesSubVertices(v.Ref, res, property)
 			if err != nil {
 				return fmt.Errorf("could not cleanup sub vertices for %s: %w", v.Ref, err)
 			}

--- a/pkg/engine2/operational_eval/vertex_property.go
+++ b/pkg/engine2/operational_eval/vertex_property.go
@@ -144,7 +144,7 @@ func (v *propertyVertex) Evaluate(eval *Evaluator) error {
 		return err
 	}
 	propertyType := v.Template.Type()
-	if strings.HasPrefix(propertyType, "list") || strings.HasPrefix(propertyType, "set") {
+	if strings.HasPrefix(propertyType, "list") || strings.HasPrefix(propertyType, "set") || strings.HasPrefix(propertyType, "map") {
 		property, err := res.GetProperty(v.Ref.Property)
 		if err != nil {
 			return fmt.Errorf("could not get property %s on resource %s: %w", v.Ref.Property, v.Ref.Resource, err)


### PR DESCRIPTION
closes #863

conditionally remove vertices based on changes to complex property types if their parent no longer exists

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
