### PR TITLE
increasing op eval unit test coverage

### DIFF
--- a/pkg/engine2/operational_eval/eval.go
+++ b/pkg/engine2/operational_eval/eval.go
@@ -211,7 +211,7 @@ func (eval *Evaluator) RecalculateUnevaluated() error {
 	return errs
 }
 
-func (eval *Evaluator) cleanupPropertiesSubVertices(ref construct.PropertyRef, resource *construct.Resource, val any) error {
+func (eval *Evaluator) cleanupPropertiesSubVertices(ref construct.PropertyRef, resource *construct.Resource) error {
 	topo, err := graph.TopologicalSort(eval.unevaluated)
 	if err != nil {
 		return err

--- a/pkg/engine2/operational_eval/eval_test.go
+++ b/pkg/engine2/operational_eval/eval_test.go
@@ -1,0 +1,116 @@
+package operational_eval
+
+import (
+	"testing"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+	"github.com/klothoplatform/klotho/pkg/engine2/enginetesting"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluator_cleanupPropertiesSubVertices(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		initialState []Vertex
+		ref          construct.PropertyRef
+		resource     *construct.Resource
+		want         []Key
+		wantErr      bool
+	}{
+		{
+			name: "simple resource",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: construct.ResourceId{Name: "a"},
+						Property: "prop1[0]",
+					},
+				},
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: construct.ResourceId{Name: "a"},
+						Property: "prop1[0].prop2",
+					},
+				},
+			},
+			ref: construct.PropertyRef{
+				Resource: construct.ResourceId{Name: "a"},
+				Property: "prop1[0]",
+			},
+			resource: &construct.Resource{
+				ID: construct.ResourceId{Name: "a"},
+				Properties: map[string]any{
+					"prop1": "value1",
+				},
+			},
+			want: []Key{},
+		},
+		{
+			name: "doesnt remove if path parent 2 back exists",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: construct.ResourceId{Name: "a"},
+						Property: "prop1[0]",
+					},
+				},
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: construct.ResourceId{Name: "a"},
+						Property: "prop1[0].prop2",
+					},
+				},
+			},
+			ref: construct.PropertyRef{
+				Resource: construct.ResourceId{Name: "a"},
+				Property: "prop1[0].prop2",
+			},
+			resource: &construct.Resource{
+				ID: construct.ResourceId{Name: "a"},
+				Properties: map[string]any{
+					"prop1": "value1",
+				},
+			},
+			want: []Key{
+				{Ref: construct.PropertyRef{
+					Resource: construct.ResourceId{Name: "a"},
+					Property: "prop1[0]",
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+				err = eval.unevaluated.AddVertex(v)
+				assert.NoError(err)
+			}
+			err := eval.cleanupPropertiesSubVertices(tt.ref, tt.resource)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			adj, err := eval.graph.AdjacencyMap()
+			assert.NoError(err)
+			assert.Equal(len(adj), len(tt.want))
+			for key := range adj {
+				assert.Contains(tt.want, key)
+			}
+
+			// check that the unevaluated graph is also cleaned up
+			adj, err = eval.unevaluated.AdjacencyMap()
+			assert.NoError(err)
+			assert.Equal(len(adj), len(tt.want))
+			for key := range adj {
+				assert.Contains(tt.want, key)
+			}
+		})
+	}
+}

--- a/pkg/engine2/operational_eval/evaluator.go
+++ b/pkg/engine2/operational_eval/evaluator.go
@@ -197,8 +197,10 @@ func (eval *Evaluator) isEvaluated(k Key) (bool, error) {
 	_, err = eval.unevaluated.Vertex(k)
 	if errors.Is(err, graph.ErrVertexNotFound) {
 		return true, nil
+	} else if err != nil {
+		return false, err
 	}
-	return false, err
+	return false, nil
 }
 
 func (eval *Evaluator) addEdge(source, target Key) error {

--- a/pkg/engine2/operational_eval/evaluator_test.go
+++ b/pkg/engine2/operational_eval/evaluator_test.go
@@ -1,0 +1,306 @@
+package operational_eval
+
+import (
+	"testing"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+	"github.com/klothoplatform/klotho/pkg/construct2/graphtest"
+	"github.com/klothoplatform/klotho/pkg/engine2/enginetesting"
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base2"
+	"github.com/klothoplatform/klotho/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEvaluator_isEvaluated(t *testing.T) {
+	tests := []struct {
+		name          string
+		vertex        Vertex
+		inGraph       bool
+		inUnevaluated bool
+		want          bool
+		wantErr       bool
+	}{
+		{
+			name: "simple evaluated vertex",
+			vertex: &propertyVertex{
+				Ref: construct.PropertyRef{
+					Resource: graphtest.ParseId(t, "a:a:a"),
+					Property: "prop1",
+				},
+			},
+			inGraph: true,
+			want:    true,
+		},
+		{
+			name: "simple unevaluated vertex",
+			vertex: &propertyVertex{
+				Ref: construct.PropertyRef{
+					Resource: graphtest.ParseId(t, "a:a:a"),
+					Property: "prop1",
+				},
+			},
+			inGraph:       true,
+			inUnevaluated: true,
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			if tt.inGraph {
+				err := eval.graph.AddVertex(tt.vertex)
+				assert.NoError(err)
+			}
+			if tt.inUnevaluated {
+				err := eval.unevaluated.AddVertex(tt.vertex)
+				assert.NoError(err)
+			}
+			got, err := eval.isEvaluated(tt.vertex.Key())
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+func TestEvaluator_addEdge(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState []Vertex
+		source       Key
+		target       Key
+		wantErr      bool
+	}{
+		{
+			name: "simple add edge",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					},
+				},
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop2",
+					},
+				},
+			},
+			source: Key{Ref: construct.PropertyRef{
+				Resource: graphtest.ParseId(t, "a:a:a"),
+				Property: "prop1",
+			}},
+			target: Key{Ref: construct.PropertyRef{
+				Resource: graphtest.ParseId(t, "a:a:a"),
+				Property: "prop2",
+			}},
+		},
+		{
+			name: "add edge with missing source",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop2",
+					},
+				},
+			},
+			source: Key{Ref: construct.PropertyRef{
+				Resource: graphtest.ParseId(t, "a:a:a"),
+				Property: "prop1",
+			}},
+			target: Key{Ref: construct.PropertyRef{
+				Resource: graphtest.ParseId(t, "a:a:a"),
+				Property: "prop2",
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+				err = eval.unevaluated.AddVertex(v)
+				assert.NoError(err)
+			}
+			err := eval.addEdge(tt.source, tt.target)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			_, err = eval.graph.Edge(tt.source, tt.target)
+			assert.NoError(err)
+			_, err = eval.unevaluated.Edge(tt.source, tt.target)
+			assert.NoError(err)
+		})
+	}
+}
+
+func TestEvaluator_enqueue(t *testing.T) {
+	tests := []struct {
+		name         string
+		changes      graphChanges
+		initialState []Vertex
+		want         map[Key][]Key
+		wantErr      bool
+	}{
+		{
+			name: "simple enqueue",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop2",
+					},
+				},
+			},
+			changes: graphChanges{
+				nodes: map[Key]Vertex{
+					{Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					}}: &propertyVertex{
+						Ref: construct.PropertyRef{
+							Resource: graphtest.ParseId(t, "a:a:a"),
+							Property: "prop1",
+						},
+					},
+				},
+				edges: map[Key]set.Set[Key]{
+
+					{Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					}}: set.SetOf[Key](
+						Key{Ref: construct.PropertyRef{
+							Resource: graphtest.ParseId(t, "a:a:a"),
+							Property: "prop2",
+						}},
+					),
+				},
+			},
+			want: map[Key][]Key{
+				{Ref: construct.PropertyRef{
+					Resource: graphtest.ParseId(t, "a:a:a"),
+					Property: "prop1",
+				}}: []Key{
+					{Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop2",
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+			}
+			err := eval.enqueue(tt.changes)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			adj, err := eval.graph.AdjacencyMap()
+			assert.NoError(err)
+			for k, v := range tt.want {
+				p := adj[k]
+				for _, dep := range v {
+					assert.Contains(p, dep)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluator_UpdateId(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		initialGraph []any
+		initialState []Vertex
+		oldId        construct.ResourceId
+		newId        construct.ResourceId
+		want         map[Key]Vertex
+		wantGraph    []any
+		wantErr      bool
+	}{
+		{
+			name:         "simple update with property vertex",
+			initialGraph: []any{"a:a:a"},
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					},
+				},
+			},
+			oldId: graphtest.ParseId(t, "a:a:a"),
+			newId: graphtest.ParseId(t, "b:b:b"),
+			want: map[Key]Vertex{
+				{Ref: construct.PropertyRef{
+					Resource: graphtest.ParseId(t, "b:b:b"),
+					Property: "prop1",
+				}}: &propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "b:b:b"),
+						Property: "prop1",
+					},
+				},
+			},
+			wantGraph: []any{"b:b:b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			testSol.KB.On("GetResourceTemplate", mock.Anything).Return(&knowledgebase.ResourceTemplate{}, nil)
+			newG := graphtest.MakeGraph(t, construct.NewGraph(), tt.initialGraph...)
+			err := testSol.RawView().AddVerticesFrom(newG)
+			assert.NoError(err)
+			err = testSol.RawView().AddVerticesFrom(newG)
+			assert.NoError(err)
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+			}
+			err = eval.UpdateId(tt.oldId, tt.newId)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			adj, err := eval.graph.AdjacencyMap()
+			assert.NoError(err)
+			assert.Equal(len(adj), len(tt.want))
+			for k, v := range tt.want {
+				actual, err := eval.graph.Vertex(k)
+				assert.NoError(err)
+				assert.Equal(v, actual)
+			}
+			wantGraph := graphtest.MakeGraph(t, construct.NewGraph(), tt.wantGraph...)
+			graphtest.AssertGraphEqual(t, testSol.RawView(), wantGraph, "graph")
+		})
+	}
+}

--- a/pkg/engine2/operational_eval/graph_test.go
+++ b/pkg/engine2/operational_eval/graph_test.go
@@ -1,0 +1,178 @@
+package operational_eval
+
+import (
+	"testing"
+
+	construct "github.com/klothoplatform/klotho/pkg/construct2"
+	"github.com/klothoplatform/klotho/pkg/construct2/graphtest"
+	"github.com/klothoplatform/klotho/pkg/engine2/enginetesting"
+	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base2"
+	"github.com/klothoplatform/klotho/pkg/knowledge_base2/properties"
+	"github.com/klothoplatform/klotho/pkg/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluator_resourceVertices(t *testing.T) {
+	tests := []struct {
+		name    string
+		res     *construct.Resource
+		tmpl    *knowledgebase.ResourceTemplate
+		want    graphChanges
+		wantErr bool
+	}{
+		{
+			name: "simple resource",
+			res: &construct.Resource{
+				ID: graphtest.ParseId(t, "a:a:a"),
+				Properties: map[string]any{
+					"prop1": "value1",
+				},
+			},
+			tmpl: &knowledgebase.ResourceTemplate{
+				Properties: map[string]knowledgebase.Property{
+					"prop1": &properties.StringProperty{
+						PropertyDetails: knowledgebase.PropertyDetails{
+							Path: "prop1",
+						},
+					},
+				},
+			},
+			want: graphChanges{
+				nodes: map[Key]Vertex{
+					{Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					}}: &propertyVertex{
+						Ref: construct.PropertyRef{
+							Resource: graphtest.ParseId(t, "a:a:a"),
+							Property: "prop1",
+						},
+						Template: &properties.StringProperty{
+							PropertyDetails: knowledgebase.PropertyDetails{
+								Path: "prop1",
+							},
+						},
+						EdgeRules: map[construct.SimpleEdge][]knowledgebase.OperationalRule{},
+					},
+				},
+				edges: map[Key]set.Set[Key]{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			err := testSol.DataflowGraph().AddVertex(tt.res)
+			assert.NoError(err)
+			eval := NewEvaluator(testSol)
+			actual, err := eval.resourceVertices(tt.res, tt.tmpl)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tt.want, actual)
+		})
+	}
+}
+
+func TestEvaluator_RemoveEdge(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState []Vertex
+		source       construct.ResourceId
+		target       construct.ResourceId
+		want         map[Key]Vertex
+		wantErr      bool
+	}{
+		{
+			name: "remove edge",
+			initialState: []Vertex{
+				&edgeVertex{
+					Edge: construct.SimpleEdge{
+						Source: graphtest.ParseId(t, "a:a:a"),
+						Target: graphtest.ParseId(t, "a:a:b"),
+					},
+				},
+			},
+			source: graphtest.ParseId(t, "a:a:a"),
+			target: graphtest.ParseId(t, "a:a:b"),
+			want:   map[Key]Vertex{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+			}
+			err := eval.RemoveEdge(tt.source, tt.target)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			adj, err := eval.graph.AdjacencyMap()
+			assert.NoError(err)
+			assert.Equal(len(adj), len(tt.want))
+			for k, v := range tt.want {
+				actual, err := eval.graph.Vertex(k)
+				assert.NoError(err)
+				assert.Equal(v, actual)
+			}
+		})
+	}
+}
+
+func TestEvaluator_RemoveResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState []Vertex
+		id           construct.ResourceId
+		want         map[Key]Vertex
+		wantErr      bool
+	}{
+		{
+			name: "remove resource property vertex",
+			initialState: []Vertex{
+				&propertyVertex{
+					Ref: construct.PropertyRef{
+						Resource: graphtest.ParseId(t, "a:a:a"),
+						Property: "prop1",
+					},
+				},
+			},
+			id:   graphtest.ParseId(t, "a:a:a"),
+			want: map[Key]Vertex{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			testSol := enginetesting.NewTestSolution()
+			eval := NewEvaluator(testSol)
+			for _, v := range tt.initialState {
+				err := eval.graph.AddVertex(v)
+				assert.NoError(err)
+			}
+			err := eval.RemoveResource(tt.id)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			adj, err := eval.graph.AdjacencyMap()
+			assert.NoError(err)
+			assert.Equal(len(adj), len(tt.want))
+			for k, v := range tt.want {
+				actual, err := eval.graph.Vertex(k)
+				assert.NoError(err)
+				assert.Equal(v, actual)
+			}
+		})
+	}
+}

--- a/pkg/engine2/operational_eval/vertex_property.go
+++ b/pkg/engine2/operational_eval/vertex_property.go
@@ -11,7 +11,6 @@ import (
 	"github.com/klothoplatform/klotho/pkg/engine2/operational_rule"
 	"github.com/klothoplatform/klotho/pkg/engine2/solution_context"
 	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledge_base2"
-	"github.com/klothoplatform/klotho/pkg/set"
 )
 
 type (
@@ -148,15 +147,7 @@ func (v *propertyVertex) Evaluate(eval *Evaluator) error {
 			return fmt.Errorf("could not get property %s on resource %s: %w", v.Ref.Property, v.Ref.Resource, err)
 		}
 		if property != nil {
-			if strings.HasPrefix(propertyType, "set") {
-				if set, ok := property.(set.HashedSet[string, any]); ok {
-					property = set.ToSlice()
-				} else {
-					return fmt.Errorf("could not convert property %s on resource %s to set", v.Ref.Property, v.Ref.Resource)
-				}
-			}
-
-			err = eval.cleanupPropertiesSubVertices(v.Ref, res, property)
+			err = eval.cleanupPropertiesSubVertices(v.Ref, res)
 			if err != nil {
 				return fmt.Errorf("could not cleanup sub vertices for %s: %w", v.Ref, err)
 			}


### PR DESCRIPTION
mainly happy path tests to increase coverage on expected inputs/outputs. Now that the test base is in place we can ramp up the test coverage on those functions

```
ok  	github.com/klothoplatform/klotho/pkg/engine2/operational_eval	0.474s	coverage: 27.7% of statements
```

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
