### PR TITLE
refactor ecs to support multiple containers

### DIFF
--- a/pkg/engine2/operational_eval/evaluator.go
+++ b/pkg/engine2/operational_eval/evaluator.go
@@ -382,6 +382,7 @@ func (changes graphChanges) AddVertexAndDeps(eval *Evaluator, v Vertex) error {
 		return fmt.Errorf("could not get dependencies for %s: %w", v.Key(), err)
 	}
 	changes.Merge(depCaptureChanges)
+
 	return nil
 }
 

--- a/pkg/engine2/operational_eval/vertex_property.go
+++ b/pkg/engine2/operational_eval/vertex_property.go
@@ -18,8 +18,9 @@ type (
 	propertyVertex struct {
 		Ref construct.PropertyRef
 
-		Template  knowledgebase.Property
-		EdgeRules map[construct.SimpleEdge][]knowledgebase.OperationalRule
+		Template      knowledgebase.Property
+		EdgeRules     map[construct.SimpleEdge][]knowledgebase.OperationalRule
+		ResourceRules map[string][]knowledgebase.OperationalRule
 	}
 )
 
@@ -53,6 +54,17 @@ func (prop *propertyVertex) Dependencies(eval *Evaluator, propCtx dependencyCapt
 		}
 	}
 
+<<<<<<< HEAD
+=======
+	for _, rule := range prop.ResourceRules {
+		for _, opRule := range rule {
+			if err := propCtx.ExecuteOpRule(resData, opRule); err != nil {
+				return fmt.Errorf("could not execute resource operational rule for %s: %w", prop.Ref, err)
+			}
+		}
+	}
+
+>>>>>>> f58c3acf (add resource rule vertices)
 	return nil
 }
 

--- a/pkg/engine2/operational_rule/operational_action.go
+++ b/pkg/engine2/operational_rule/operational_action.go
@@ -97,6 +97,7 @@ func (action *operationalResourceAction) createUniqueResources(resource *constru
 					return err
 				}
 				if action.numNeeded > 0 {
+
 					err := action.ruleCtx.addDependencyForDirection(action.Step, resource, res)
 					if err != nil {
 						return err
@@ -319,7 +320,7 @@ func (action *operationalResourceAction) getPriorityResourceType() (
 			if err != nil && !errors.Is(err, graph.ErrVertexNotFound) {
 				return construct.ResourceId{}, resourceSelector, err
 			}
-			if id.IsZero() || res != nil {
+			if id.IsZero() || (res != nil && !action.Step.Unique) {
 				continue
 			}
 			return construct.ResourceId{Provider: id.Provider, Type: id.Type, Namespace: id.Namespace, Name: id.Name}, resourceSelector, nil

--- a/pkg/engine2/testdata/ecs_rds.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/ecs_rds.dataflow-viz.yaml
@@ -23,11 +23,8 @@ resources:
 
   ecs_service/ecs_service_0:
     children:
-        - aws:ecr_image:ecs_service_0-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:ecs_task_definition:ecs_service_0
         - aws:iam_role:ecs_service_0-execution-role
-        - aws:log_group:ecs_service_0-log-group
     parent: vpc/vpc-0
     tag: big
 

--- a/pkg/engine2/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine2/testdata/ecs_rds.expect.yaml
@@ -28,28 +28,34 @@ resources:
         TaskDefinition: aws:ecs_task_definition:ecs_service_0
     aws:ecs_cluster:ecs_cluster-0:
     aws:ecs_task_definition:ecs_service_0:
-        Cpu: "256"
-        EnvironmentVariables:
-            RDS_INSTANCE_2_RDS_CONNECTION_ARN: aws:rds_instance:rds-instance-2#RdsConnectionArn
-            RDS_INSTANCE_2_RDS_ENDPOINT: aws:rds_instance:rds-instance-2#Endpoint
-            RDS_INSTANCE_2_RDS_PASSWORD: aws:rds_instance:rds-instance-2#Password
-            RDS_INSTANCE_2_RDS_USERNAME: aws:rds_instance:rds-instance-2#Username
+        ContainerDefinitions:
+            - Cpu: "256"
+              Environment:
+                - {}
+                - {}
+                - {}
+                - {}
+              Image: aws:ecr_image:ecs_service_0-ecs_service_0
+              LogConfiguration:
+                LogDriver: awslogs
+                Options:
+                    awslogs-group: aws:log_group:ecs_service_0-log-group#LogGroupName
+                    awslogs-region: aws:region:region-0#RegionName
+                    awslogs-stream-prefix: ecs_service_0-ecs_service_0
+              Memory: "512"
+              Name: ecs_service_0
+              PortMappings:
+                - ContainerPort: 80
+                  HostPort: 80
+                  Protocol: TCP
         ExecutionRole: aws:iam_role:ecs_service_0-execution-role
-        Image: aws:ecr_image:ecs_service_0-image
-        LogGroup: aws:log_group:ecs_service_0-log-group
-        Memory: "512"
         NetworkMode: awsvpc
-        PortMappings:
-            - ContainerPort: 80
-              HostPort: 80
-              Protocol: TCP
-        Region: aws:region:region-0
         RequiresCompatibilities:
             - FARGATE
         TaskRole: aws:iam_role:ecs_service_0-execution-role
-    aws:ecr_image:ecs_service_0-image:
+    aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
-        Dockerfile: ecs_service_0-image.Dockerfile
+        Dockerfile: ecs_service_0-ecs_service_0.Dockerfile
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:ecs_service_0-execution-role:
         AssumeRolePolicyDoc:
@@ -169,6 +175,11 @@ resources:
               Protocol: "-1"
               ToPort: 0
         IngressRules:
+            - Description: Allow ingress traffic from within the same security group
+              FromPort: 0
+              Protocol: "-1"
+              Self: true
+              ToPort: 0
             - CidrBlocks:
                 - 10.0.128.0/18
               Description: Allow ingress traffic from ip addresses within the subnet subnet-0
@@ -180,11 +191,6 @@ resources:
               Description: Allow ingress traffic from ip addresses within the subnet subnet-1
               FromPort: 0
               Protocol: "-1"
-              ToPort: 0
-            - Description: Allow ingress traffic from within the same security group
-              FromPort: 0
-              Protocol: "-1"
-              Self: true
               ToPort: 0
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-0-route_table:
@@ -208,11 +214,10 @@ edges:
     aws:ecs_service:ecs_service_0 -> aws:ecs_task_definition:ecs_service_0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-1:
-    aws:ecs_task_definition:ecs_service_0 -> aws:ecr_image:ecs_service_0-image:
+    aws:ecs_task_definition:ecs_service_0 -> aws:ecr_image:ecs_service_0-ecs_service_0:
     aws:ecs_task_definition:ecs_service_0 -> aws:iam_role:ecs_service_0-execution-role:
     aws:ecs_task_definition:ecs_service_0 -> aws:log_group:ecs_service_0-log-group:
-    aws:ecs_task_definition:ecs_service_0 -> aws:region:region-0:
-    aws:ecr_image:ecs_service_0-image -> aws:ecr_repo:ecr_repo-0:
+    aws:ecr_image:ecs_service_0-ecs_service_0 -> aws:ecr_repo:ecr_repo-0:
     aws:iam_role:ecs_service_0-execution-role -> aws:rds_instance:rds-instance-2:
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway -> aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip:
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway -> aws:subnet:vpc-0:subnet-2:

--- a/pkg/engine2/testdata/ecs_rds.iac-viz.yaml
+++ b/pkg/engine2/testdata/ecs_rds.iac-viz.yaml
@@ -56,9 +56,9 @@ resources:
 
   aws:nat_gateway:subnet-2/subnet-0-route_table-nat_gateway -> elastic_ip/subnet-0-route_table-nat_gateway-elastic_ip:
   aws:nat_gateway:subnet-2/subnet-0-route_table-nat_gateway -> aws:subnet:vpc-0/subnet-2:
-  ecr_image/ecs_service_0-image:
+  ecr_image/ecs_service_0-ecs_service_0:
 
-  ecr_image/ecs_service_0-image -> ecr_repo/ecr_repo-0:
+  ecr_image/ecs_service_0-ecs_service_0 -> ecr_repo/ecr_repo-0:
   iam_role/ecs_service_0-execution-role:
 
   iam_role/ecs_service_0-execution-role -> rds_instance/rds-instance-2:
@@ -84,10 +84,9 @@ resources:
 
   ecs_task_definition/ecs_service_0:
 
-  ecs_task_definition/ecs_service_0 -> ecr_image/ecs_service_0-image:
+  ecs_task_definition/ecs_service_0 -> ecr_image/ecs_service_0-ecs_service_0:
   ecs_task_definition/ecs_service_0 -> iam_role/ecs_service_0-execution-role:
   ecs_task_definition/ecs_service_0 -> log_group/ecs_service_0-log-group:
-  ecs_task_definition/ecs_service_0 -> rds_instance/rds-instance-2:
   ecs_task_definition/ecs_service_0 -> region/region-0:
   aws:security_group:vpc-0/ecs_service_0-security_group:
 

--- a/pkg/infra/iac3/templates/aws/ecs_task_definition/factory.ts
+++ b/pkg/infra/iac3/templates/aws/ecs_task_definition/factory.ts
@@ -5,20 +5,13 @@ import * as awsInputs from '@pulumi/aws/types/input'
 import { TemplateWrapper } from '../../wrappers'
 
 interface Args {
-    LogGroup: aws.cloudwatch.LogGroup
-    Region: pulumi.Output<pulumi.UnwrappedObject<aws.GetRegionResult>>
     Name: string
-    Cpu?: string
-    Memory?: string
     NetworkMode?: string
     ExecutionRole: aws.iam.Role
     TaskRole: aws.iam.Role
-    EnvironmentVariables: TemplateWrapper<Record<string, pulumi.Output<string>>>
-    Image: docker.Image
-    PortMappings?: Record<string, object>
     RequiresCompatibilities?: string[]
     EfsVolumes: TemplateWrapper<awsInputs.ecs.TaskDefinitionVolumeEfsVolumeConfiguration[]>
-    MountPoints: Record<string, string>
+    ContainerDefinitions: TemplateWrapper<awsInputs.ecs.TaskDefinitionContainerDefinitions[]>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -44,26 +37,6 @@ function create(args: Args): aws.ecs.TaskDefinition {
         //TMPL {{- if .EfsVolumes }}
         volumes: args.EfsVolumes,
         //TMPL {{- end }}
-        containerDefinitions: pulumi.jsonStringify([
-            {
-                name: args.Name,
-                image: args.Image.imageName,
-                portMappings: args.PortMappings,
-                //TMPL {{- if .EnvironmentVariables }}
-                environment: args.EnvironmentVariables,
-                //TMPL {{- end }}
-                //TMPL {{- if .MountPoints }}
-                mountPoints: args.MountPoints,
-                //TMPL {{- end }}
-                logConfiguration: {
-                    logDriver: 'awslogs',
-                    options: {
-                        'awslogs-group': args.LogGroup.name,
-                        'awslogs-region': args.Region.name,
-                        'awslogs-stream-prefix': args.Name,
-                    },
-                },
-            },
-        ]),
+        containerDefinitions: pulumi.jsonStringify(args.ContainerDefinitions),
     })
 }

--- a/pkg/infra/iac3/templates/aws/rds_instance/factory.ts
+++ b/pkg/infra/iac3/templates/aws/rds_instance/factory.ts
@@ -49,6 +49,7 @@ function properties(object: aws.rds.Instance, args: Args) {
         }),
         RdsConnectionArn: pulumi.interpolate`arn:aws:rds-db:${region.name}:${accountId.accountId}:dbuser:${object.resourceId}/${object.username}`,
         Endpoint: object.endpoint,
+        ConnectionString: pulumi.interpolate`${args.Engine}://${object.username}:${object.password}@${object.endpoint.address}:${object.endpoint.port}/${args.DatabaseName}`,
     }
 }
 

--- a/pkg/knowledge_base2/dynamic_value.go
+++ b/pkg/knowledge_base2/dynamic_value.go
@@ -38,6 +38,7 @@ type (
 	DynamicValueData struct {
 		Resource construct.ResourceId
 		Edge     *construct.Edge
+		Path     construct.PropertyPath
 	}
 )
 
@@ -64,6 +65,7 @@ func (ctx DynamicValueContext) TemplateFunctions() template.FuncMap {
 		"fieldValue":        ctx.FieldValue,
 		"hasField":          ctx.HasField,
 		"fieldRef":          ctx.FieldRef,
+		"pathAncestor":      ctx.PathAncestor,
 
 		"toJson": ctx.toJson,
 
@@ -558,6 +560,19 @@ func (ctx DynamicValueContext) toJson(value any) (string, error) {
 		return "", err
 	}
 	return string(j), nil
+}
+
+func (ctx DynamicValueContext) PathAncestor(path construct.PropertyPath, depth int) (string, error) {
+	if depth < 0 {
+		return "", fmt.Errorf("depth must be >= 0")
+	}
+	if depth == 0 {
+		return path.String(), nil
+	}
+	if len(path) <= depth {
+		return "", fmt.Errorf("depth %d is greater than path length %d", depth, len(path))
+	}
+	return path[:len(path)-depth].String(), nil
 }
 
 // filterMatch returns a json array by filtering the values array with the regex pattern

--- a/pkg/knowledge_base2/properties/map_property.go
+++ b/pkg/knowledge_base2/properties/map_property.go
@@ -114,6 +114,9 @@ func (m *MapProperty) Parse(value any, ctx knowledgebase.DynamicContext, data kn
 				result[key] = val
 			}
 		}
+	}
+
+	if m.KeyProperty == nil || m.ValueProperty == nil {
 		return result, nil
 	}
 

--- a/pkg/knowledge_base2/reader/resource_template.go
+++ b/pkg/knowledge_base2/reader/resource_template.go
@@ -15,6 +15,8 @@ type (
 
 		PathSatisfaction knowledgebase.PathSatisfaction `json:"path_satisfaction" yaml:"path_satisfaction"`
 
+		AdditionalRules []knowledgebase.AdditionalRule `json:"additional_rules" yaml:"additional_rules"`
+
 		Consumption knowledgebase.Consumption `json:"consumption" yaml:"consumption"`
 
 		// DeleteContext defines the context in which a resource can be deleted
@@ -44,6 +46,7 @@ func (r *ResourceTemplate) Convert() (*knowledgebase.ResourceTemplate, error) {
 		QualifiedTypeName: r.QualifiedTypeName,
 		DisplayName:       r.DisplayName,
 		Properties:        kbProperties,
+		AdditionalRules:   r.AdditionalRules,
 		Classification:    r.Classification,
 		PathSatisfaction:  r.PathSatisfaction,
 		Consumption:       r.Consumption,

--- a/pkg/templates/aws/edges/ecs_task_definition-log_group.yaml
+++ b/pkg/templates/aws/edges/ecs_task_definition-log_group.yaml
@@ -1,9 +1,7 @@
 source: aws:ecs_task_definition
 target: aws:log_group
 operational_rules:
-  - if: |
-      {{ eq .Target (fieldValue "LogGroup" .Source)}}
-    configuration_rules:
+  - configuration_rules:
       - resource: '{{ .Target }}'
         configuration:
           field: LogGroupName

--- a/pkg/templates/aws/edges/target_group-ecs_service.yaml
+++ b/pkg/templates/aws/edges/target_group-ecs_service.yaml
@@ -9,7 +9,7 @@ operational_rules:
           value:
             - TargetGroup: '{{ .Source }}'
               ContainerName: '{{ (downstream "aws:ecs_task_definition" .Target).Name }}'
-              ContainerPort: '{{ fieldValue "PortMappings[0].ContainerPort" (fieldValue "TaskDefinition" .Target)}}'
+              ContainerPort: '{{ fieldValue "ContainerDefinitions[0].PortMappings[0].ContainerPort" (fieldValue "TaskDefinition" .Target)}}'
       - resource: '{{ .Source }}'
         configuration:
           field: TargetType

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -79,8 +79,18 @@ properties:
 consumption:
   consumed:
     - model: EnvironmentVariables
-      property_path: EnvironmentVariables
+      property_path: ContainerDefinitions[0].Environment
       resource: '{{ fieldValue "TaskDefinition" .Self }}'
+      converter: |
+        [
+        {{ $i := 0}}
+        {{ range $key, $value := . }}
+          {
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+          }{{if ne $i (sub (len $) 1)}},{{end}}{{ $i = add $i 1 }}
+        {{ end }}
+        ]
   emitted:
     - model: EnvironmentVariables
       value:

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -2,58 +2,139 @@ qualified_type_name: aws:ecs_task_definition
 display_name: ECS Task Definition
 
 properties:
-  Image:
-    type: resource(aws:ecr_image)
-    operational_rule:
-      step:
-        direction: downstream
-        resources:
-          - aws:ecr_image:{{ .Self.Name }}-image
-        unique: true
-    description: Reference to an Amazon Elastic Container Registry (ECR) image that
-      will be used for the container within the task
-  MountPoints:
-    type: set
+  ContainerDefinitions:
+    default_value:
+      - Name: '{{ .Self.Name }}'
+    type: list
     properties:
-      ContainerPath:
+      Command:
+        type: list(string)
+        description: The command that is passed to the container
+      Cpu:
         type: string
-        description: The path on the container to mount the volume at
-      SourceVolume:
+        default_value: '256'
+        description: The number of CPU units reserved for the container
+      DependsOn:
+        type: list
+        properties:
+          Condition:
+            type: string
+            description: The dependency condition of the container
+          ContainerName:
+            type: string
+            description: The name of the container to depend on
+        description: The dependencies defined for container startup and shutdown
+      EntryPoint:
+        type: list(string)
+        description: The entry point that is passed to the container
+      Environment:
+        type: list
+        properties:
+          Name:
+            type: string
+            sanitize: |
+              {{ .
+                | replace `[^[:alnum:]_]+` "_"
+                | replace `^[^a-zA-Z]+` ""
+                | upper
+              }}
+            description: The name of the environment variable
+          Value:
+            type: string
+            description: The value of the environment variable
+        description: The environment variables to pass to a container
+      Image:
+        type: resource(aws:ecr_image)
+        operational_rule:
+          step:
+            direction: downstream
+            resources:
+              - aws:ecr_image:{{ .Self.Name }}-{{ fieldValue (printf "%s.Name" (pathAncestor .Path 1)) .Self}}
+            unique: true
+        description: Reference to an Amazon Elastic Container Registry (ECR) image that
+          will be used for the container within the task
+      LogConfiguration:
+        type: map
+        properties:
+          LogDriver:
+            type: string
+            description: The log driver to use for the container
+            default_value: awslogs
+          Options:
+            type: map(string,string)
+            description: The configuration options to send to the log driver
+            properties:
+              awslogs-group:
+                type: string
+                description: The log group to send stdout to
+                operational_rule:
+                  step:
+                    direction: downstream
+                    resources:
+                      - aws:log_group:{{ .Self.Name }}-log-group
+                    unique: true
+                    use_property_ref: LogGroupName
+              awslogs-region:
+                type: string
+                description: The region which your log group will exist in
+                default_value: '{{ fieldRef "RegionName" (downstream "aws:region" (upstream "aws:ecs_service" .Self)) }}'
+              awslogs-stream-prefix:
+                type: string
+                description: The prefix to use when creating the log stream
+                default_value: '{{ .Self.Name }}-{{ fieldValue (printf "%s.Name" (pathAncestor .Path 3)) .Self }}'
+          SecretOptions:
+            type: list
+            properties:
+              Name:
+                type: string
+                description: The name of the secret
+              ValueFrom:
+                type: string
+                description: The secret to expose to the container
+            description: The secrets to pass to the log configuration
+        description: The log configuration specification for the container
+      Memory:
         type: string
-        description: The name of the volume to mount
-      ReadOnly:
-        type: bool
-        description: Determines if the volume should be mounted as read-only
-    description: A list of mount points for data volumes in your container
-    important: true
-  EnvironmentVariables:
-    type: map(string,string)
-    description: A map of the environment variables to pass to the container
-    important: true
-    key_property:
-      sanitize: |
-        {{ .
-          | replace `[^[:alnum:]_]+` "_"
-          | replace `^[^a-zA-Z]+` ""
-          | upper
-        }}
-  Cpu:
-    type: string
-    default_value: '256'
-    description: The amount of CPU to allocate for the task
-  Memory:
-    type: string
-    default_value: '512'
-    description: The amount of memory (in MiB) used by the task
-  LogGroup:
-    type: resource(aws:log_group)
-    operational_rule:
-      step:
-        direction: downstream
-        resources:
-          - aws:log_group:{{ .Self.Name }}-log-group
-        unique: true
-    description: Specifies the log group for the ECS task's logs
+        default_value: '512'
+        description: The hard limit (in MiB) of memory to present to the container
+      MountPoints:
+        type: set
+        properties:
+          ContainerPath:
+            type: string
+            description: The path on the container to mount the volume at
+          SourceVolume:
+            type: string
+            description: The name of the volume to mount
+          ReadOnly:
+            type: bool
+            description: Determines if the volume should be mounted as read-only
+        description: A list of mount points for data volumes in your container
+      Name:
+        type: string
+        description: The name of the container
+      PortMappings:
+        type: list
+        important: true
+        default_value:
+          - ContainerPort: 80
+            HostPort: 80
+            Protocol: TCP
+        properties:
+          ContainerPort:
+            type: int
+            description: The port number on the container
+          HostPort:
+            type: int
+            description: The port number on the host where the container is exposed
+          Protocol:
+            type: string
+            description: The protocol used for the port mapping, such as TCP or UDP
+        description: A set of port mappings between the container and host
+
+      
+      
+      
   ExecutionRole:
     type: resource(aws:iam_role)
     operational_rule:
@@ -69,35 +150,10 @@ properties:
     default_value: '{{ fieldValue "ExecutionRole" .Self }}'
     description: The IAM role that determines the permissions for making AWS API calls
       from within the ECS task
-  Region:
-    type: resource(aws:region)
-    operational_rule:
-      step:
-        direction: downstream
-        resources:
-          - aws:region
-    description: The AWS region where the ECS task is deployed
   NetworkMode:
     type: string
     default_value: awsvpc
     description: The Docker networking mode to use for the containers in the task
-  PortMappings:
-    type: list
-    default_value:
-      - ContainerPort: 80
-        HostPort: 80
-        Protocol: TCP
-    properties:
-      ContainerPort:
-        type: int
-        description: The port number on the container
-      HostPort:
-        type: int
-        description: The port number on the host where the container is exposed
-      Protocol:
-        type: string
-        description: The protocol used for the port mapping, such as TCP or UDP
-    description: A set of port mappings between the container and host
   RequiresCompatibilities:
     type: list(string)
     default_value:
@@ -137,10 +193,21 @@ properties:
         description: The authorization configuration details for the EFS volume
     description: An array of Amazon Elastic File System (EFS) volumes to be attached
       to containers
+  
 consumption:
   consumed:
     - model: EnvironmentVariables
-      property_path: EnvironmentVariables
+      property_path: ContainerDefinitions[0].Environment
+      converter: |
+        [
+        {{ $i := 0}}
+        {{ range $key, $value := . }}
+          {
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+          }{{if ne $i (sub (len $) 1)}},{{end}}{{ $i = add $i 1 }}
+        {{ end }}
+        ]
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/rds_instance.yaml
+++ b/pkg/templates/aws/resources/rds_instance.yaml
@@ -55,6 +55,26 @@ properties:
   Engine:
     type: string
     default_value: postgres
+    allowed_values:
+      - postgres
+      - mysql
+      - aurora-postgresql
+      - aurora-mysql
+      - aurora-postgresql
+      - mariadb
+      - oracle-ee
+      - oracle-ee-cdb
+      - oracle-se2
+      - oracle-se2-cdb
+      - custom-oracle-ee
+      - custom-oracle-ee-cdb
+      - custom-sqlserver-ee
+      - custom-sqlserver-se
+      - custom-sqlserver-web
+      - sqlserver-ee
+      - sqlserver-ex
+      - sqlserver-se
+      - sqlserver-web
   EngineVersion:
     type: string
     default_value: '13.7'
@@ -72,6 +92,10 @@ properties:
     configuration_disabled: true
     deploy_time: true
   RdsConnectionArn:
+    type: string
+    configuration_disabled: true
+    deploy_time: true
+  ConnectionString:
     type: string
     configuration_disabled: true
     deploy_time: true

--- a/pkg/templates/aws/resources/region.yaml
+++ b/pkg/templates/aws/resources/region.yaml
@@ -1,5 +1,12 @@
 qualified_type_name: aws:region
 display_name: Region
 
+properties:
+  RegionName:
+    description: The name of the region
+    type: string
+    deploy_time: true
+    configuration_disabled: true
+
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/kubernetes/resources/helm_chart.yaml
+++ b/pkg/templates/kubernetes/resources/helm_chart.yaml
@@ -37,6 +37,12 @@ properties:
   Internal:
     type: bool
 
+classification:
+  is:
+    - kubernetes
+    - helm
+    - chart
+
 delete_context:
   requires_no_upstream: true
 views:


### PR DESCRIPTION
refactors the ecs model to allow for multiple containers being supported

ability to specify path in dynamic data to get parent/ancestor path relations (used to make a new image per container in ecs)

Note: Need to modify isOperationalSideEffect as a follow up to vix dataflow children in ecs-rds example

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
