### PR TITLE
Mark stage -> deployment direct only so path selection can't use that to bypass rest_api

### DIFF
--- a/pkg/engine2/testdata/cf_distribution.dataflow-viz.yaml
+++ b/pkg/engine2/testdata/cf_distribution.dataflow-viz.yaml
@@ -14,7 +14,6 @@ resources:
 
   cloudfront_distribution/cloudfront_distribution_2 -> rest_api/rest_api_1:
     path:
-        - aws:api_deployment:rest_api_1:api_deployment-0
         - aws:api_stage:rest_api_1:cloudfront_distribution_2-rest_api_1
 
   cloudfront_distribution/cloudfront_distribution_2 -> s3_bucket/s3-bucket-3:

--- a/pkg/templates/aws/edges/api_stage-api_deployment.yaml
+++ b/pkg/templates/aws/edges/api_stage-api_deployment.yaml
@@ -1,2 +1,3 @@
 source: aws:api_stage
 target: aws:api_deployment
+direct_edge_only: true


### PR DESCRIPTION
Fixes https://github.com/klothoplatform/klotho/issues/868

Repro input for ^
```yaml
constraints:
  - node: aws:cloudfront_distribution:cloudfront_distribution_2
    operator: add
    scope: application
  - node: aws:load_balancer:load-balancer-8
    operator: add
    scope: application
  - operator: must_exist
    scope: edge
    target:
      source: aws:cloudfront_distribution:cloudfront_distribution_2
      target: aws:load_balancer:load-balancer-8
```

Now fails with `could not find shortest path between aws:cloudfront_distribution:cloudfront_distribution_2 and aws:load_balancer:load-balancer-8: target vertex not reachable from source`