### PR TITLE
auto generate deployment policy

### DIFF
--- a/create_test.sh
+++ b/create_test.sh
@@ -36,5 +36,5 @@ fi
 [ -e "$out_dir/dataflow-topology.yaml" ] && cp "$out_dir/dataflow-topology.yaml" "$test_dir/$name.dataflow-viz.yaml"
 [ -e "$out_dir/iac-topology.yaml" ] && cp "$out_dir/iac-topology.yaml" "$test_dir/$name.iac-viz.yaml"
 [ -e "$out_dir/error_details.json" ] && cp "$out_dir/error_details.json" "$test_dir/$name.err.json"
-
+[ -e "$out_dir/deployment_permissions_policy.json" ] && cp "$out_dir/deployment_permissions_policy.json" "$test_dir/$name.deployment-policy.json"
 rm -rf $out_dir

--- a/pkg/engine/cli.go
+++ b/pkg/engine/cli.go
@@ -21,6 +21,7 @@ import (
 	knowledgebase "github.com/klothoplatform/klotho/pkg/knowledgebase"
 	"github.com/klothoplatform/klotho/pkg/knowledgebase/reader"
 	"github.com/klothoplatform/klotho/pkg/logging"
+	"github.com/klothoplatform/klotho/pkg/provider/aws"
 	"github.com/klothoplatform/klotho/pkg/templates"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -438,6 +439,20 @@ func (em *EngineMain) RunEngine(cmd *cobra.Command, args []string) (exitCode int
 			Content: b,
 		},
 	)
+
+	if architectureEngineCfg.provider == "aws" {
+		polictBytes, err := aws.DeploymentPermissionsPolicy(context.Solutions[0])
+		if err != nil {
+			internalError(fmt.Errorf("failed to generate deployment permissions policy: %w", err))
+			return
+		}
+		files = append(files,
+			&kio.RawFile{
+				FPath:   "deployment_permissions_policy.json",
+				Content: polictBytes,
+			},
+		)
+	}
 
 	err = kio.OutputTo(files, architectureEngineCfg.outputDir)
 	if err != nil {

--- a/pkg/engine/testdata/2_routes.deployment-policy.json
+++ b/pkg/engine/testdata/2_routes.deployment-policy.json
@@ -1,0 +1,118 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:AddPermission",
+                "lambda:RemovePermission",
+                "lambda:AddPermission"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/cf_distribution.deployment-policy.json
+++ b/pkg/engine/testdata/cf_distribution.deployment-policy.json
@@ -1,0 +1,55 @@
+{
+    "Statement": [
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "s3:PutBucketPolicy",
+                "s3:DeleteBucketPolicy",
+                "s3:PutBucketPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:PutBucketAcl"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/delete_api_to_lambda_edge.deployment-policy.json
+++ b/pkg/engine/testdata/delete_api_to_lambda_edge.deployment-policy.json
@@ -1,0 +1,109 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/delete_namespace_resource.deployment-policy.json
+++ b/pkg/engine/testdata/delete_namespace_resource.deployment-policy.json
@@ -1,0 +1,55 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/delete_resource_and_iacdeps.deployment-policy.json
+++ b/pkg/engine/testdata/delete_resource_and_iacdeps.deployment-policy.json
@@ -1,0 +1,68 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:CreateCluster",
+                "ecs:DeleteCluster",
+                "ecs:UpdateClusterSettings"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/ecs_rds.deployment-policy.json
+++ b/pkg/engine/testdata/ecs_rds.deployment-policy.json
@@ -1,0 +1,170 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:CreateService",
+                "ecs:DeleteService",
+                "ecs:UpdateService"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:CreateCluster",
+                "ecs:DeleteCluster",
+                "ecs:UpdateClusterSettings"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:RegisterTaskDefinition",
+                "ecs:DeregisterTaskDefinition",
+                "ecs:RegisterTaskDefinition"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:ModifyDBInstance"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:ModifyDBSubnetGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/extend_graph.deployment-policy.json
+++ b/pkg/engine/testdata/extend_graph.deployment-policy.json
@@ -1,0 +1,127 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "dynamodb:CreateTable",
+                "dynamodb:DeleteTable",
+                "dynamodb:UpdateTable"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:AddPermission",
+                "lambda:RemovePermission",
+                "lambda:AddPermission"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/idempotent_constraints.deployment-policy.json
+++ b/pkg/engine/testdata/idempotent_constraints.deployment-policy.json
@@ -1,0 +1,170 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:CreateService",
+                "ecs:DeleteService",
+                "ecs:UpdateService"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:CreateCluster",
+                "ecs:DeleteCluster",
+                "ecs:UpdateClusterSettings"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecs:RegisterTaskDefinition",
+                "ecs:DeregisterTaskDefinition",
+                "ecs:RegisterTaskDefinition"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:ModifyDBInstance"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:ModifyDBSubnetGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/k8s_api.deployment-policy.json
+++ b/pkg/engine/testdata/k8s_api.deployment-policy.json
@@ -1,0 +1,265 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateVpcLink",
+                "apigateway:DeleteVpcLink",
+                "apigateway:UpdateVpcLink"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elbv2:CreateLoadBalancer",
+                "elbv2:DeleteLoadBalancer",
+                "elbv2:ModifyLoadBalancerAttributes"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elbv2:CreateListener",
+                "elbv2:DeleteListener",
+                "elbv2:ModifyListener"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "eks:CreateNodegroup",
+                "eks:DeleteNodegroup",
+                "eks:UpdateNodegroupConfig"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:AttachRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreatePolicy",
+                "iam:DeletePolicy",
+                "iam:CreatePolicyVersion"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateOpenIDConnectProvider",
+                "iam:DeleteOpenIDConnectProvider",
+                "iam:AddClientIDToOpenIDConnectProvider"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "eks:CreateCluster",
+                "eks:DeleteCluster",
+                "eks:UpdateCluster"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/lambda_efs.deployment-policy.json
+++ b/pkg/engine/testdata/lambda_efs.deployment-policy.json
@@ -1,0 +1,161 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "efs:CreateAccessPoint",
+                "efs:DeleteAccessPoint",
+                "efs:CreateAccessPoint"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "efs:CreateMountTarget",
+                "efs:DeleteMountTarget",
+                "efs:CreateMountTarget"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "efs:CreateFileSystem",
+                "efs:DeleteFileSystem",
+                "efs:CreateFileSystem"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/namespace_pathselect.deployment-policy.json
+++ b/pkg/engine/testdata/namespace_pathselect.deployment-policy.json
@@ -1,0 +1,134 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/remove_path.deployment-policy.json
+++ b/pkg/engine/testdata/remove_path.deployment-policy.json
@@ -1,0 +1,152 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:ModifyDBInstance"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "rds:CreateDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:ModifyDBSubnetGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/rename.deployment-policy.json
+++ b/pkg/engine/testdata/rename.deployment-policy.json
@@ -1,0 +1,64 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:PutBucketAcl"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/same_path_multiple_methods.deployment-policy.json
+++ b/pkg/engine/testdata/same_path_multiple_methods.deployment-policy.json
@@ -1,0 +1,59 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:CreateStage",
+                "apigateway:DeleteStage",
+                "apigateway:UpdateStage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateDeployment",
+                "apigateway:DeleteDeployment",
+                "apigateway:UpdateDeployment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateRestApi",
+                "apigateway:DeleteRestApi",
+                "apigateway:UpdateRestApi"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:CreateResource",
+                "apigateway:DeleteResource",
+                "apigateway:UpdateResource"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutMethod",
+                "apigateway:DeleteMethod",
+                "apigateway:UpdateMethod"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "apigateway:PutIntegration",
+                "apigateway:DeleteIntegration",
+                "apigateway:UpdateIntegration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/single_lambda.deployment-policy.json
+++ b/pkg/engine/testdata/single_lambda.deployment-policy.json
@@ -1,0 +1,55 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/static_site.deployment-policy.json
+++ b/pkg/engine/testdata/static_site.deployment-policy.json
@@ -1,0 +1,28 @@
+{
+    "Statement": [
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "s3:PutBucketPolicy",
+                "s3:DeleteBucketPolicy",
+                "s3:PutBucketPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:PutBucketAcl"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/vpc_import.deployment-policy.json
+++ b/pkg/engine/testdata/vpc_import.deployment-policy.json
@@ -1,0 +1,23 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/vpc_import_to_lambda.deployment-policy.json
+++ b/pkg/engine/testdata/vpc_import_to_lambda.deployment-policy.json
@@ -1,0 +1,82 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.deployment-policy.json
+++ b/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.deployment-policy.json
@@ -1,0 +1,134 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:ModifySecurityGroupRules"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:PutImage",
+                "ecr:BatchDeleteImage",
+                "ecr:PutImage"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateSubnet",
+                "ec2:DeleteSubnet",
+                "ec2:ModifySubnetAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository",
+                "ecr:PutLifecyclePolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AssociateRouteTable",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": null,
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateRouteTable",
+                "ec2:DeleteRouteTable",
+                "ec2:ReplaceRouteTableAssociation"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:DeleteLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateNatGateway",
+                "ec2:DeleteNatGateway",
+                "ec2:CreateNatGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:ReleaseAddress",
+                "ec2:AssociateAddress"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeAvailabilityZones"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:AttachInternetGateway"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:CreateVpc",
+                "ec2:DeleteVpc",
+                "ec2:ModifyVpcAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/pkg/infra/iac3/templates/package-lock.json
+++ b/pkg/infra/iac3/templates/package-lock.json
@@ -1,0 +1,3387 @@
+{
+    "name": "pulumi-templates",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "pulumi-templates",
+            "workspaces": [
+                "*/*"
+            ],
+            "devDependencies": {
+                "@types/node": "^18.15.11"
+            }
+        },
+        "aws/ami": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/api_deployment": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/api_integration": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/api_method": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/api_resource": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/api_stage": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/app_runner_service": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/docker": "^4.1.2",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/availability_zone": {
+            "name": "availability_zones",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/cloudfront_distribution": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/cloudfront_origin_access_identity": {
+            "name": "origin_access_identity",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/dynamodb_table": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/ec2_instance": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/ecr_image": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/command": "^0.7.2",
+                "@pulumi/docker": "^4.1.2",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/ecr_repo": {
+            "name": "ecr_repository",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/ecs_cluster": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/ecs_service": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/ecs_task_definition": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/docker": "^4.1.2",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/efs_access_point": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/efs_file_system": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/efs_mount_target": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/eks_add_on": {
+            "name": "eks_addon",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/eks_cluster": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/eks_fargate_profile": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/eks_node_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/aws-native": "^0.56.0"
+            }
+        },
+        "aws/elastic_ip": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/elasticache_cluster": {
+            "name": "elasticache",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/elasticache_subnet_group": {
+            "name": "elasticache_subnetgroup",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/iam_instance_profile": {
+            "name": "instance_profile",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/iam_oidc_provider": {
+            "name": "open_id_connect_provider",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/eks": "^0.42.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/iam_policy": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/iam_role": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/iam_role_policy_attachment": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/internet_gateway": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/lambda_event_source_mapping": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/lambda_function": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/docker": "^4.1.2",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/lambda_permission": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/load_balancer": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/load_balancer_listener": {
+            "name": "listener",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/log_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/nat_gateway": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/private_dns_namespace": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/rds_instance": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/rds_proxy": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/rds_proxy_target_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/rds_subnet_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/region": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/rest_api": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/route_table": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/route_table_association": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/s3_bucket": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/s3_bucket_policy": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/s3_object": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0",
+                "mime": "^2.0.0"
+            }
+        },
+        "aws/secret": {
+            "name": "fs-secret",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/secret_version": {
+            "name": "fs-secret-version",
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/security_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/security_group_rule": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/ses_email_identity": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/sqs_queue": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/subnet": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/target_group": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/vpc": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "aws/vpc_endpoint": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "aws/vpc_link": {
+            "dependencies": {
+                "@pulumi/aws": "^5.37.0"
+            }
+        },
+        "kubernetes/helm_chart": {
+            "dependencies": {
+                "@pulumi/kubernetes": "^3.21.4",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "kubernetes/kube_config": {
+            "name": "kubeconfig",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "kubernetes/kubernetes_provider": {
+            "dependencies": {
+                "@pulumi/kubernetes": "^3.21.4",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "kubernetes/manifest": {
+            "dependencies": {
+                "@pulumi/kubernetes": "^3.21.4",
+                "@pulumi/pulumi": "^3.69.0"
+            }
+        },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.9.6",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.6.tgz",
+            "integrity": "sha512-yq3qTy23u++8zdvf+h4mz4ohDFi681JAkMZZPTKh8zmUVh0AKLisFlgxcn22FMNowXz15oJ6pqgwT7DJ+PdJvg==",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.7.8",
+                "@types/node": ">=12.12.47"
+            },
+            "engines": {
+                "node": "^8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+            "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.2.4",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@logdna/tail-file": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-2.2.0.tgz",
+            "integrity": "sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==",
+            "engines": {
+                "node": ">=10.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+            "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-metrics": {
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
+            "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
+            "deprecated": "Please use @opentelemetry/api >= 1.3.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.18.1.tgz",
+            "integrity": "sha512-HHfJR32NH2x0b69CACCwH8m1dpNALoCTtpgmIWMNkeMGNUeKT48d4AX4xsF4uIRuUoRTbTgtSBRvS+cF97qwCQ==",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+            "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.18.1.tgz",
+            "integrity": "sha512-RmoWVFXFhvIh3q4szUe8I+/vxuMR0HNsOm39zNxnWJcK7JDwnPra9cLY/M78u6bTgB6Fte8GKgU128vvDzz0Iw==",
+            "dependencies": {
+                "@opentelemetry/core": "1.18.1",
+                "@opentelemetry/resources": "1.18.1",
+                "@opentelemetry/sdk-trace-base": "1.18.1",
+                "@opentelemetry/semantic-conventions": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
+            "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+            "dependencies": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "require-in-the-middle": "^5.0.3",
+                "semver": "^7.3.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc": {
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz",
+            "integrity": "sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==",
+            "dependencies": {
+                "@opentelemetry/api-metrics": "0.32.0",
+                "@opentelemetry/instrumentation": "0.32.0",
+                "@opentelemetry/semantic-conventions": "1.6.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
+            "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.18.1.tgz",
+            "integrity": "sha512-oSTUOsnt31JDx5SoEy27B5jE1/tiPvvE46w7CDKj0R5oZhCCfYH2bbSGa7NOOyDXDNqQDkgqU1DIV/xOd3f8pw==",
+            "dependencies": {
+                "@opentelemetry/core": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.18.1.tgz",
+            "integrity": "sha512-Kh4M1Qewv0Tbmts6D8LgNzx99IjdE18LCmY/utMkgVyU7Bg31Yuj+X6ZyoIRKPcD2EV4rVkuRI16WVMRuGbhWA==",
+            "dependencies": {
+                "@opentelemetry/core": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+            "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+            "dependencies": {
+                "@opentelemetry/core": "1.18.1",
+                "@opentelemetry/semantic-conventions": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
+            "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+            "dependencies": {
+                "@opentelemetry/core": "1.18.1",
+                "@opentelemetry/resources": "1.18.1",
+                "@opentelemetry/semantic-conventions": "1.18.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.18.1.tgz",
+            "integrity": "sha512-ML0l9TNlfLoplLF1F8lb95NGKgdm6OezDS3Ymqav9sYxMd5bnH2LZVzd4xEF+ov5vpZJOGdWxJMs2nC9no7+xA==",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "1.18.1",
+                "@opentelemetry/core": "1.18.1",
+                "@opentelemetry/propagator-b3": "1.18.1",
+                "@opentelemetry/propagator-jaeger": "1.18.1",
+                "@opentelemetry/sdk-trace-base": "1.18.1",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.8.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+            "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "node_modules/@pulumi/aws": {
+            "version": "5.43.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-5.43.0.tgz",
+            "integrity": "sha512-ZWI+QvEaFy27wUW8j8EVadgvl6u3926AAgpghflSPxF/9mG5XoDy0rqkRZOgO13ZJinC1qkQDzoMz0ACgmwTiw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "aws-sdk": "^2.0.0",
+                "builtin-modules": "3.0.0",
+                "mime": "^2.0.0",
+                "read-package-tree": "^5.2.1",
+                "resolve": "^1.7.1"
+            }
+        },
+        "node_modules/@pulumi/aws-native": {
+            "version": "0.56.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws-native/-/aws-native-0.56.0.tgz",
+            "integrity": "sha512-0HgdAXcsCVBzzfe85KApDOvWXVMRCaAJC722dIJ/av4klJADzMpR03auKYvb4iQDIvG0tF+w8nArxKH6Q7uYKQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/@pulumi/command": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/command/-/command-0.7.2.tgz",
+            "integrity": "sha512-R/eAIXIywSkn2cHIaNqs0EXcXduNeDuS+wom6oadB5KEP+6elgJbo4WMDP+OuDYGkkxEWIKjk0bPPO7570aXFQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0"
+            }
+        },
+        "node_modules/@pulumi/docker": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/docker/-/docker-4.5.0.tgz",
+            "integrity": "sha512-DOiczZK1cF4NGlEWzacPLjGcoPKXHXISoqq4KqCO97YW28rZSu6LOdveQ8tLaUHGeyWQ+CS3PT45caSxHAbzbw==",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "semver": "^5.4.0"
+            }
+        },
+        "node_modules/@pulumi/eks": {
+            "version": "0.42.7",
+            "resolved": "https://registry.npmjs.org/@pulumi/eks/-/eks-0.42.7.tgz",
+            "integrity": "sha512-uQeomOiKx6/GeZs7YhGsnZO+psBZLuX+vxrv5oqOvTGEkd+9LHWxggY91v8TV2bKc7uxfd0FC+30WVT2NYyPCA==",
+            "dependencies": {
+                "@pulumi/aws": "5.10.0",
+                "@pulumi/kubernetes": "3.20.2",
+                "@pulumi/pulumi": "^3.0.0",
+                "axios": "0.27.2",
+                "https-proxy-agent": "5.0.1",
+                "js-yaml": "3.14.1",
+                "netmask": "2.0.2",
+                "semver": "7.3.7",
+                "which": "1.3.1"
+            }
+        },
+        "node_modules/@pulumi/eks/node_modules/@pulumi/aws": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-5.10.0.tgz",
+            "integrity": "sha512-5z5MTc8mKkVFp0qFceXz4HsoZ9Rs7BPeczmgYsIwhHTWGsuELtgxhzrh/Z51x9xLxgff+oED4BRYs48t67Z9gw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0",
+                "aws-sdk": "^2.0.0",
+                "builtin-modules": "3.0.0",
+                "mime": "^2.0.0",
+                "read-package-tree": "^5.2.1",
+                "resolve": "^1.7.1"
+            }
+        },
+        "node_modules/@pulumi/eks/node_modules/@pulumi/kubernetes": {
+            "version": "3.20.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-3.20.2.tgz",
+            "integrity": "sha512-Hgloo8Rqr4UXK9nNNd6rmv0gS9fMINBiWXhc/7yW91F33EBRTWsYtimkxZGA5pg5gp/2R5Ifz6xDPL1wSBHbtw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.25.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/@pulumi/eks/node_modules/semver": {
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@pulumi/eks/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/@pulumi/kubernetes": {
+            "version": "3.30.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-3.30.2.tgz",
+            "integrity": "sha512-3877pq6eA8HAgULAtPUtihafG8glO8VKUNy6+/4sY9rE9xjnVcIFHE4ymuN+j0e40Wf49pupflhi7taZz1lSMQ==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@pulumi/pulumi": "^3.25.0",
+                "@types/glob": "^5.0.35",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "node_modules/@pulumi/pulumi": {
+            "version": "3.94.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.94.2.tgz",
+            "integrity": "sha512-3EophVuj7XDtLrY2UcofO0GTgwbr6RCFG1mRC0X1jYImpMGUAP++DYfKMnDGTu9vAAW7h2kJb0s361aLAKunnQ==",
+            "dependencies": {
+                "@grpc/grpc-js": "1.9.6",
+                "@logdna/tail-file": "^2.0.6",
+                "@opentelemetry/api": "^1.2.0",
+                "@opentelemetry/exporter-zipkin": "^1.6.0",
+                "@opentelemetry/instrumentation": "^0.32.0",
+                "@opentelemetry/instrumentation-grpc": "^0.32.0",
+                "@opentelemetry/resources": "^1.6.0",
+                "@opentelemetry/sdk-trace-base": "^1.6.0",
+                "@opentelemetry/sdk-trace-node": "^1.6.0",
+                "@opentelemetry/semantic-conventions": "^1.6.0",
+                "@pulumi/query": "^0.3.0",
+                "execa": "^5.1.0",
+                "google-protobuf": "^3.5.0",
+                "ini": "^2.0.0",
+                "js-yaml": "^3.14.0",
+                "minimist": "^1.2.6",
+                "normalize-package-data": "^3.0.0",
+                "pkg-dir": "^7.0.0",
+                "read-package-tree": "^5.3.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^7.5.2",
+                "source-map-support": "^0.5.6",
+                "ts-node": "^7.0.1",
+                "typescript": "~3.8.3",
+                "upath": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@pulumi/pulumi/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@pulumi/query": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/query/-/query-0.3.0.tgz",
+            "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
+        },
+        "node_modules/@types/glob": {
+            "version": "5.0.38",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.38.tgz",
+            "integrity": "sha512-rTtf75rwyP9G2qO5yRpYtdJ6aU1QqEhWbtW55qEgquEDa6bXW0s2TWZfDm02GuppjEozOWG/F2UnPq5hAQb+gw==",
+            "dependencies": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/minimatch": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
+        },
+        "node_modules/@types/node": {
+            "version": "18.18.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.12.tgz",
+            "integrity": "sha512-G7slVfkwOm7g8VqcEF1/5SXiMjP3Tbt+pXDU3r/qhlM2KkGm786DUD4xyMA2QzEElFrv/KZV9gjygv4LnkpbMQ==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ=="
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/ami": {
+            "resolved": "aws/ami",
+            "link": true
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/api_deployment": {
+            "resolved": "aws/api_deployment",
+            "link": true
+        },
+        "node_modules/api_integration": {
+            "resolved": "aws/api_integration",
+            "link": true
+        },
+        "node_modules/api_method": {
+            "resolved": "aws/api_method",
+            "link": true
+        },
+        "node_modules/api_resource": {
+            "resolved": "aws/api_resource",
+            "link": true
+        },
+        "node_modules/api_stage": {
+            "resolved": "aws/api_stage",
+            "link": true
+        },
+        "node_modules/app_runner_service": {
+            "resolved": "aws/app_runner_service",
+            "link": true
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/array.prototype.reduce": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz",
+            "integrity": "sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arraybuffer.prototype.slice": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+            "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "get-intrinsic": "^1.2.1",
+                "is-array-buffer": "^3.0.2",
+                "is-shared-array-buffer": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/availability_zones": {
+            "resolved": "aws/availability_zone",
+            "link": true
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.1501.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1501.0.tgz",
+            "integrity": "sha512-mlYhHlB255oov0ks06hxEUYzOHji4urr0xJ8TRbkgUnp1lYdNaTjUFpwzfqbA7w74ZD6gJtca/EjDxk8g4SSSQ==",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.16.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "util": "^0.12.4",
+                "uuid": "8.0.0",
+                "xml2js": "0.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "dependencies": {
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+        },
+        "node_modules/builtin-modules": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+            "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cloudfront_distribution": {
+            "resolved": "aws/cloudfront_distribution",
+            "link": true
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dezalgo": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dynamodb_table": {
+            "resolved": "aws/dynamodb_table",
+            "link": true
+        },
+        "node_modules/ec2_instance": {
+            "resolved": "aws/ec2_instance",
+            "link": true
+        },
+        "node_modules/ecr_image": {
+            "resolved": "aws/ecr_image",
+            "link": true
+        },
+        "node_modules/ecr_repository": {
+            "resolved": "aws/ecr_repo",
+            "link": true
+        },
+        "node_modules/ecs_cluster": {
+            "resolved": "aws/ecs_cluster",
+            "link": true
+        },
+        "node_modules/ecs_service": {
+            "resolved": "aws/ecs_service",
+            "link": true
+        },
+        "node_modules/ecs_task_definition": {
+            "resolved": "aws/ecs_task_definition",
+            "link": true
+        },
+        "node_modules/efs_access_point": {
+            "resolved": "aws/efs_access_point",
+            "link": true
+        },
+        "node_modules/efs_file_system": {
+            "resolved": "aws/efs_file_system",
+            "link": true
+        },
+        "node_modules/efs_mount_target": {
+            "resolved": "aws/efs_mount_target",
+            "link": true
+        },
+        "node_modules/eks_addon": {
+            "resolved": "aws/eks_add_on",
+            "link": true
+        },
+        "node_modules/eks_cluster": {
+            "resolved": "aws/eks_cluster",
+            "link": true
+        },
+        "node_modules/eks_fargate_profile": {
+            "resolved": "aws/eks_fargate_profile",
+            "link": true
+        },
+        "node_modules/eks_node_group": {
+            "resolved": "aws/eks_node_group",
+            "link": true
+        },
+        "node_modules/elastic_ip": {
+            "resolved": "aws/elastic_ip",
+            "link": true
+        },
+        "node_modules/elasticache": {
+            "resolved": "aws/elasticache_cluster",
+            "link": true
+        },
+        "node_modules/elasticache_subnetgroup": {
+            "resolved": "aws/elasticache_subnet_group",
+            "link": true
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/es-abstract": {
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "arraybuffer.prototype.slice": "^1.0.2",
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.5",
+                "es-set-tostringtag": "^2.0.1",
+                "es-to-primitive": "^1.2.1",
+                "function.prototype.name": "^1.1.6",
+                "get-intrinsic": "^1.2.2",
+                "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
+                "is-callable": "^1.2.7",
+                "is-negative-zero": "^2.0.2",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.12",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.13.1",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "safe-array-concat": "^1.0.1",
+                "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.8",
+                "string.prototype.trimend": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.7",
+                "typed-array-buffer": "^1.0.0",
+                "typed-array-byte-length": "^1.0.0",
+                "typed-array-byte-offset": "^1.0.0",
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+            "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+            "dependencies": {
+                "locate-path": "^7.1.0",
+                "path-exists": "^5.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dependencies": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-secret": {
+            "resolved": "aws/secret",
+            "link": true
+        },
+        "node_modules/fs-secret-version": {
+            "resolved": "aws/secret_version",
+            "link": true
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/function.prototype.name": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "functions-have-names": "^1.2.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+            "dependencies": {
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dependencies": {
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/google-protobuf": {
+            "version": "3.21.2",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+            "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+        },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/helm_chart": {
+            "resolved": "kubernetes/helm_chart",
+            "link": true
+        },
+        "node_modules/hosted-git-info": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iam_policy": {
+            "resolved": "aws/iam_policy",
+            "link": true
+        },
+        "node_modules/iam_role": {
+            "resolved": "aws/iam_role",
+            "link": true
+        },
+        "node_modules/iam_role_policy_attachment": {
+            "resolved": "aws/iam_role_policy_attachment",
+            "link": true
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/ini": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/instance_profile": {
+            "resolved": "aws/iam_instance_profile",
+            "link": true
+        },
+        "node_modules/internal-slot": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/internet_gateway": {
+            "resolved": "aws/internet_gateway",
+            "link": true
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "dependencies": {
+                "has-bigints": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "dependencies": {
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-shared-array-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+            "dependencies": {
+                "which-typed-array": "^1.1.11"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakref": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+        },
+        "node_modules/jmespath": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
+        "node_modules/kubeconfig": {
+            "resolved": "kubernetes/kube_config",
+            "link": true
+        },
+        "node_modules/kubernetes_provider": {
+            "resolved": "kubernetes/kubernetes_provider",
+            "link": true
+        },
+        "node_modules/lambda_event_source_mapping": {
+            "resolved": "aws/lambda_event_source_mapping",
+            "link": true
+        },
+        "node_modules/lambda_function": {
+            "resolved": "aws/lambda_function",
+            "link": true
+        },
+        "node_modules/lambda_permission": {
+            "resolved": "aws/lambda_permission",
+            "link": true
+        },
+        "node_modules/listener": {
+            "resolved": "aws/load_balancer_listener",
+            "link": true
+        },
+        "node_modules/load_balancer": {
+            "resolved": "aws/load_balancer",
+            "link": true
+        },
+        "node_modules/locate-path": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+            "dependencies": {
+                "p-locate": "^6.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+        },
+        "node_modules/log_group": {
+            "resolved": "aws/log_group",
+            "link": true
+        },
+        "node_modules/long": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "node_modules/manifest": {
+            "resolved": "kubernetes/manifest",
+            "link": true
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+        },
+        "node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+            "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/nat_gateway": {
+            "resolved": "aws/nat_gateway",
+            "link": true
+        },
+        "node_modules/netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "is-core-module": "^2.5.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/normalize-package-data/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm-normalize-package-bin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "has-symbols": "^1.0.3",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object.getownpropertydescriptors": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz",
+            "integrity": "sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==",
+            "dependencies": {
+                "array.prototype.reduce": "^1.0.6",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1",
+                "safe-array-concat": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open_id_connect_provider": {
+            "resolved": "aws/iam_oidc_provider",
+            "link": true
+        },
+        "node_modules/origin_access_identity": {
+            "resolved": "aws/cloudfront_origin_access_identity",
+            "link": true
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+            "dependencies": {
+                "p-limit": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/pkg-dir": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+            "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+            "dependencies": {
+                "find-up": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/private_dns_namespace": {
+            "resolved": "aws/private_dns_namespace",
+            "link": true
+        },
+        "node_modules/protobufjs": {
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+            "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/rds_instance": {
+            "resolved": "aws/rds_instance",
+            "link": true
+        },
+        "node_modules/rds_proxy": {
+            "resolved": "aws/rds_proxy",
+            "link": true
+        },
+        "node_modules/rds_proxy_target_group": {
+            "resolved": "aws/rds_proxy_target_group",
+            "link": true
+        },
+        "node_modules/rds_subnet_group": {
+            "resolved": "aws/rds_subnet_group",
+            "link": true
+        },
+        "node_modules/read-package-json": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+            "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+            "dependencies": {
+                "glob": "^7.1.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "normalize-package-data": "^2.0.0",
+                "npm-normalize-package-bin": "^1.0.0"
+            }
+        },
+        "node_modules/read-package-json/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "node_modules/read-package-json/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/read-package-tree": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+            "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+            "deprecated": "The functionality that this package provided is now in @npmcli/arborist",
+            "dependencies": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+            }
+        },
+        "node_modules/readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "set-function-name": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/region": {
+            "resolved": "aws/region",
+            "link": true
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-in-the-middle": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+            "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/rest_api": {
+            "resolved": "aws/rest_api",
+            "link": true
+        },
+        "node_modules/route_table": {
+            "resolved": "aws/route_table",
+            "link": true
+        },
+        "node_modules/route_table_association": {
+            "resolved": "aws/route_table_association",
+            "link": true
+        },
+        "node_modules/s3_bucket": {
+            "resolved": "aws/s3_bucket",
+            "link": true
+        },
+        "node_modules/s3_bucket_policy": {
+            "resolved": "aws/s3_bucket_policy",
+            "link": true
+        },
+        "node_modules/s3_object": {
+            "resolved": "aws/s3_object",
+            "link": true
+        },
+        "node_modules/safe-array-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "has-symbols": "^1.0.3",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-array-concat/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+        },
+        "node_modules/security_group": {
+            "resolved": "aws/security_group",
+            "link": true
+        },
+        "node_modules/security_group_rule": {
+            "resolved": "aws/security_group_rule",
+            "link": true
+        },
+        "node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/ses_email_identity": {
+            "resolved": "aws/ses_email_identity",
+            "link": true
+        },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-function-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+        },
+        "node_modules/side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+            "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        },
+        "node_modules/sqs_queue": {
+            "resolved": "aws/sqs_queue",
+            "link": true
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.22.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/subnet": {
+            "resolved": "aws/subnet",
+            "link": true
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/target_group": {
+            "resolved": "aws/target_group",
+            "link": true
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/ts-node": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "dependencies": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typed-array-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.0.3",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
+        "node_modules/upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "node_modules/util-promisify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+            "integrity": "sha512-K+5eQPYs14b3+E+hmE2J6gCZ4JmMl9DbYS6BeP2CHq6WMuNxErxf5B/n0fz85L8zUuoO6rIzNNmIQDu/j+1OcA==",
+            "dependencies": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+            "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/vpc": {
+            "resolved": "aws/vpc",
+            "link": true
+        },
+        "node_modules/vpc_endpoint": {
+            "resolved": "aws/vpc_endpoint",
+            "link": true
+        },
+        "node_modules/vpc_link": {
+            "resolved": "aws/vpc_link",
+            "link": true
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.4",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/pkg/knowledgebase/reader/resource_template.go
+++ b/pkg/knowledgebase/reader/resource_template.go
@@ -26,6 +26,8 @@ type (
 
 		NoIac bool `json:"no_iac" yaml:"no_iac"`
 
+		DeploymentPermissions knowledgebase.DeploymentPermissions `json:"deployment_permissions" yaml:"deployment_permissions"`
+
 		SanitizeNameTmpl string `yaml:"sanitize_name"`
 	}
 )
@@ -43,16 +45,17 @@ func (r *ResourceTemplate) Convert() (*knowledgebase.ResourceTemplate, error) {
 		}
 	}
 	return &knowledgebase.ResourceTemplate{
-		QualifiedTypeName: r.QualifiedTypeName,
-		DisplayName:       r.DisplayName,
-		Properties:        kbProperties,
-		AdditionalRules:   r.AdditionalRules,
-		Classification:    r.Classification,
-		PathSatisfaction:  r.PathSatisfaction,
-		Consumption:       r.Consumption,
-		DeleteContext:     r.DeleteContext,
-		Views:             r.Views,
-		NoIac:             r.NoIac,
-		SanitizeNameTmpl:  sanitizeTmpl,
+		QualifiedTypeName:     r.QualifiedTypeName,
+		DisplayName:           r.DisplayName,
+		Properties:            kbProperties,
+		AdditionalRules:       r.AdditionalRules,
+		Classification:        r.Classification,
+		PathSatisfaction:      r.PathSatisfaction,
+		Consumption:           r.Consumption,
+		DeleteContext:         r.DeleteContext,
+		Views:                 r.Views,
+		NoIac:                 r.NoIac,
+		DeploymentPermissions: r.DeploymentPermissions,
+		SanitizeNameTmpl:      sanitizeTmpl,
 	}, nil
 }

--- a/pkg/knowledgebase/resource_template.go
+++ b/pkg/knowledgebase/resource_template.go
@@ -47,8 +47,20 @@ type (
 		// NoIac defines if the resource should be ignored by the IaC engine
 		NoIac bool `json:"no_iac" yaml:"no_iac"`
 
+		// DeploymentPermissions defines the permissions that are required to deploy and tear down the resource
+		DeploymentPermissions DeploymentPermissions `json:"deployment_permissions" yaml:"deployment_permissions"`
+
 		// SanitizeNameTmpl defines a template that is used to sanitize the name of the resource
 		SanitizeNameTmpl *SanitizeTmpl `yaml:"sanitize_name"`
+	}
+
+	DeploymentPermissions struct {
+		// Deploy defines the permissions that are required to deploy the resource
+		Deploy []string `json:"deploy" yaml:"deploy"`
+		// TearDown defines the permissions that are required to tear down the resource
+		TearDown []string `json:"tear_down" yaml:"tear_down"`
+		// Update defines the permissions that are required to update the resource
+		Update []string `json:"update" yaml:"update"`
 	}
 
 	// PropertyDetails defines the common details of a property

--- a/pkg/provider/aws/permissions.go
+++ b/pkg/provider/aws/permissions.go
@@ -1,0 +1,64 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/klothoplatform/klotho/pkg/construct"
+	"github.com/klothoplatform/klotho/pkg/engine/solution_context"
+)
+
+// Permissions returns the permissions for the AWS provider
+func DeploymentPermissionsPolicy(ctx solution_context.SolutionContext) ([]byte, error) {
+	policy := &construct.Resource{
+		ID: construct.ResourceId{
+			Provider: "aws",
+			Type:     "iam_policy",
+			Name:     "deployment_permissions",
+		},
+		Properties: construct.Properties{
+			"Policy": map[string]any{
+				"Version": "2012-10-17",
+			},
+		},
+	}
+	kb := ctx.KnowledgeBase()
+	policyRt, err := kb.GetResourceTemplate(policy.ID)
+	if err != nil {
+		return nil, err
+	}
+	if policyRt == nil {
+		return nil, fmt.Errorf("resource template not found for resource %s", policy.ID)
+	}
+	// Find the StatementProperty so we can use its methods
+	statementProperty := policyRt.GetProperty("Policy.Statement")
+
+	err = construct.WalkGraph(ctx.DataflowGraph(), func(id construct.ResourceId, resource *construct.Resource, nerr error) error {
+		if nerr != nil {
+			return nerr
+		}
+		rt, err := kb.GetResourceTemplate(resource.ID)
+		if err != nil {
+			return err
+		}
+		if rt == nil {
+			return fmt.Errorf("resource template not found for resource %s", resource.ID)
+		}
+
+		statement := map[string]any{
+			"Effect":   "Allow",
+			"Action":   append(rt.DeploymentPermissions.Deploy, append(rt.DeploymentPermissions.TearDown, rt.DeploymentPermissions.Update...)...),
+			"Resource": "*",
+		}
+		return statementProperty.AppendProperty(policy, statement)
+	})
+	if err != nil {
+		return nil, err
+	}
+	pol, err := policy.GetProperty("Policy")
+
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(pol, "", "    ")
+}

--- a/pkg/templates/aws/resources/acm_certificate.yaml
+++ b/pkg/templates/aws/resources/acm_certificate.yaml
@@ -48,3 +48,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["acm:RequestCertificate", "acm:AddTagsToCertificate", "acm:ImportCertificate"]
+  tear_down: ["acm:DeleteCertificate"]
+  update: ["acm:ResendValidationEmail"]

--- a/pkg/templates/aws/resources/ami.yaml
+++ b/pkg/templates/aws/resources/ami.yaml
@@ -9,3 +9,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateImage"]
+  tear_down: ["ec2:DeregisterImage"]
+  update: ["ec2:ModifyImageAttribute"]

--- a/pkg/templates/aws/resources/api_deployment.yaml
+++ b/pkg/templates/aws/resources/api_deployment.yaml
@@ -19,3 +19,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["apigateway:CreateDeployment"]
+  tear_down: ["apigateway:DeleteDeployment"]
+  update: ["apigateway:UpdateDeployment"]

--- a/pkg/templates/aws/resources/api_integration.yaml
+++ b/pkg/templates/aws/resources/api_integration.yaml
@@ -107,3 +107,8 @@ delete_context:
 
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["apigateway:PutIntegration"]
+  tear_down: ["apigateway:DeleteIntegration"]
+  update: ["apigateway:UpdateIntegration"]

--- a/pkg/templates/aws/resources/api_method.yaml
+++ b/pkg/templates/aws/resources/api_method.yaml
@@ -48,3 +48,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["apigateway:PutMethod"]
+  tear_down: ["apigateway:DeleteMethod"]
+  update: ["apigateway:UpdateMethod"]

--- a/pkg/templates/aws/resources/api_resource.yaml
+++ b/pkg/templates/aws/resources/api_resource.yaml
@@ -54,3 +54,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["apigateway:CreateResource"]
+  tear_down: ["apigateway:DeleteResource"]
+  update: ["apigateway:UpdateResource"]

--- a/pkg/templates/aws/resources/api_stage.yaml
+++ b/pkg/templates/aws/resources/api_stage.yaml
@@ -35,3 +35,8 @@ delete_context:
 
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["apigateway:CreateStage"]
+  tear_down: ["apigateway:DeleteStage"]
+  update: ["apigateway:UpdateStage"]

--- a/pkg/templates/aws/resources/app_runer_service.yaml
+++ b/pkg/templates/aws/resources/app_runer_service.yaml
@@ -56,3 +56,8 @@ classification:
 
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["apprunner:CreateService"]
+  tear_down: ["apprunner:DeleteService"]
+  update: ["apprunner:UpdateService"]

--- a/pkg/templates/aws/resources/availability_zone.yaml
+++ b/pkg/templates/aws/resources/availability_zone.yaml
@@ -19,3 +19,6 @@ properties:
     description: References the AWS Region associated with the Availability Zone
 delete_context:
   requires_no_upstream: true
+
+deployment_permissions:
+  deploy: ["ec2:DescribeAvailabilityZones"]

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -203,3 +203,9 @@ delete_context:
 
 views:
   dataflow: big
+
+
+aws:cloudfront_distribution:
+  deploy: ["cloudfront:CreateDistribution"]
+  tear_down: ["cloudfront:DeleteDistribution"]
+  update: ["cloudfront:UpdateDistribution"]

--- a/pkg/templates/aws/resources/cloudfront_origin_access_identity.yaml
+++ b/pkg/templates/aws/resources/cloudfront_origin_access_identity.yaml
@@ -16,3 +16,8 @@ properties:
 
 delete_context:
   requires_no_upstream_or_downstream: true
+
+aws:deployment_permissions:
+  deploy: ["cloudfront:CreateCloudFrontOriginAccessIdentity"]
+  tear_down: ["cloudfront:DeleteCloudFrontOriginAccessIdentity"]
+  update: ["cloudfront:UpdateCloudFrontOriginAccessIdentity"]

--- a/pkg/templates/aws/resources/dynamodb_table.yaml
+++ b/pkg/templates/aws/resources/dynamodb_table.yaml
@@ -84,3 +84,9 @@ delete_context:
 
 views:
   dataflow: big
+
+
+deployment_permissions:
+  deploy: ["dynamodb:CreateTable"]
+  tear_down: ["dynamodb:DeleteTable"]
+  update: ["dynamodb:UpdateTable"]

--- a/pkg/templates/aws/resources/ec2_instance.yaml
+++ b/pkg/templates/aws/resources/ec2_instance.yaml
@@ -70,3 +70,9 @@ delete_context:
   requires_no_downstream: true
 views:
   dataflow: big
+
+
+deployment_permissions:
+  deploy: ["ec2:RunInstances"]
+  tear_down: ["ec2:TerminateInstances"]
+  update: ["ec2:ModifyInstanceAttribute"]

--- a/pkg/templates/aws/resources/ecr_image.yaml
+++ b/pkg/templates/aws/resources/ecr_image.yaml
@@ -41,3 +41,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ecr:PutImage"]
+  tear_down: ["ecr:BatchDeleteImage"]
+  update: ["ecr:PutImage"]

--- a/pkg/templates/aws/resources/ecr_repo.yaml
+++ b/pkg/templates/aws/resources/ecr_repo.yaml
@@ -12,3 +12,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["ecr:CreateRepository"]
+  tear_down: ["ecr:DeleteRepository"]
+  update: ["ecr:PutLifecyclePolicy"]

--- a/pkg/templates/aws/resources/ecs_cluster.yaml
+++ b/pkg/templates/aws/resources/ecs_cluster.yaml
@@ -7,3 +7,8 @@ classification:
 
 delete_context:
   requires_no_upstream: true
+
+deployment_permissions:
+  deploy: ["ecs:CreateCluster"]
+  tear_down: ["ecs:DeleteCluster"]
+  update: ["ecs:UpdateClusterSettings"]

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -121,3 +121,8 @@ delete_context:
   requires_no_downstream: true
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["ecs:CreateService"]
+  tear_down: ["ecs:DeleteService"]
+  update: ["ecs:UpdateService"]

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -235,3 +235,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["ecs:RegisterTaskDefinition"]
+  tear_down: ["ecs:DeregisterTaskDefinition"]
+  update: ["ecs:RegisterTaskDefinition"]

--- a/pkg/templates/aws/resources/efs_access_point.yaml
+++ b/pkg/templates/aws/resources/efs_access_point.yaml
@@ -48,3 +48,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["efs:CreateAccessPoint"]
+  tear_down: ["efs:DeleteAccessPoint"]
+  update: ["efs:CreateAccessPoint"]

--- a/pkg/templates/aws/resources/efs_file_system.yaml
+++ b/pkg/templates/aws/resources/efs_file_system.yaml
@@ -74,3 +74,10 @@ delete_context:
   requires_no_downstream: true
 views:
   dataflow: big
+
+
+
+deployment_permissions:
+  deploy: ["efs:CreateFileSystem"]
+  tear_down: ["efs:DeleteFileSystem"]
+  update: ["efs:CreateFileSystem"]

--- a/pkg/templates/aws/resources/efs_mount_target.yaml
+++ b/pkg/templates/aws/resources/efs_mount_target.yaml
@@ -48,3 +48,9 @@ classification:
 
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["efs:CreateMountTarget"]
+  tear_down: ["efs:DeleteMountTarget"]
+  update: ["efs:CreateMountTarget"]

--- a/pkg/templates/aws/resources/eks_add_on.yaml
+++ b/pkg/templates/aws/resources/eks_add_on.yaml
@@ -19,3 +19,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+aws:eks_add_on:
+  deploy: ["eks:CreateAddon"]
+  tear_down: ["eks:DeleteAddon"]
+  update: ["eks:UpdateAddon"]

--- a/pkg/templates/aws/resources/eks_cluster.yaml
+++ b/pkg/templates/aws/resources/eks_cluster.yaml
@@ -69,3 +69,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: parent
+
+
+deployment_permissions:
+  deploy: ["eks:CreateCluster"]
+  tear_down: ["eks:DeleteCluster"]
+  update: ["eks:UpdateCluster"]

--- a/pkg/templates/aws/resources/eks_fargate_profile.yaml
+++ b/pkg/templates/aws/resources/eks_fargate_profile.yaml
@@ -48,3 +48,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["eks:CreateFargateProfile"]
+  tear_down: ["eks:DeleteFargateProfile"]
+  update: ["eks:CreateFargateProfile"]

--- a/pkg/templates/aws/resources/eks_node_group.yaml
+++ b/pkg/templates/aws/resources/eks_node_group.yaml
@@ -79,3 +79,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["eks:CreateNodegroup"]
+  tear_down: ["eks:DeleteNodegroup"]
+  update: ["eks:UpdateNodegroupConfig"]

--- a/pkg/templates/aws/resources/elastic_ip.yaml
+++ b/pkg/templates/aws/resources/elastic_ip.yaml
@@ -9,3 +9,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:AllocateAddress"]
+  tear_down: ["ec2:ReleaseAddress"]
+  update: ["ec2:AssociateAddress"]

--- a/pkg/templates/aws/resources/elasticache_cluster.yaml
+++ b/pkg/templates/aws/resources/elasticache_cluster.yaml
@@ -81,3 +81,9 @@ delete_context:
   requires_no_downstream: true
 views:
   dataflow: big
+
+
+deployment_permissions:
+  deploy: ["elasticache:CreateCacheCluster"]
+  tear_down: ["elasticache:DeleteCacheCluster"]
+  update: ["elasticache:ModifyCacheCluster"]

--- a/pkg/templates/aws/resources/elasticache_subnet_group.yaml
+++ b/pkg/templates/aws/resources/elasticache_subnet_group.yaml
@@ -31,3 +31,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["elasticache:CreateCacheSubnetGroup"]
+  tear_down: ["elasticache:DeleteCacheSubnetGroup"]
+  update: ["elasticache:ModifyCacheSubnetGroup"]

--- a/pkg/templates/aws/resources/iam_instance_profile.yaml
+++ b/pkg/templates/aws/resources/iam_instance_profile.yaml
@@ -12,3 +12,8 @@ properties:
         unique: true
     description: The role that is associated with the instance profile to be used
       by the EC2 instances
+
+deployment_permissions:
+  deploy: ["iam:CreateInstanceProfile"]
+  tear_down: ["iam:DeleteInstanceProfile"]
+  update: ["iam:AddRoleToInstanceProfile"]

--- a/pkg/templates/aws/resources/iam_oidc_provider.yaml
+++ b/pkg/templates/aws/resources/iam_oidc_provider.yaml
@@ -40,3 +40,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["iam:CreateOpenIDConnectProvider"]
+  tear_down: ["iam:DeleteOpenIDConnectProvider"]
+  update: ["iam:AddClientIDToOpenIDConnectProvider"]

--- a/pkg/templates/aws/resources/iam_policy.yaml
+++ b/pkg/templates/aws/resources/iam_policy.yaml
@@ -74,3 +74,8 @@ delete_context:
 
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["iam:CreatePolicy"]
+  tear_down: ["iam:DeletePolicy"]
+  update: ["iam:CreatePolicyVersion"]

--- a/pkg/templates/aws/resources/iam_role.yaml
+++ b/pkg/templates/aws/resources/iam_role.yaml
@@ -92,3 +92,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["iam:CreateRole"]
+  tear_down: ["iam:DeleteRole"]
+  update: ["iam:UpdateAssumeRolePolicy"]

--- a/pkg/templates/aws/resources/iam_role_policy_attachment.yaml
+++ b/pkg/templates/aws/resources/iam_role_policy_attachment.yaml
@@ -15,3 +15,8 @@ properties:
     description: The name of the IAM role to which the policy will be attached
 delete_context:
   requires_no_upstream_or_downstream: true
+
+deployment_permissions:
+  deploy: ["iam:AttachRolePolicy"]
+  tear_down: ["iam:DetachRolePolicy"]
+  update: ["iam:AttachRolePolicy"]

--- a/pkg/templates/aws/resources/internet_gateway.yaml
+++ b/pkg/templates/aws/resources/internet_gateway.yaml
@@ -20,3 +20,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateInternetGateway"]
+  tear_down: ["ec2:DeleteInternetGateway"]
+  update: ["ec2:AttachInternetGateway"]

--- a/pkg/templates/aws/resources/lambda_event_source_mapping.yaml
+++ b/pkg/templates/aws/resources/lambda_event_source_mapping.yaml
@@ -37,3 +37,9 @@ properties:
     properties:
       MaximumConcurrency:
         type: int
+
+
+deployment_permissions:
+  deploy: ["lambda:CreateEventSourceMapping"]
+  tear_down: ["lambda:DeleteEventSourceMapping"]
+  update: ["lambda:UpdateEventSourceMapping"]

--- a/pkg/templates/aws/resources/lambda_function.yaml
+++ b/pkg/templates/aws/resources/lambda_function.yaml
@@ -106,3 +106,9 @@ delete_context:
 
 views:
   dataflow: big
+
+
+deployment_permissions:
+  deploy: ["lambda:CreateFunction"]
+  tear_down: ["lambda:DeleteFunction"]
+  update: ["lambda:UpdateFunctionConfiguration"]

--- a/pkg/templates/aws/resources/lambda_permission.yaml
+++ b/pkg/templates/aws/resources/lambda_permission.yaml
@@ -24,3 +24,9 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["lambda:AddPermission"]
+  tear_down: ["lambda:RemovePermission"]
+  update: ["lambda:AddPermission"]

--- a/pkg/templates/aws/resources/listener_certificate.yaml
+++ b/pkg/templates/aws/resources/listener_certificate.yaml
@@ -23,3 +23,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["elbv2:AddListenerCertificates"]
+  tear_down: ["elbv2:RemoveListenerCertificates"]
+  update: ["elbv2:AddListenerCertificates"]

--- a/pkg/templates/aws/resources/load_balancer.yaml
+++ b/pkg/templates/aws/resources/load_balancer.yaml
@@ -101,3 +101,9 @@ delete_context:
   requires_no_downstream: true
 views:
   dataflow: parent
+
+
+deployment_permissions:
+  deploy: ["elbv2:CreateLoadBalancer"]
+  tear_down: ["elbv2:DeleteLoadBalancer"]
+  update: ["elbv2:ModifyLoadBalancerAttributes"]

--- a/pkg/templates/aws/resources/load_balancer_listener.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener.yaml
@@ -42,3 +42,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["elbv2:CreateListener"]
+  tear_down: ["elbv2:DeleteListener"]
+  update: ["elbv2:ModifyListener"]

--- a/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
@@ -74,3 +74,8 @@ classification:
 path_satisfaction:
   as_source:
     - network#Listener#LoadBalancer#Subnets
+
+deployment_permissions:
+  deploy: ["elbv2:CreateRule"]
+  tear_down: ["elbv2:DeleteRule"]
+  update: ["elbv2:ModifyRule"]

--- a/pkg/templates/aws/resources/log_group.yaml
+++ b/pkg/templates/aws/resources/log_group.yaml
@@ -31,3 +31,8 @@ delete_context:
 
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["logs:CreateLogGroup"]
+  tear_down: ["logs:DeleteLogGroup"]
+  update: ["logs:PutRetentionPolicy"]

--- a/pkg/templates/aws/resources/nat_gateway.yaml
+++ b/pkg/templates/aws/resources/nat_gateway.yaml
@@ -32,3 +32,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateNatGateway"]
+  tear_down: ["ec2:DeleteNatGateway"]
+  update: ["ec2:CreateNatGateway"]

--- a/pkg/templates/aws/resources/private_dns_namespace.yaml
+++ b/pkg/templates/aws/resources/private_dns_namespace.yaml
@@ -30,3 +30,9 @@ delete_context:
 
 views:
   dataflow: small
+
+
+aws:private_dns_namespace:
+  deploy: ["servicediscovery:CreatePrivateDnsNamespace"]
+  tear_down: ["servicediscovery:DeleteNamespace"]
+  update: ["servicediscovery:UpdatePrivateDnsNamespace"]

--- a/pkg/templates/aws/resources/rds_instance.yaml
+++ b/pkg/templates/aws/resources/rds_instance.yaml
@@ -138,3 +138,8 @@ delete_context:
   requires_explicit_delete: true
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["rds:CreateDBInstance"]
+  tear_down: ["rds:DeleteDBInstance"]
+  update: ["rds:ModifyDBInstance"]

--- a/pkg/templates/aws/resources/rds_proxy.yaml
+++ b/pkg/templates/aws/resources/rds_proxy.yaml
@@ -72,3 +72,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["rds:CreateDBProxy"]
+  tear_down: ["rds:DeleteDBProxy"]
+  update: ["rds:ModifyDBProxy"]

--- a/pkg/templates/aws/resources/rds_proxy_target_group.yaml
+++ b/pkg/templates/aws/resources/rds_proxy_target_group.yaml
@@ -52,3 +52,8 @@ classification:
     - rds_proxy_target_group
   gives:
     - reliability:storage
+
+deployment_permissions:
+  deploy: ["rds:CreateDBProxyTargetGroup"]
+  tear_down: ["rds:DeleteDBProxyTargetGroup"]
+  update: ["rds:ModifyDBProxyTargetGroup"]

--- a/pkg/templates/aws/resources/rds_subnet_group.yaml
+++ b/pkg/templates/aws/resources/rds_subnet_group.yaml
@@ -33,3 +33,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["rds:CreateDBSubnetGroup"]
+  tear_down: ["rds:DeleteDBSubnetGroup"]
+  update: ["rds:ModifyDBSubnetGroup"]

--- a/pkg/templates/aws/resources/region.yaml
+++ b/pkg/templates/aws/resources/region.yaml
@@ -10,3 +10,7 @@ properties:
 
 delete_context:
   requires_no_upstream: true
+
+
+aws:region:
+  deploy: ["ec2:DescribeRegions"]

--- a/pkg/templates/aws/resources/rest_api.yaml
+++ b/pkg/templates/aws/resources/rest_api.yaml
@@ -35,3 +35,8 @@ delete_context:
 
 views:
   dataflow: parent
+
+deployment_permissions:
+  deploy: ["apigateway:CreateRestApi"]
+  tear_down: ["apigateway:DeleteRestApi"]
+  update: ["apigateway:UpdateRestApi"]

--- a/pkg/templates/aws/resources/route_table.yaml
+++ b/pkg/templates/aws/resources/route_table.yaml
@@ -33,3 +33,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateRouteTable"]
+  tear_down: ["ec2:DeleteRouteTable"]
+  update: ["ec2:ReplaceRouteTableAssociation"]

--- a/pkg/templates/aws/resources/route_table_association.yaml
+++ b/pkg/templates/aws/resources/route_table_association.yaml
@@ -10,3 +10,9 @@ properties:
     type: resource(aws:subnet)
     default_value: '{{ upstream "aws:subnet" .Self }}'
     description: The Subnet to which the Route Table will be associated
+
+
+deployment_permissions:
+  deploy: ["ec2:AssociateRouteTable"]
+  tear_down: ["ec2:DisassociateRouteTable"]
+  update: ["ec2:ReplaceRouteTableAssociation"]

--- a/pkg/templates/aws/resources/s3_bucket.yaml
+++ b/pkg/templates/aws/resources/s3_bucket.yaml
@@ -69,3 +69,8 @@ delete_context:
 
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["s3:CreateBucket"]
+  tear_down: ["s3:DeleteBucket"]
+  update: ["s3:PutBucketAcl"]

--- a/pkg/templates/aws/resources/s3_bucket_policy.yaml
+++ b/pkg/templates/aws/resources/s3_bucket_policy.yaml
@@ -49,3 +49,8 @@ delete_context:
 
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["s3:PutBucketPolicy"]
+  tear_down: ["s3:DeleteBucketPolicy"]
+  update: ["s3:PutBucketPolicy"]

--- a/pkg/templates/aws/resources/s3_object.yaml
+++ b/pkg/templates/aws/resources/s3_object.yaml
@@ -21,3 +21,8 @@ delete_context:
 
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["s3:PutObject"]
+  tear_down: ["s3:DeleteObject"]
+  update: ["s3:PutObject"]

--- a/pkg/templates/aws/resources/secret.yaml
+++ b/pkg/templates/aws/resources/secret.yaml
@@ -33,3 +33,9 @@ delete_context:
 
 views:
   dataflow: big
+
+
+deployment_permissions:
+  deploy: ["secretsmanager:CreateSecret"]
+  tear_down: ["secretsmanager:DeleteSecret"]
+  update: ["secretsmanager:UpdateSecret"]

--- a/pkg/templates/aws/resources/secret_version.yaml
+++ b/pkg/templates/aws/resources/secret_version.yaml
@@ -21,3 +21,9 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+
+deployment_permissions:
+  deploy: ["secretsmanager:PutSecretValue"]
+  tear_down: ["secretsmanager:DeleteSecret"]
+  update: ["secretsmanager:PutSecretValue"]

--- a/pkg/templates/aws/resources/security_group.yaml
+++ b/pkg/templates/aws/resources/security_group.yaml
@@ -69,3 +69,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateSecurityGroup"]
+  tear_down: ["ec2:DeleteSecurityGroup"]
+  update: ["ec2:ModifySecurityGroupRules"]

--- a/pkg/templates/aws/resources/security_group_rule.yaml
+++ b/pkg/templates/aws/resources/security_group_rule.yaml
@@ -28,3 +28,9 @@ properties:
     type: string
     description: Specifies the rule type, either 'ingress' or 'egress', defining the
       traffic direction
+
+
+deployment_permissions:
+  deploy: ["ec2:AuthorizeSecurityGroupIngress", "ec2:AuthorizeSecurityGroupEgress"]
+  tear_down: ["ec2:RevokeSecurityGroupIngress", "ec2:RevokeSecurityGroupEgress"]
+  update: ["ec2:AuthorizeSecurityGroupIngress", "ec2:AuthorizeSecurityGroupEgress", "ec2:RevokeSecurityGroupIngress", "ec2:RevokeSecurityGroupEgress"]

--- a/pkg/templates/aws/resources/service_discovery_service.yaml
+++ b/pkg/templates/aws/resources/service_discovery_service.yaml
@@ -59,3 +59,7 @@ classification:
   is:
     - service_discovery
 
+deployment_permissions:
+  deploy: ["servicediscovery:CreateService"]
+  tear_down: ["servicediscovery:DeleteService"]
+  update: ["servicediscovery:UpdateService"]

--- a/pkg/templates/aws/resources/ses_email_identity.yaml
+++ b/pkg/templates/aws/resources/ses_email_identity.yaml
@@ -25,3 +25,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["ses:VerifyEmailIdentity"]
+  tear_down: ["ses:DeleteIdentity"]
+  update: ["ses:VerifyEmailIdentity"]

--- a/pkg/templates/aws/resources/sqs_queue.yaml
+++ b/pkg/templates/aws/resources/sqs_queue.yaml
@@ -39,3 +39,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: big
+
+deployment_permissions:
+  deploy: ["sqs:CreateQueue"]
+  tear_down: ["sqs:DeleteQueue"]
+  update: ["sqs:SetQueueAttributes"]

--- a/pkg/templates/aws/resources/subnet.yaml
+++ b/pkg/templates/aws/resources/subnet.yaml
@@ -70,3 +70,8 @@ classification:
 
 delete_context:
   requires_no_upstream: true
+
+deployment_permissions:
+  deploy: ["ec2:CreateSubnet"]
+  tear_down: ["ec2:DeleteSubnet"]
+  update: ["ec2:ModifySubnetAttribute"]

--- a/pkg/templates/aws/resources/target_group.yaml
+++ b/pkg/templates/aws/resources/target_group.yaml
@@ -101,3 +101,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["elasticloadbalancing:CreateTargetGroup"]
+  tear_down: ["elasticloadbalancing:DeleteTargetGroup"]
+  update: ["elasticloadbalancing:ModifyTargetGroup"]

--- a/pkg/templates/aws/resources/vpc.yaml
+++ b/pkg/templates/aws/resources/vpc.yaml
@@ -38,3 +38,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: parent
+
+deployment_permissions:
+  deploy: ["ec2:CreateVpc"]
+  tear_down: ["ec2:DeleteVpc"]
+  update: ["ec2:ModifyVpcAttribute"]

--- a/pkg/templates/aws/resources/vpc_endpoint.yaml
+++ b/pkg/templates/aws/resources/vpc_endpoint.yaml
@@ -47,3 +47,8 @@ delete_context:
   requires_no_upstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["ec2:CreateVpcEndpoint"]
+  tear_down: ["ec2:DeleteVpcEndpoints"]
+  update: ["ec2:ModifyVpcEndpoint"]

--- a/pkg/templates/aws/resources/vpc_link.yaml
+++ b/pkg/templates/aws/resources/vpc_link.yaml
@@ -9,3 +9,8 @@ delete_context:
   requires_no_upstream_or_downstream: true
 views:
   dataflow: small
+
+deployment_permissions:
+  deploy: ["apigateway:CreateVpcLink"]
+  tear_down: ["apigateway:DeleteVpcLink"]
+  update: ["apigateway:UpdateVpcLink"]


### PR DESCRIPTION
Ability to produce a basic deployment policy for the architecture

- Because we dont have arns we cannot limit the resource field, but as we add tags to resources we can add conditional based rules to all of our policies and start to narrow down more

added test cases to the functional tests

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
