### PR TITLE
 ensure set properties are loaded into eval as expected

### DIFF
--- a/pkg/construct/properties.go
+++ b/pkg/construct/properties.go
@@ -210,9 +210,13 @@ func (r *Resource) PropertyPath(pathStr string) (PropertyPath, error) {
 				value = value.Elem()
 			}
 			if value.IsValid() && value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
-				return nil, &PropertyPathError{
-					Path:  pathParts[:i-1],
-					Cause: fmt.Errorf("expected array, got %s", value.Type()),
+				if hs, ok := value.Interface().(set.HashedSet[string, any]); ok {
+					value = reflect.ValueOf(hs.ToSlice())
+				} else {
+					return nil, &PropertyPathError{
+						Path:  pathParts[:i-1],
+						Cause: fmt.Errorf("expected array, got %s", value.Type()),
+					}
 				}
 			}
 			if !value.IsValid() || value.IsZero() {

--- a/pkg/knowledgebase/resource_template.go
+++ b/pkg/knowledgebase/resource_template.go
@@ -403,11 +403,11 @@ func (tmpl ResourceTemplate) LoopProperties(res *construct.Resource, addProp fun
 						errs = errors.Join(errs, fmt.Errorf("could not cast property to set"))
 						continue
 					}
-					for k := range hs.ToMap() {
+					for i := range hs.ToSlice() {
 						subProperties := make(Properties)
 						for subK, subProp := range prop.SubProperties() {
 							propTemplate := subProp.Clone()
-							ReplacePath(propTemplate, prop.Details().Path, fmt.Sprintf("%s[%s]", prop.Details().Path, k))
+							ReplacePath(propTemplate, prop.Details().Path, fmt.Sprintf("%s[%d]", prop.Details().Path, i))
 							subProperties[subK] = propTemplate
 						}
 						if len(subProperties) > 0 {


### PR DESCRIPTION
fixes #929 

load sets in properly so that we can reference them as lists without it being incorrect

This affects resource constraints which attempt to set properties nested within sets

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
