### PR TITLE
Global tags

### DIFF
--- a/pkg/engine/cli.go
+++ b/pkg/engine/cli.go
@@ -52,6 +52,7 @@ var architectureEngineCfg struct {
 	inputGraph  string
 	constraints string
 	outputDir   string
+	globalTag   string
 }
 
 var getValidEdgeTargetsCfg struct {
@@ -122,6 +123,7 @@ func (em *EngineMain) AddEngineCli(root *cobra.Command) {
 	flags.StringVarP(&architectureEngineCfg.inputGraph, "input-graph", "i", "", "Input graph file")
 	flags.StringVarP(&architectureEngineCfg.constraints, "constraints", "c", "", "Constraints file")
 	flags.StringVarP(&architectureEngineCfg.outputDir, "output-dir", "o", "", "Output directory")
+	flags.StringVarP(&architectureEngineCfg.globalTag, "global-tag", "t", "", "Global tag")
 	flags.StringVar(&engineCfg.profileTo, "profiling", "", "Profile to file")
 
 	getPossibleEdgesCmd := &cobra.Command{
@@ -366,7 +368,9 @@ func (em *EngineMain) RunEngine(cmd *cobra.Command, args []string) (exitCode int
 		return
 	}
 
-	context := &EngineContext{}
+	context := &EngineContext{
+		GlobalTag: architectureEngineCfg.globalTag,
+	}
 
 	if architectureEngineCfg.inputGraph != "" {
 		var input FileFormat

--- a/pkg/engine/edge_targets.go
+++ b/pkg/engine/edge_targets.go
@@ -159,7 +159,7 @@ func (e *Engine) GetValidEdgeTargets(context *GetPossibleEdgesContext) (map[stri
 	if err != nil {
 		return nil, err
 	}
-	solutionCtx := NewSolutionContext(e.Kb)
+	solutionCtx := NewSolutionContext(e.Kb, "")
 	err = solutionCtx.LoadGraph(inputGraph)
 	if err != nil {
 		return nil, err

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,6 +19,7 @@ type (
 		Constraints  constraints.Constraints
 		InitialState construct.Graph
 		Solutions    []solution_context.SolutionContext
+		GlobalTag    string
 	}
 )
 
@@ -29,7 +30,7 @@ func NewEngine(kb knowledgebase.TemplateKB) *Engine {
 }
 
 func (e *Engine) Run(context *EngineContext) error {
-	solutionCtx := NewSolutionContext(e.Kb)
+	solutionCtx := NewSolutionContext(e.Kb, context.GlobalTag)
 	solutionCtx.constraints = &context.Constraints
 	err := solutionCtx.LoadGraph(context.InitialState)
 	if err != nil {

--- a/pkg/engine/enginetesting/mock_solution.go
+++ b/pkg/engine/enginetesting/mock_solution.go
@@ -55,3 +55,8 @@ func (m *MockSolution) RawView() construct.Graph {
 	args := m.Called()
 	return args.Get(0).(construct.Graph)
 }
+
+func (m *MockSolution) GlobalTag() string {
+	args := m.Called()
+	return args.String(0)
+}

--- a/pkg/engine/enginetesting/test_solution.go
+++ b/pkg/engine/enginetesting/test_solution.go
@@ -78,6 +78,10 @@ func (sol *TestSolution) RawView() construct.Graph {
 	return solution_context.NewRawView(sol)
 }
 
+func (sol *TestSolution) GlobalTag() string {
+	return "test"
+}
+
 type testOperationalView struct {
 	construct.Graph
 	Mock *mock.Mock

--- a/pkg/engine/operational_eval/vertex_property.go
+++ b/pkg/engine/operational_eval/vertex_property.go
@@ -106,7 +106,7 @@ func (v *propertyVertex) Evaluate(eval *Evaluator) error {
 		return fmt.Errorf("could not get property path for %s: %w", v.Ref, err)
 	}
 
-	dynData := knowledgebase.DynamicValueData{Resource: res.ID, Path: path}
+	dynData := knowledgebase.DynamicValueData{Resource: res.ID, Path: path, GlobalTag: eval.Solution.GlobalTag()}
 
 	if err := v.evaluateConstraints(
 		&solution_context.Configurer{Ctx: sol},

--- a/pkg/engine/solution_context.go
+++ b/pkg/engine/solution_context.go
@@ -24,10 +24,11 @@ type (
 		mappedResources map[construct.ResourceId]construct.ResourceId
 		constraints     *constraints.Constraints
 		propertyEval    *property_eval.Evaluator
+		globalTag       string
 	}
 )
 
-func NewSolutionContext(kb knowledgebase.TemplateKB) *solutionContext {
+func NewSolutionContext(kb knowledgebase.TemplateKB, globalTag string) *solutionContext {
 	ctx := &solutionContext{
 		KB: kb,
 		Dataflow: graph_addons.LoggingGraph[construct.ResourceId, *construct.Resource]{
@@ -38,6 +39,7 @@ func NewSolutionContext(kb knowledgebase.TemplateKB) *solutionContext {
 		Deployment:      construct.NewAcyclicGraph(),
 		decisions:       &solution_context.MemoryRecord{},
 		mappedResources: make(map[construct.ResourceId]construct.ResourceId),
+		globalTag:       globalTag,
 	}
 	ctx.propertyEval = property_eval.NewEvaluator(ctx)
 	return ctx
@@ -143,4 +145,8 @@ func (ctx solutionContext) ExpandConstruct(resource *construct.Resource) ([]solu
 func (ctx solutionContext) GenerateCombinations() ([]solutionContext, error) {
 	// TODO constructs not yet supported
 	return []solutionContext{ctx}, nil
+}
+
+func (ctx solutionContext) GlobalTag() string {
+	return ctx.globalTag
 }

--- a/pkg/engine/solution_context/interface.go
+++ b/pkg/engine/solution_context/interface.go
@@ -29,6 +29,9 @@ type (
 		// Read operations come from the Dataflow graph.
 		// Write operations will update both the Dataflow and Deployment graphs.
 		RawView() construct.Graph
+
+		// GlobalTag returns the global tag for the solution context
+		GlobalTag() string
 	}
 
 	OperationalView interface {

--- a/pkg/engine/testdata/2_routes.expect.yaml
+++ b/pkg/engine/testdata/2_routes.expect.yaml
@@ -3,6 +3,9 @@ resources:
         Deployment: aws:api_deployment:rest_api_1:api_deployment-0
         RestApi: aws:rest_api:rest_api_1
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:api_deployment:rest_api_1:api_deployment-0:
         RestApi: aws:rest_api:rest_api_1
         Triggers:
@@ -14,6 +17,9 @@ resources:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_1
     aws:api_resource:rest_api_1:lambda0:
         FullPath: /lambda0
         PathPart: lambda0
@@ -79,12 +85,18 @@ resources:
         Image: aws:ecr_image:lambda_function_0-image
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0
         Timeout: 180
     aws:lambda_function:lambda_function_1:
         ExecutionRole: aws:iam_role:lambda_function_1-ExecutionRole
         Image: aws:ecr_image:lambda_function_1-image
         LogGroup: aws:log_group:lambda_function_1-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_1
         Timeout: 180
     aws:ecr_image:lambda_function_0-image:
         Context: .
@@ -102,6 +114,9 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
     aws:ecr_image:lambda_function_1-image:
         Context: .
@@ -119,16 +134,31 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_1-ExecutionRole
     aws:ecr_repo:lambda_function_0-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-image-ecr_repo
     aws:log_group:lambda_function_0-log-group:
         LogGroupName: /aws/lambda/lambda_function_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-log-group
     aws:ecr_repo:lambda_function_1-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_1-image-ecr_repo
     aws:log_group:lambda_function_1-log-group:
         LogGroupName: /aws/lambda/lambda_function_1
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_1-log-group
 edges:
     aws:api_stage:rest_api_1:api_stage-0 -> aws:api_deployment:rest_api_1:api_deployment-0:
     aws:api_stage:rest_api_1:api_stage-0 -> aws:rest_api:rest_api_1:

--- a/pkg/engine/testdata/cf_distribution.expect.yaml
+++ b/pkg/engine/testdata/cf_distribution.expect.yaml
@@ -43,12 +43,18 @@ resources:
         Restrictions:
             GeoRestriction:
                 RestrictionType: none
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: cloudfront_distribution_2
         ViewerCertificate:
             CloudfrontDefaultCertificate: true
     aws:api_stage:rest_api_1:cloudfront_distribution_2-rest_api_1:
         Deployment: aws:api_deployment:rest_api_1:api_deployment-0
         RestApi: aws:rest_api:rest_api_1
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: cloudfront_distribution_2-rest_api_1
     aws:cloudfront_origin_access_identity:cloudfront_origin_access_identity-0:
         Comment: this is needed to set up S3 polices so that the S3 bucket is not public
     aws:api_deployment:rest_api_1:api_deployment-0:
@@ -70,9 +76,15 @@ resources:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_1
     aws:s3_bucket:s3-bucket-3:
         ForceDestroy: true
         SSEAlgorithm: AES256
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: s3-bucket-3
 edges:
     aws:cloudfront_distribution:cloudfront_distribution_2 -> aws:api_stage:rest_api_1:cloudfront_distribution_2-rest_api_1:
     ? aws:cloudfront_distribution:cloudfront_distribution_2 -> aws:cloudfront_origin_access_identity:cloudfront_origin_access_identity-0

--- a/pkg/engine/testdata/delete_api_to_lambda_edge.expect.yaml
+++ b/pkg/engine/testdata/delete_api_to_lambda_edge.expect.yaml
@@ -3,11 +3,17 @@ resources:
         Deployment: aws:api_deployment:rest_api_0:api_deployment-0
         RestApi: aws:rest_api:rest_api_0
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:lambda_function:lambda_function_2:
         ExecutionRole: aws:iam_role:lambda_function_2-ExecutionRole
         Image: aws:ecr_image:lambda_function_2-image
         LogGroup: aws:log_group:lambda_function_2-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2
         Timeout: 180
     aws:api_deployment:rest_api_0:api_deployment-0:
         RestApi: aws:rest_api:rest_api_0
@@ -31,15 +37,27 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-ExecutionRole
     aws:rest_api:rest_api_0:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_0
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:log_group:lambda_function_2-log-group:
         LogGroupName: /aws/lambda/lambda_function_2
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-log-group
     aws:api_resource:rest_api_0:api_resource-0:
         FullPath: /{proxy+}
         PathPart: '{proxy+}'

--- a/pkg/engine/testdata/delete_namespace_resource.expect.yaml
+++ b/pkg/engine/testdata/delete_namespace_resource.expect.yaml
@@ -4,6 +4,9 @@ resources:
         Image: aws:ecr_image:lambda_function_2-image
         LogGroup: aws:log_group:lambda_function_2-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2
         Timeout: 180
     aws:SERVICE_API:lambda_function_2-lambda_function_2-log-group:
     aws:ecr_image:lambda_function_2-image:
@@ -22,11 +25,20 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-ExecutionRole
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:log_group:lambda_function_2-log-group:
         LogGroupName: /aws/lambda/lambda_function_2
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-log-group
 edges:
     aws:lambda_function:lambda_function_2 -> aws:SERVICE_API:lambda_function_2-lambda_function_2-log-group:
     aws:lambda_function:lambda_function_2 -> aws:ecr_image:lambda_function_2-image:

--- a/pkg/engine/testdata/delete_resource_and_iacdeps.expect.yaml
+++ b/pkg/engine/testdata/delete_resource_and_iacdeps.expect.yaml
@@ -3,7 +3,13 @@ resources:
         Deployment: aws:api_deployment:rest_api_0:api_deployment-0
         RestApi: aws:rest_api:rest_api_0
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:ecs_cluster:ecs_cluster-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_cluster-0
     aws:api_deployment:rest_api_0:api_deployment-0:
         RestApi: aws:rest_api:rest_api_0
         Triggers:
@@ -15,6 +21,9 @@ resources:
             - image/*
         Stages:
             - aws:api_stage:rest_api_0:api_stage-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_0
     aws:api_resource:rest_api_0:api_resource-0:
         FullPath: /{proxy+}
         PathPart: '{proxy+}'

--- a/pkg/engine/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine/testdata/ecs_rds.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-security_group
         Vpc: aws:vpc:vpc-0
     aws:ecs_service:ecs_service_0:
         AssignPublicIp: false
@@ -25,8 +28,14 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0
         TaskDefinition: aws:ecs_task_definition:ecs_service_0
     aws:ecs_cluster:ecs_cluster-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_cluster-0
     aws:ecs_task_definition:ecs_service_0:
         ContainerDefinitions:
             - Cpu: 256
@@ -59,6 +68,9 @@ resources:
         NetworkMode: awsvpc
         RequiresCompatibilities:
             - FARGATE
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0
         TaskRole: aws:iam_role:ecs_service_0-execution-role
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
@@ -86,21 +98,42 @@ resources:
                 Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-execution-role
     aws:log_group:ecs_service_0-log-group:
         LogGroupName: /aws/ecs/ecs_service_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-log-group
     aws:ecr_repo:ecs_service_0-ecs_service_0-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-ecs_service_0-ecr_repo
     aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway-elastic_ip
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-2-subnet-2-route_table:
@@ -110,20 +143,32 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-0:
         Index: 0
         Region: aws:region:region-0
     aws:internet_gateway:vpc-0:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-3-subnet-3-route_table:
@@ -133,6 +178,9 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-1:
         Index: 1
@@ -149,15 +197,24 @@ resources:
             - aws:security_group:vpc-0:rds-instance-2-security_group
         SkipFinalSnapshot: true
         SubnetGroup: aws:rds_subnet_group:rds_subnet_group-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-2
     aws:rds_subnet_group:rds_subnet_group-0:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds_subnet_group-0
     aws:subnet:vpc-0:subnet-0:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-0-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:subnet:vpc-0:subnet-1:
@@ -165,6 +222,9 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-0-subnet-0-route_table:
@@ -199,21 +259,33 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-2-security_group
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-0-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc-0
     aws:vpc:vpc-0:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-0
 edges:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:ecs_service:ecs_service_0:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:vpc:vpc-0:

--- a/pkg/engine/testdata/extend_graph.expect.yaml
+++ b/pkg/engine/testdata/extend_graph.expect.yaml
@@ -3,12 +3,18 @@ resources:
         Deployment: aws:api_deployment:rest_api_1:api_deployment-0
         RestApi: aws:rest_api:rest_api_1
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:dynamodb_table:dynamodb_table_3:
         Attributes:
             - Name: id
               Type: S
         BillingMode: PAY_PER_REQUEST
         HashKey: id
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: dynamodb_table_3
     aws:api_deployment:rest_api_1:api_deployment-0:
         RestApi: aws:rest_api:rest_api_1
         Triggers:
@@ -20,6 +26,9 @@ resources:
             - image/*
         Stages:
             - aws:api_stage:rest_api_1:api_stage-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_1
     aws:api_resource:rest_api_1:api_resource-0:
         FullPath: /{proxy+}
         PathPart: '{proxy+}'
@@ -52,6 +61,9 @@ resources:
         Image: aws:ecr_image:lambda_function_0-image
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0
         Timeout: 180
     aws:SERVICE_API:lambda_function_0_lambda_function_0-log-group:
     aws:ecr_image:lambda_function_0-image:
@@ -70,11 +82,20 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:log_group:lambda_function_0-log-group:
         LogGroupName: /aws/lambda/lambda_function_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-log-group
 edges:
     aws:api_stage:rest_api_1:api_stage-0 -> aws:api_deployment:rest_api_1:api_deployment-0:
     aws:api_stage:rest_api_1:api_stage-0 -> aws:rest_api:rest_api_1:

--- a/pkg/engine/testdata/idempotent_constraints.expect.yaml
+++ b/pkg/engine/testdata/idempotent_constraints.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-security_group
         Vpc: aws:vpc:vpc-0
     aws:ecs_service:ecs_service_0:
         AssignPublicIp: false
@@ -25,8 +28,14 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0
         TaskDefinition: aws:ecs_task_definition:ecs_service_0
     aws:ecs_cluster:ecs_cluster-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_cluster-0
     aws:ecs_task_definition:ecs_service_0:
         ContainerDefinitions:
             - Cpu: 256
@@ -59,6 +68,9 @@ resources:
         NetworkMode: awsvpc
         RequiresCompatibilities:
             - FARGATE
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0
         TaskRole: aws:iam_role:ecs_service_0-execution-role
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
@@ -86,21 +98,42 @@ resources:
                 Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-execution-role
     aws:log_group:ecs_service_0-log-group:
         LogGroupName: /aws/ecs/ecs_service_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-log-group
     aws:ecr_repo:ecs_service_0-ecs_service_0-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-ecs_service_0-ecr_repo
     aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway-elastic_ip
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-2-subnet-2-route_table:
@@ -110,20 +143,32 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-0:
         Index: 0
         Region: aws:region:region-0
     aws:internet_gateway:vpc-0:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-3-subnet-3-route_table:
@@ -133,6 +178,9 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-1:
         Index: 1
@@ -149,15 +197,24 @@ resources:
             - aws:security_group:vpc-0:rds-instance-2-security_group
         SkipFinalSnapshot: true
         SubnetGroup: aws:rds_subnet_group:rds_subnet_group-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-2
     aws:rds_subnet_group:rds_subnet_group-0:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds_subnet_group-0
     aws:subnet:vpc-0:subnet-0:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-0-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:subnet:vpc-0:subnet-1:
@@ -165,6 +222,9 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-0-subnet-0-route_table:
@@ -199,21 +259,33 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-2-security_group
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-0-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc-0
     aws:vpc:vpc-0:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-0
 edges:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:ecs_service:ecs_service_0:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:vpc:vpc-0:

--- a/pkg/engine/testdata/k8s_api.expect.yaml
+++ b/pkg/engine/testdata/k8s_api.expect.yaml
@@ -3,13 +3,22 @@ resources:
         Deployment: aws:api_deployment:rest_api_4:api_deployment-0
         RestApi: aws:rest_api:rest_api_4
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:eks_add_on:amazon-cloudwatch-observability:
         AddOnName: amazon-cloudwatch-observability
         Cluster: aws:eks_cluster:eks_cluster-0
         Role: aws:iam_role:amazon-cloudwatch-observability-iam_role
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: amazon-cloudwatch-observability
     aws:eks_add_on:vpc-cni:
         AddOnName: vpc-cni
         Cluster: aws:eks_cluster:eks_cluster-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-cni
     aws:security_group_rule:security_group_rule-0:
         CidrBlocks:
             - 10.0.0.0/16
@@ -69,10 +78,16 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
             - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: amazon-cloudwatch-observability-iam_role
     aws:rest_api:rest_api_4:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_4
     aws:api_resource:rest_api_4:api_resource-0:
         FullPath: /{proxy+}
         PathPart: '{proxy+}'
@@ -98,12 +113,18 @@ resources:
         Uri: aws:api_integration:rest_api_4:rest_api_4_integration_0#LbUri
         VpcLink: aws:vpc_link:rest_api_4_integration_0-pod2
     aws:vpc_link:rest_api_4_integration_0-pod2:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_4_integration_0-pod2
         Target: aws:load_balancer:rest-api-4-integbcc77100
     aws:load_balancer:rest-api-4-integbcc77100:
         Scheme: internal
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest-api-4-integbcc77100
         Type: network
     aws:load_balancer_listener:rest-api-4-integbcc77100:rest_api_4_integration_0-pod2:
         DefaultActions:
@@ -112,6 +133,9 @@ resources:
         LoadBalancer: aws:load_balancer:rest-api-4-integbcc77100
         Port: 80
         Protocol: TCP
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_4_integration_0-pod2
     aws:target_group:rest-api-4-integbcc77100:
         HealthCheck:
             Enabled: true
@@ -122,6 +146,9 @@ resources:
             UnhealthyThreshold: 2
         Port: 80
         Protocol: TCP
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest-api-4-integbcc77100
         TargetType: ip
         Vpc: aws:vpc:vpc-0
     kubernetes:target_group_binding:eks_cluster-0:restapi4integration0-pod2:
@@ -220,6 +247,9 @@ resources:
                     Federated:
                         - aws:iam_oidc_provider:eks_cluster-0#Arn
             Version: "2012-10-17"
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: aws-load-balancer-controller
     aws:ecr_image:pod2-ecr_image:
         Context: .
         Dockerfile: pod2-ecr_image.Dockerfile
@@ -238,6 +268,9 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: eks_node_group-0
     kubernetes:service_account:eks_cluster-0:pod2:
         Cluster: aws:eks_cluster:eks_cluster-0
         Object:
@@ -256,6 +289,9 @@ resources:
         Role: aws:iam_role:aws-load-balancer-controller
     aws:ecr_repo:pod2-ecr_image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: pod2-ecr_image-ecr_repo
     aws:iam_role:eks_node_group-0-iam_role:
         AssumeRolePolicyDoc:
             Statement:
@@ -273,6 +309,9 @@ resources:
             - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
             - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
             - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: eks_node_group-0-iam_role
     aws:iam_role:pod2:
         AssumeRolePolicyDoc:
             Statement:
@@ -283,6 +322,9 @@ resources:
                     Federated:
                         - aws:iam_oidc_provider:eks_cluster-0#Arn
             Version: "2012-10-17"
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: pod2
     aws:iam_policy:iam_policy-0:
         Policy:
             Statement:
@@ -429,11 +471,17 @@ resources:
                   Resource:
                     - '*'
             Version: "2012-10-17"
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: iam_policy-0
     aws:iam_oidc_provider:eks_cluster-0:
         ClientIdLists:
             - sts.amazonaws.com
         Cluster: aws:eks_cluster:eks_cluster-0
         Region: aws:region:region-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: eks_cluster-0
     aws:eks_cluster:eks_cluster-0:
         ClusterRole: aws:iam_role:ClusterRole-eks_cluster-0
         SecurityGroups:
@@ -441,6 +489,9 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: eks_cluster-0
         Version: "1.28"
         Vpc: aws:vpc:vpc-0
     aws:iam_role:ClusterRole-eks_cluster-0:
@@ -455,11 +506,17 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ClusterRole-eks_cluster-0
     aws:subnet:vpc-0:subnet-0:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-0-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:subnet:vpc-0:subnet-1:
@@ -467,6 +524,9 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-0-subnet-0-route_table:
@@ -507,37 +567,64 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: eks_cluster-0-security_group
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-0-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc-0:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc-0:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-0:
@@ -556,19 +643,31 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc-0
     aws:region:region-0:
     aws:route_table:vpc-0:subnet-3-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc-0
     aws:internet_gateway:vpc-0:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc-0
     aws:vpc:vpc-0:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-0
 edges:
     aws:api_stage:rest_api_4:api_stage-0 -> aws:api_deployment:rest_api_4:api_deployment-0:
     aws:api_stage:rest_api_4:api_stage-0 -> aws:rest_api:rest_api_4:

--- a/pkg/engine/testdata/lambda_efs.expect.yaml
+++ b/pkg/engine/testdata/lambda_efs.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-security_group
         Vpc: aws:vpc:vpc-0
     aws:lambda_function:lambda_test_app:
         EfsAccessPoint: aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs
@@ -25,6 +28,9 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:lambda_test_app-test-efs-fs
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app
         Timeout: 180
     aws:ecr_image:lambda_test_app-image:
         Context: .
@@ -41,6 +47,9 @@ resources:
                 OwnerUid: 1000
                 Permissions: "777"
             Path: /mnt/efs
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs
     aws:iam_role:lambda_test_app-ExecutionRole:
         AssumeRolePolicyDoc:
             Statement:
@@ -64,8 +73,14 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-ExecutionRole
     aws:ecr_repo:lambda_test_app-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-image-ecr_repo
     aws:efs_mount_target:test-efs-fs:lambda_test_app-test-efs-fs:
         FileSystem: aws:efs_file_system:test-efs-fs
         SecurityGroups:
@@ -76,6 +91,9 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:lambda_test_app-test-efs-fs-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:lambda_test_app-test-efs-fs-lambda_test_app-test-efs-fs-route_table:
@@ -85,16 +103,28 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs-route_table
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-2:lambda_test_app-test-efs-fs-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs-route_table-nat_gateway
     aws:elastic_ip:lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc-0:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-2-subnet-2-route_table:
@@ -104,11 +134,17 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc-0
     aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
     aws:log_group:lambda_test_app-log-group:
         LogGroupName: /aws/lambda/lambda_test_app
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-log-group
     aws:availability_zone:region-0:availability_zone-1:
         Index: 1
         Region: aws:region:region-0
@@ -116,6 +152,9 @@ resources:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         Encrypted: true
         PerformanceMode: generalPurpose
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: test-efs-fs
         ThroughputMode: bursting
     aws:availability_zone:region-0:availability_zone-0:
         Index: 0
@@ -131,6 +170,9 @@ resources:
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-1-subnet-1-route_table:
@@ -162,6 +204,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-test-efs-fs
         Vpc: aws:vpc:vpc-0
     aws:security_group:vpc-0:subnet-1-test-efs-fs:
         EgressRules:
@@ -183,21 +228,36 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-test-efs-fs
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc-0:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-3-subnet-3-route_table:
@@ -207,13 +267,22 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc-0
     aws:internet_gateway:vpc-0:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc-0
     aws:vpc:vpc-0:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-0
 edges:
     aws:security_group:vpc-0:lambda_test_app-security_group -> aws:lambda_function:lambda_test_app:
     aws:security_group:vpc-0:lambda_test_app-security_group -> aws:vpc:vpc-0:

--- a/pkg/engine/testdata/namespace_pathselect.expect.yaml
+++ b/pkg/engine/testdata/namespace_pathselect.expect.yaml
@@ -4,6 +4,9 @@ resources:
         Image: aws:ecr_image:lambda_function_0-image
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0
         Timeout: 180
     aws:security_group:vpc_1:lambda_function_2-security_group:
         EgressRules:
@@ -19,6 +22,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-security_group
         Vpc: aws:vpc:vpc_1
     aws:ecr_image:lambda_function_0-image:
         Context: .
@@ -36,6 +42,9 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:lambda_function:lambda_function_2:
         ExecutionRole: aws:iam_role:lambda_function_2-ExecutionRole
         Image: aws:ecr_image:lambda_function_2-image
@@ -46,9 +55,15 @@ resources:
         Subnets:
             - aws:subnet:vpc_1:lambda_function_2-vpc_1
             - aws:subnet:vpc_1:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2
         Timeout: 180
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:ecr_image:lambda_function_2-image:
         Context: .
         Dockerfile: lambda_function_2-image.Dockerfile
@@ -66,11 +81,17 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-ExecutionRole
     aws:subnet:vpc_1:lambda_function_2-vpc_1:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc_1:lambda_function_2-vpc_1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-vpc_1
         Type: private
         Vpc: aws:vpc:vpc_1
     aws:subnet:vpc_1:subnet-1:
@@ -78,10 +99,16 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc_1:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc_1
     aws:ecr_repo:lambda_function_2-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-image-ecr_repo
     aws:route_table_association:lambda_function_2-vpc_1-lambda_function_2-vpc_1-route_table:
         RouteTable: aws:route_table:vpc_1:lambda_function_2-vpc_1-route_table
         Subnet: aws:subnet:vpc_1:lambda_function_2-vpc_1
@@ -93,38 +120,68 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:lambda_function_2-vpc_1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-vpc_1-route_table
         Vpc: aws:vpc:vpc_1
     aws:log_group:lambda_function_0-log-group:
         LogGroupName: /aws/lambda/lambda_function_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-log-group
     aws:log_group:lambda_function_2-log-group:
         LogGroupName: /aws/lambda/lambda_function_2
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-log-group
     aws:route_table:vpc_1:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc_1
     aws:nat_gateway:subnet-2:lambda_function_2-vpc_1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:lambda_function_2-vpc_1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc_1:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-vpc_1-route_table-nat_gateway
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc_1:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:elastic_ip:lambda_function_2-vpc_1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_2-vpc_1-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc_1:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc_1:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc_1
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc_1:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc_1:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc_1
     aws:availability_zone:region-0:availability_zone-0:
@@ -143,19 +200,31 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc_1:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc_1
     aws:region:region-0:
     aws:route_table:vpc_1:subnet-3-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc_1:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc_1
     aws:internet_gateway:vpc_1:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc_1
     aws:vpc:vpc_1:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc_1
 edges:
     aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
     aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:

--- a/pkg/engine/testdata/remove_path.expect.yaml
+++ b/pkg/engine/testdata/remove_path.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-security_group
         Vpc: aws:vpc:vpc-0
     aws:security_group:vpc-0:lambda_function_3-security_group:
         EgressRules:
@@ -28,6 +31,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_3-security_group
         Vpc: aws:vpc:vpc-0
     aws:lambda_function:lambda_function_0:
         EnvironmentVariables:
@@ -44,6 +50,9 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0
         Timeout: 180
     aws:lambda_function:lambda_function_3:
         EnvironmentVariables:
@@ -60,6 +69,9 @@ resources:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_3
         Timeout: 180
     aws:ecr_image:lambda_function_0-image:
         Context: .
@@ -88,6 +100,9 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:ecr_image:lambda_function_3-image:
         Context: .
         Dockerfile: lambda_function_3-image.Dockerfile
@@ -115,24 +130,48 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_3-ExecutionRole
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway-elastic_ip
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:log_group:lambda_function_0-log-group:
         LogGroupName: /aws/lambda/lambda_function_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-log-group
     aws:log_group:lambda_function_3-log-group:
         LogGroupName: /aws/lambda/lambda_function_3
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_3-log-group
     aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-0-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-2-subnet-2-route_table:
@@ -142,20 +181,32 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-0:
         Index: 0
         Region: aws:region:region-0
     aws:internet_gateway:vpc-0:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc-0
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc-0:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:subnet:vpc-0:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-3-subnet-3-route_table:
@@ -165,6 +216,9 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc-0:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc-0
     aws:availability_zone:region-0:availability_zone-1:
         Index: 1
@@ -181,15 +235,24 @@ resources:
             - aws:security_group:vpc-0:rds-instance-1-security_group
         SkipFinalSnapshot: true
         SubnetGroup: aws:rds_subnet_group:rds_subnet_group-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-1
     aws:rds_subnet_group:rds_subnet_group-0:
         Subnets:
             - aws:subnet:vpc-0:subnet-0
             - aws:subnet:vpc-0:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds_subnet_group-0
     aws:subnet:vpc-0:subnet-0:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-0-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:subnet:vpc-0:subnet-1:
@@ -197,6 +260,9 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc-0:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc-0
     aws:route_table_association:subnet-0-subnet-0-route_table:
@@ -232,21 +298,33 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rds-instance-1-security_group
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-0-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:subnet-0-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-0-route_table
         Vpc: aws:vpc:vpc-0
     aws:route_table:vpc-0:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc-0
     aws:vpc:vpc-0:
         CidrBlock: 10.0.0.0/16
         EnableDnsHostnames: true
         EnableDnsSupport: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: vpc-0
 edges:
     aws:security_group:vpc-0:lambda_function_0-security_group -> aws:lambda_function:lambda_function_0:
     aws:security_group:vpc-0:lambda_function_0-security_group -> aws:vpc:vpc-0:

--- a/pkg/engine/testdata/rename.expect.yaml
+++ b/pkg/engine/testdata/rename.expect.yaml
@@ -6,6 +6,9 @@ resources:
         Image: aws:ecr_image:lambda_test_app-image
         LogGroup: aws:log_group:lambda_test_app-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app
         Timeout: 180
     aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
     aws:ecr_image:lambda_test_app-image:
@@ -35,14 +38,26 @@ resources:
                 Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-ExecutionRole
     aws:ecr_repo:ecr_repo-0:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecr_repo-0
     aws:log_group:lambda_test_app-log-group:
         LogGroupName: /aws/lambda/lambda_test_app
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_test_app-log-group
     aws:s3_bucket:new-bucket:
         ForceDestroy: true
         SSEAlgorithm: aws:kms
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: new-bucket
 edges:
     aws:lambda_function:lambda_test_app -> aws:SERVICE_API:lambda_test_app-lambda_test_app-log-group:
     aws:lambda_function:lambda_test_app -> aws:ecr_image:lambda_test_app-image:

--- a/pkg/engine/testdata/same_path_multiple_methods.expect.yaml
+++ b/pkg/engine/testdata/same_path_multiple_methods.expect.yaml
@@ -3,6 +3,9 @@ resources:
         Deployment: aws:api_deployment:rest_api_0:api_deployment-0
         RestApi: aws:rest_api:rest_api_0
         StageName: stage
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: api_stage-0
     aws:api_deployment:rest_api_0:api_deployment-0:
         RestApi: aws:rest_api:rest_api_0
         Triggers:
@@ -16,6 +19,9 @@ resources:
         BinaryMediaTypes:
             - application/octet-stream
             - image/*
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: rest_api_0
     aws:api_resource:rest_api_0:api_resource-1:
         FullPath: /html
         PathPart: html

--- a/pkg/engine/testdata/single_lambda.expect.yaml
+++ b/pkg/engine/testdata/single_lambda.expect.yaml
@@ -4,6 +4,9 @@ resources:
         Image: aws:ecr_image:lambda_function_0-image
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0
         Timeout: 180
     aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
     aws:ecr_image:lambda_function_0-image:
@@ -22,11 +25,20 @@ resources:
             Version: "2012-10-17"
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:ecr_repo:lambda_function_0-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-image-ecr_repo
     aws:log_group:lambda_function_0-log-group:
         LogGroupName: /aws/lambda/lambda_function_0
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function_0-log-group
 edges:
     aws:lambda_function:lambda_function_0 -> aws:SERVICE_API:lambda_function_0-lambda_function_0-log-group:
     aws:lambda_function:lambda_function_0 -> aws:ecr_image:lambda_function_0-image:

--- a/pkg/engine/testdata/static_site.expect.yaml
+++ b/pkg/engine/testdata/static_site.expect.yaml
@@ -30,6 +30,9 @@ resources:
         Restrictions:
             GeoRestriction:
                 RestrictionType: none
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: cloudfront_distribution_1
         ViewerCertificate:
             CloudfrontDefaultCertificate: true
     aws:cloudfront_origin_access_identity:cloudfront_origin_access_identity-0:
@@ -50,6 +53,9 @@ resources:
     aws:s3_bucket:s3-bucket-0:
         ForceDestroy: true
         SSEAlgorithm: AES256
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: s3-bucket-0
 edges:
     ? aws:cloudfront_distribution:cloudfront_distribution_1 -> aws:cloudfront_origin_access_identity:cloudfront_origin_access_identity-0
     :

--- a/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-security_group
         Vpc: aws:vpc:vpc
     aws:subnet:subnet3:
         Type: public
@@ -32,6 +35,9 @@ resources:
         Subnets:
             - aws:subnet:vpc:subnet1
             - aws:subnet:vpc:subnet2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function
         Timeout: 180
     aws:ecr_image:lambda_function-image:
         Context: .
@@ -50,6 +56,9 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-ExecutionRole
     aws:subnet:vpc:subnet1:
         Type: private
         Vpc: aws:vpc:vpc
@@ -60,12 +69,18 @@ resources:
         imported: true
     aws:ecr_repo:lambda_function-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-image-ecr_repo
     aws:SERVICE_API:lambda_function-lambda_function-log-group:
     aws:vpc:vpc:
         imported: true
     aws:log_group:lambda_function-log-group:
         LogGroupName: /aws/lambda/lambda_function
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-log-group
 edges:
     aws:security_group:vpc:lambda_function-security_group -> aws:lambda_function:lambda_function:
     aws:security_group:vpc:lambda_function-security_group -> aws:vpc:vpc:

--- a/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
@@ -13,6 +13,9 @@ resources:
               Protocol: "-1"
               Self: true
               ToPort: 0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-security_group
         Vpc: aws:vpc:vpc
     aws:lambda_function:lambda_function:
         ExecutionRole: aws:iam_role:lambda_function-ExecutionRole
@@ -24,6 +27,9 @@ resources:
         Subnets:
             - aws:subnet:vpc:lambda_function-vpc
             - aws:subnet:vpc:subnet-1
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function
         Timeout: 180
     aws:ecr_image:lambda_function-image:
         Context: .
@@ -42,11 +48,17 @@ resources:
         ManagedPolicies:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
             - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-ExecutionRole
     aws:subnet:vpc:lambda_function-vpc:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.128.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc:lambda_function-vpc-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-vpc
         Type: private
         Vpc: aws:vpc:vpc
     aws:subnet:vpc:subnet-1:
@@ -54,10 +66,16 @@ resources:
         CidrBlock: 10.0.192.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc:subnet-1-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1
         Type: private
         Vpc: aws:vpc:vpc
     aws:ecr_repo:lambda_function-image-ecr_repo:
         ForceDelete: true
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-image-ecr_repo
     aws:route_table_association:lambda_function-vpc-lambda_function-vpc-route_table:
         RouteTable: aws:route_table:vpc:lambda_function-vpc-route_table
         Subnet: aws:subnet:vpc:lambda_function-vpc
@@ -69,35 +87,62 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-2:lambda_function-vpc-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-vpc-route_table
         Vpc: aws:vpc:vpc
     aws:log_group:lambda_function-log-group:
         LogGroupName: /aws/lambda/lambda_function
         RetentionInDays: 5
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-log-group
     aws:route_table:vpc:subnet-1-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               NatGateway: aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table
         Vpc: aws:vpc:vpc
     aws:nat_gateway:subnet-2:lambda_function-vpc-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:lambda_function-vpc-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc:subnet-2
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-vpc-route_table-nat_gateway
     aws:nat_gateway:subnet-3:subnet-1-route_table-nat_gateway:
         ElasticIp: aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip
         Subnet: aws:subnet:vpc:subnet-3
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway
     aws:elastic_ip:lambda_function-vpc-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: lambda_function-vpc-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc:subnet-2:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-0
         CidrBlock: 10.0.0.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc:subnet-2-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2
         Type: public
         Vpc: aws:vpc:vpc
     aws:elastic_ip:subnet-1-route_table-nat_gateway-elastic_ip:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-1-route_table-nat_gateway-elastic_ip
     aws:subnet:vpc:subnet-3:
         AvailabilityZone: aws:availability_zone:region-0:availability_zone-1
         CidrBlock: 10.0.64.0/18
         MapPublicIpOnLaunch: false
         RouteTable: aws:route_table:vpc:subnet-3-route_table
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3
         Type: public
         Vpc: aws:vpc:vpc
     aws:availability_zone:region-0:availability_zone-0:
@@ -116,14 +161,23 @@ resources:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-2-route_table
         Vpc: aws:vpc:vpc
     aws:region:region-0:
     aws:route_table:vpc:subnet-3-route_table:
         Routes:
             - CidrBlock: 0.0.0.0/0
               Gateway: aws:internet_gateway:vpc:internet_gateway-0
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: subnet-3-route_table
         Vpc: aws:vpc:vpc
     aws:internet_gateway:vpc:internet_gateway-0:
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: internet_gateway-0
         Vpc: aws:vpc:vpc
     aws:vpc:vpc:
         imported: true

--- a/pkg/infra/cli.go
+++ b/pkg/infra/cli.go
@@ -107,7 +107,7 @@ func GenerateIac(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	solCtx := engine.NewSolutionContext(kb)
+	solCtx := engine.NewSolutionContext(kb, "")
 	err = solCtx.LoadGraph(input.Graph)
 	if err != nil {
 		return err

--- a/pkg/infra/iac/templates/aws/acm_certificate/factory.ts
+++ b/pkg/infra/iac/templates/aws/acm_certificate/factory.ts
@@ -10,7 +10,7 @@ interface Args {
     DomainName: string
     EarlyRenewalDuration?: string
     SubjectAlternativeNames?: string[]
-    Tags?: ModelCaseWrapper<Record<string, string>>
+    Tags: ModelCaseWrapper<Record<string, string>>
     ValidationMethod?: string
     DomainValidationOptions?: pulumi.Input<pulumi.Input<inputs.acm.CertificateValidationOption>[]>
 }

--- a/pkg/infra/iac/templates/aws/ami/factory.ts
+++ b/pkg/infra/iac/templates/aws/ami/factory.ts
@@ -1,9 +1,15 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.ec2.Ami {
-    return new aws.ec2.Ami(args.Name, {})
+    return new aws.ec2.Ami(args.Name, {
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
 }

--- a/pkg/infra/iac/templates/aws/api_stage/factory.ts
+++ b/pkg/infra/iac/templates/aws/api_stage/factory.ts
@@ -1,10 +1,12 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     RestApi: aws.apigateway.RestApi
     Deployment: aws.apigateway.Deployment
     StageName: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -13,6 +15,9 @@ function create(args: Args): aws.apigateway.Stage {
         deployment: args.Deployment.id,
         restApi: args.RestApi.id,
         stageName: args.StageName,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/app_runner_service/factory.ts
+++ b/pkg/infra/iac/templates/aws/app_runner_service/factory.ts
@@ -9,6 +9,7 @@ interface Args {
     InstanceRole: aws.iam.Role
     EnvironmentVariables: ModelCaseWrapper<Record<string, pulumi.Output<string>>>
     Port: number
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -45,6 +46,9 @@ function create(args: Args): aws.apprunner.Service {
                 isPubliclyAccessible: true,
             },
         },
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
+++ b/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -12,6 +13,7 @@ interface Args {
     DefaultRootObject: string
     CNAMEs: string[]
     CustomErrorResponses: aws.types.input.cloudfront.DistributionCustomErrorResponse[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -38,6 +40,9 @@ function create(args: Args): aws.cloudfront.Distribution {
         restrictions: args.Restrictions,
         //TMPL {{- if .DefaultRootObject }}
         defaultRootObject: args.DefaultRootObject,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/dynamodb_table/factory.ts
+++ b/pkg/infra/iac/templates/aws/dynamodb_table/factory.ts
@@ -10,6 +10,7 @@ interface Args {
     RangeKey: string
     BillingMode: string
     protect: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.dynamodb.Table {
@@ -22,6 +23,9 @@ function create(args: Args): aws.dynamodb.Table {
             rangeKey: args.RangeKey,
             //TMPL {{- end }}
             billingMode: args.BillingMode,
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
         },
         { protect: args.protect }
     )

--- a/pkg/infra/iac/templates/aws/ec2_instance/factory.ts
+++ b/pkg/infra/iac/templates/aws/ec2_instance/factory.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -7,6 +8,7 @@ interface Args {
     Subnet: aws.ec2.Subnet
     AMI: aws.ec2.Ami
     InstanceType: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.ec2.Instance {
@@ -16,6 +18,9 @@ function create(args: Args): aws.ec2.Instance {
         vpcSecurityGroupIds: args.SecurityGroups.map((sg) => sg.id),
         subnetId: args.Subnet.id,
         instanceType: args.InstanceType,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/ecr_repo/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecr_repo/factory.ts
@@ -1,7 +1,9 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -13,9 +15,8 @@ function create(args: Args): aws.ecr.Repository {
         imageTagMutability: 'MUTABLE',
         forceDelete: true,
         encryptionConfigurations: [{ encryptionType: 'KMS' }],
-        tags: {
-            env: 'production',
-            AppName: args.Name,
-        },
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/ecs_cluster/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_cluster/factory.ts
@@ -1,10 +1,16 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.ecs.Cluster {
-    return new aws.ecs.Cluster(args.Name, {})
+    return new aws.ecs.Cluster(args.Name, {
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
 }

--- a/pkg/infra/iac/templates/aws/ecs_service/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_service/factory.ts
@@ -2,7 +2,7 @@ import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import { OutputInstance } from '@pulumi/pulumi'
 import * as awsInputs from '@pulumi/aws/types/input'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     AssignPublicIp: Promise<boolean> | OutputInstance<boolean> | boolean
@@ -21,6 +21,7 @@ interface Args {
     LoadBalancers: TemplateWrapper<any[]>
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
     ServiceRegistries: pulumi.Input<awsInputs.ecs.ServiceServiceRegistries>
+        Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -58,6 +59,9 @@ function create(args: Args): aws.ecs.Service {
             waitForSteadyState: true,
             //TMPL {{- if .ServiceRegistries }}
             serviceRegistries: args.ServiceRegistries,
+            //TMPL {{- end }}
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
             //TMPL {{- end }}
         },
         { dependsOn: args.dependsOn }

--- a/pkg/infra/iac/templates/aws/ecs_service/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_service/factory.ts
@@ -21,7 +21,7 @@ interface Args {
     LoadBalancers: TemplateWrapper<any[]>
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
     ServiceRegistries: pulumi.Input<awsInputs.ecs.ServiceServiceRegistries>
-        Tags: ModelCaseWrapper<Record<string, string>>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols

--- a/pkg/infra/iac/templates/aws/ecs_task_definition/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_task_definition/factory.ts
@@ -2,7 +2,7 @@ import * as aws from '@pulumi/aws'
 import * as docker from '@pulumi/docker'
 import * as pulumi from '@pulumi/pulumi'
 import * as awsInputs from '@pulumi/aws/types/input'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -12,6 +12,7 @@ interface Args {
     RequiresCompatibilities?: string[]
     EfsVolumes: TemplateWrapper<awsInputs.ecs.TaskDefinitionVolumeEfsVolumeConfiguration[]>
     ContainerDefinitions: TemplateWrapper<awsInputs.ecs.TaskDefinitionContainerDefinitions[]>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -38,5 +39,8 @@ function create(args: Args): aws.ecs.TaskDefinition {
         volumes: args.EfsVolumes,
         //TMPL {{- end }}
         containerDefinitions: pulumi.jsonStringify(args.ContainerDefinitions),
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/efs_access_point/factory.ts
+++ b/pkg/infra/iac/templates/aws/efs_access_point/factory.ts
@@ -1,10 +1,14 @@
 import * as aws from '@pulumi/aws'
 import * as awsInputs from '@pulumi/aws/types/input'
+import { ModelCaseWrapper } from '../../wrappers'
+
+
 interface Args {
     Name: string
     FileSystem: aws.efs.FileSystem
     RootDirectory?: awsInputs.efs.AccessPointRootDirectory
     PosixUser?: awsInputs.efs.AccessPointPosixUser
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -18,6 +22,9 @@ function create(args: Args): aws.efs.AccessPoint {
         //TMPL {{- end }}
         //TMPL {{- if .RootDirectory }}
         rootDirectory: args.RootDirectory,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/efs_access_point/factory.ts
+++ b/pkg/infra/iac/templates/aws/efs_access_point/factory.ts
@@ -2,7 +2,6 @@ import * as aws from '@pulumi/aws'
 import * as awsInputs from '@pulumi/aws/types/input'
 import { ModelCaseWrapper } from '../../wrappers'
 
-
 interface Args {
     Name: string
     FileSystem: aws.efs.FileSystem

--- a/pkg/infra/iac/templates/aws/efs_file_system/factory.ts
+++ b/pkg/infra/iac/templates/aws/efs_file_system/factory.ts
@@ -1,6 +1,7 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import * as awsInputs from '@pulumi/aws/types/input'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     LifecyclePolicies: awsInputs.efs.FileSystemLifecyclePolicy[]
@@ -13,6 +14,7 @@ interface Args {
     Encrypted?: Promise<boolean> | pulumi.OutputInstance<boolean> | boolean
     CreationToken?: Promise<string> | pulumi.OutputInstance<string> | string
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -43,6 +45,9 @@ function create(args: Args): aws.efs.FileSystem {
             //TMPL {{- end }}
             //TMPL {{- if .ThroughputMode }}
             throughputMode: args.ThroughputMode,
+            //TMPL {{- end }}
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
             //TMPL {{- end }}
         },
         {

--- a/pkg/infra/iac/templates/aws/eks_add_on/factory.ts
+++ b/pkg/infra/iac/templates/aws/eks_add_on/factory.ts
@@ -1,11 +1,13 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     AddonName: string
     ClusterName: pulumi.Input<string>
     Role: aws.iam.Role
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -15,6 +17,9 @@ function create(args: Args): aws.eks.Addon {
         addonName: args.AddOnName,
         //TMPL {{- if .Role }}
         serviceAccountRoleArn: args.Role.arn,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/eks_cluster/factory.ts
+++ b/pkg/infra/iac/templates/aws/eks_cluster/factory.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -6,6 +7,7 @@ interface Args {
     SecurityGroups: aws.ec2.SecurityGroup[]
     ClusterRole: aws.iam.Role
     Version: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -19,6 +21,9 @@ function create(args: Args): aws.eks.Cluster {
             //TMPL {{- end }}
         },
         roleArn: args.ClusterRole.arn,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/eks_fargate_profile/factory.ts
+++ b/pkg/infra/iac/templates/aws/eks_fargate_profile/factory.ts
@@ -1,6 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -10,6 +10,7 @@ interface Args {
     Selectors: TemplateWrapper<
         pulumi.Input<pulumi.Input<aws.types.input.eks.FargateProfileSelector>[]>
     >
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -21,6 +22,9 @@ function create(args: Args): aws.eks.FargateProfile {
             podExecutionRoleArn: args.PodExecutionRole.arn,
             selectors: args.Selectors,
             subnetIds: args.Subnets.map((subnet) => subnet.id),
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
         },
         {
             customTimeouts: { create: '30m', update: '30m', delete: '30m' },

--- a/pkg/infra/iac/templates/aws/eks_node_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/eks_node_group/factory.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as aws_native from '@pulumi/aws-native'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -14,6 +15,7 @@ interface Args {
     DiskSize: number
     InstanceTypes: string[]
     Labels: Record<string, string>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -37,6 +39,9 @@ function create(args: Args): aws.eks.NodeGroup {
         instanceTypes: args.InstanceTypes,
         //TMPL {{- if .Labels }}
         labels: args.Labels,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/elastic_ip/factory.ts
+++ b/pkg/infra/iac/templates/aws/elastic_ip/factory.ts
@@ -1,10 +1,16 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.ec2.Eip {
-    return new aws.ec2.Eip(args.Name, {})
+    return new aws.ec2.Eip(args.Name, {
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
 }

--- a/pkg/infra/iac/templates/aws/elasticache_cluster/factory.ts
+++ b/pkg/infra/iac/templates/aws/elasticache_cluster/factory.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -8,6 +9,7 @@ interface Args {
     SecurityGroups: aws.ec2.SecurityGroup[]
     NodeType: string
     NumCacheNodes: number
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.elasticache.Cluster {
@@ -31,6 +33,9 @@ function create(args: Args): aws.elasticache.Cluster {
         ],
         subnetGroupName: args.SubnetGroup.name,
         securityGroupIds: args.SecurityGroups.map((sg) => sg.id),
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/elasticache_subnet_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/elasticache_subnet_group/factory.ts
@@ -1,12 +1,17 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Subnets: aws.ec2.Subnet[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.elasticache.SubnetGroup {
     return new aws.elasticache.SubnetGroup(args.Name, {
         subnetIds: args.Subnets.map((sg) => sg.id),
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/iam_instance_profile/factory.ts
+++ b/pkg/infra/iac/templates/aws/iam_instance_profile/factory.ts
@@ -1,12 +1,17 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Role: aws.iam.Role
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.iam.InstanceProfile {
     return new aws.iam.InstanceProfile(args.Name, {
         role: args.Role,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/iam_oidc_provider/factory.ts
+++ b/pkg/infra/iac/templates/aws/iam_oidc_provider/factory.ts
@@ -2,12 +2,14 @@ import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import { getIssuerCAThumbprint } from '@pulumi/eks/cert-thumprint'
 import * as https from 'https'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     ClientIdLists: string[]
     Cluster: aws.eks.Cluster
     Region: pulumi.Output<pulumi.UnwrappedObject<aws.GetRegionResult>>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -25,6 +27,9 @@ function create(args: Args): aws.iam.OpenIdConnectProvider {
                 })
             ),
         ],
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 function properties(object: aws.iam.OpenIdConnectProvider, args: Args) {

--- a/pkg/infra/iac/templates/aws/iam_policy/factory.ts
+++ b/pkg/infra/iac/templates/aws/iam_policy/factory.ts
@@ -4,12 +4,16 @@ import { ModelCaseWrapper } from '../../wrappers'
 interface Args {
     Name: string
     Policy: ModelCaseWrapper<aws.iam.PolicyDocument>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.iam.Policy {
     return new aws.iam.Policy(args.Name, {
         policy: args.Policy,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/iam_role/factory.ts
+++ b/pkg/infra/iac/templates/aws/iam_role/factory.ts
@@ -9,6 +9,7 @@ interface Args {
     InlinePolicies: TemplateWrapper<pulumi.Input<pulumi.Input<awsInputs.iam.RoleInlinePolicy>[]>>
     ManagedPolicies: pulumi.Output<string>[]
     AwsManagedPolicies: string[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -27,6 +28,9 @@ function create(args: Args): aws.iam.Role {
             ...args.AwsManagedPolicies,
             //TMPL {{- end }}
         ],
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/internet_gateway/factory.ts
+++ b/pkg/infra/iac/templates/aws/internet_gateway/factory.ts
@@ -1,13 +1,18 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Vpc: aws.ec2.Vpc
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.ec2.InternetGateway {
     return new aws.ec2.InternetGateway(args.Name, {
         vpcId: args.Vpc.id,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/lambda_function/factory.ts
+++ b/pkg/infra/iac/templates/aws/lambda_function/factory.ts
@@ -14,6 +14,7 @@ interface Args {
     Timeout: pulumi.Input<number>
     EfsAccessPoint: aws.efs.AccessPoint
     dependsOn?: pulumi.Input<pulumi.Input<pulumi.Resource>[]> | pulumi.Input<pulumi.Resource>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -48,10 +49,9 @@ function create(args: Args): aws.lambda.Function {
                 variables: args.EnvironmentVariables,
             },
             //TMPL {{- end }}
-            tags: {
-                env: 'production',
-                service: args.Name,
-            },
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
         },
         {
             dependsOn: args.dependsOn,

--- a/pkg/infra/iac/templates/aws/load_balancer/factory.ts
+++ b/pkg/infra/iac/templates/aws/load_balancer/factory.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -7,7 +8,7 @@ interface Args {
     Scheme: string
     SecurityGroups: aws.ec2.SecurityGroup[]
     Subnets: aws.ec2.Subnet[]
-    Tags: Record<string, string>
+    Tags: ModelCaseWrapper<Record<string, string>>
     Type: string
 }
 

--- a/pkg/infra/iac/templates/aws/load_balancer_listener/factory.ts
+++ b/pkg/infra/iac/templates/aws/load_balancer_listener/factory.ts
@@ -1,5 +1,5 @@
 import * as aws from '@pulumi/aws'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -7,6 +7,7 @@ interface Args {
     Protocol: string
     LoadBalancer: aws.lb.LoadBalancer
     DefaultActions: TemplateWrapper<aws.types.input.lb.ListenerDefaultAction[]>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -16,5 +17,8 @@ function create(args: Args): aws.lb.Listener {
         defaultActions: args.DefaultActions,
         port: args.Port,
         protocol: args.Protocol,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/load_balancer_listener_rule/factory.ts
+++ b/pkg/infra/iac/templates/aws/load_balancer_listener_rule/factory.ts
@@ -8,7 +8,7 @@ interface Args {
     Priority: number
     Conditions: []
     Actions: TemplateWrapper<inputs.lb.ListenerRuleAction[]>
-    Tags?: ModelCaseWrapper<Record<string, string>>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols

--- a/pkg/infra/iac/templates/aws/log_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/log_group/factory.ts
@@ -1,9 +1,11 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     LogGroupName: string
     RetentionInDays: number
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -11,6 +13,9 @@ function create(args: Args): aws.cloudwatch.LogGroup {
     return new aws.cloudwatch.LogGroup(args.Name, {
         name: args.LogGroupName,
         retentionInDays: args.RetentionInDays,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/nat_gateway/factory.ts
+++ b/pkg/infra/iac/templates/aws/nat_gateway/factory.ts
@@ -1,9 +1,11 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     ElasticIp: aws.ec2.Eip
     Subnet: aws.ec2.Subnet
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -11,5 +13,8 @@ function create(args: Args): aws.ec2.NatGateway {
     return new aws.ec2.NatGateway(args.Name, {
         allocationId: args.ElasticIp.id,
         subnetId: args.Subnet.id,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/private_dns_namespace/factory.ts
+++ b/pkg/infra/iac/templates/aws/private_dns_namespace/factory.ts
@@ -1,14 +1,19 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Vpc: aws.ec2.Vpc
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.servicediscovery.PrivateDnsNamespace {
     return new aws.servicediscovery.PrivateDnsNamespace(args.Name, {
         vpc: args.Vpc.id,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/rds_instance/factory.ts
+++ b/pkg/infra/iac/templates/aws/rds_instance/factory.ts
@@ -1,6 +1,7 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 import { accountId, region, kloConfig } from '../../globals'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -16,6 +17,7 @@ interface Args {
     Username: string
     Password: string
     protect: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -34,6 +36,9 @@ function create(args: Args): aws.rds.Instance {
             vpcSecurityGroupIds: args.SecurityGroups.map((sg) => sg.id),
             skipFinalSnapshot: args.SkipFinalSnapshot,
             allocatedStorage: args.AllocatedStorage,
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
         },
         { protect: args.protect }
     )

--- a/pkg/infra/iac/templates/aws/rds_proxy/factory.ts
+++ b/pkg/infra/iac/templates/aws/rds_proxy/factory.ts
@@ -1,5 +1,7 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
+
 interface Args {
     Name: string
     DebugLogging: boolean
@@ -10,6 +12,7 @@ interface Args {
     SecurityGroups: aws.ec2.SecurityGroup[]
     Subnets: aws.ec2.Subnet[]
     Auths: pulumi.Input<aws.types.input.rds.ProxyAuth>[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -23,6 +26,9 @@ function create(args: Args): aws.rds.Proxy {
         vpcSecurityGroupIds: args.SecurityGroups.map((sg) => sg.id),
         vpcSubnetIds: args.Subnets.map((subnet) => subnet.id),
         auths: args.Auths,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/rds_subnet_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/rds_subnet_group/factory.ts
@@ -1,9 +1,10 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Subnets: aws.ec2.Subnet[]
-    Tags: Record<string, string>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols

--- a/pkg/infra/iac/templates/aws/rest_api/factory.ts
+++ b/pkg/infra/iac/templates/aws/rest_api/factory.ts
@@ -1,14 +1,19 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     BinaryMediaTypes: string[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.apigateway.RestApi {
     return new aws.apigateway.RestApi(args.Name, {
         binaryMediaTypes: args.BinaryMediaTypes,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/route_table/factory.ts
+++ b/pkg/infra/iac/templates/aws/route_table/factory.ts
@@ -1,10 +1,11 @@
 import * as aws from '@pulumi/aws'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Vpc: aws.ec2.Vpc
     Routes: TemplateWrapper<aws.types.input.ec2.RouteTableRoute[]>
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -12,5 +13,8 @@ function create(args: Args): aws.ec2.RouteTable {
     return new aws.ec2.RouteTable(args.Name, {
         vpcId: args.Vpc.id,
         routes: args.Routes,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/s3_bucket/factory.ts
+++ b/pkg/infra/iac/templates/aws/s3_bucket/factory.ts
@@ -1,5 +1,6 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -7,6 +8,7 @@ interface Args {
     IndexDocument: string
     SSEAlgorithm: string
     protect: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -29,6 +31,9 @@ function create(args: Args): aws.s3.Bucket {
             website: {
                 indexDocument: args.IndexDocument,
             },
+            //TMPL {{- end }}
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
             //TMPL {{- end }}
         },
         { protect: args.protect }

--- a/pkg/infra/iac/templates/aws/s3_object/factory.ts
+++ b/pkg/infra/iac/templates/aws/s3_object/factory.ts
@@ -1,12 +1,14 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 import * as mime from 'mime'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Bucket: aws.s3.Bucket
     Key: string
     FilePath: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -16,5 +18,8 @@ function create(args: Args): aws.s3.BucketObject {
         key: args.Key,
         source: new pulumi.asset.FileAsset(args.FilePath), // use FileAsset to point to a file
         contentType: mime.getType(args.FilePath) || undefined, // set the MIME type of the file
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/secret/factory.ts
+++ b/pkg/infra/iac/templates/aws/secret/factory.ts
@@ -1,8 +1,10 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     protect: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -12,6 +14,9 @@ function create(args: Args): aws.secretsmanager.Secret {
         {
             name: args.Name,
             recoveryWindowInDays: 0,
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
         },
         { protect: args.protect }
     )

--- a/pkg/infra/iac/templates/aws/security_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/security_group/factory.ts
@@ -1,10 +1,12 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Vpc: aws.ec2.Vpc
     IngressRules: aws.types.input.ec2.SecurityGroupIngress[]
     EgressRules: aws.types.input.ec2.SecurityGroupEgress[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.ec2.SecurityGroup {
@@ -13,5 +15,8 @@ function create(args: Args): aws.ec2.SecurityGroup {
         vpcId: args.Vpc.id,
         egress: args.EgressRules,
         ingress: args.IngressRules,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/service_discovery_service/factory.ts
+++ b/pkg/infra/iac/templates/aws/service_discovery_service/factory.ts
@@ -1,10 +1,12 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     DnsConfig: aws.servicediscovery.ServiceDnsConfig
     HealthCheckCustomConfig: aws.servicediscovery.ServiceHealthCheckCustomConfig
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 function create(args: Args): aws.servicediscovery.Service {
@@ -12,6 +14,9 @@ function create(args: Args): aws.servicediscovery.Service {
         dnsConfig: args.DnsConfig,
         //TMPL {{- if .HealthCheckCustomConfig }}
         healthCheckCustomConfig: args.HealthCheckCustomConfig,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
         //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/sqs_queue/factory.ts
+++ b/pkg/infra/iac/templates/aws/sqs_queue/factory.ts
@@ -7,7 +7,7 @@ interface Args {
     DelaySeconds?: number
     MaxMessageSize?: number
     VisibilityTimeout?: number
-    Tags?: ModelCaseWrapper<Record<string, string>>
+    Tags: ModelCaseWrapper<Record<string, string>>
     protect: boolean
 }
 

--- a/pkg/infra/iac/templates/aws/subnet/factory.ts
+++ b/pkg/infra/iac/templates/aws/subnet/factory.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -7,6 +8,7 @@ interface Args {
     Vpc: aws.ec2.Vpc
     AvailabilityZone: pulumi.Output<string>
     MapPublicIpOnLaunch: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -16,8 +18,8 @@ function create(args: Args): aws.ec2.Subnet {
         cidrBlock: args.CidrBlock,
         availabilityZone: args.AvailabilityZone,
         mapPublicIpOnLaunch: args.MapPublicIpOnLaunch,
-        tags: {
-            Name: args.Name,
-        },
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/target_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/target_group/factory.ts
@@ -1,5 +1,5 @@
 import * as aws from '@pulumi/aws'
-import { TemplateWrapper } from '../../wrappers'
+import { TemplateWrapper, ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -11,6 +11,7 @@ interface Args {
     Targets: { Id: string; Port: number }[]
     HealthCheck: TemplateWrapper<Record<string, any>>
     LambdaMultiValueHeadersEnabled?: boolean
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -27,6 +28,9 @@ function create(args: Args): aws.lb.TargetGroup {
             healthCheck: args.HealthCheck,
             //TMPL {{- if .LambdaMultiValueHeadersEnabled }}
             lambdaMultiValueHeadersEnabled: args.LambdaMultiValueHeadersEnabled,
+            //TMPL {{- end }}
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
             //TMPL {{- end }}
         })
 

--- a/pkg/infra/iac/templates/aws/vpc/factory.ts
+++ b/pkg/infra/iac/templates/aws/vpc/factory.ts
@@ -1,4 +1,5 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -6,6 +7,7 @@ interface Args {
     EnableDnsHostnames: boolean
     EnableDnsSupport: boolean
     Arn?: string
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -14,9 +16,9 @@ function create(args: Args): aws.ec2.Vpc {
         cidrBlock: args.CidrBlock,
         enableDnsHostnames: args.EnableDnsHostnames,
         enableDnsSupport: args.EnableDnsSupport,
-        tags: {
-            Name: args.Name,
-        },
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }
 

--- a/pkg/infra/iac/templates/aws/vpc_endpoint/factory.ts
+++ b/pkg/infra/iac/templates/aws/vpc_endpoint/factory.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
@@ -10,6 +11,7 @@ interface Args {
     Subnets: aws.ec2.Subnet[]
     SecurityGroupIds: pulumi.Input<string[]> | undefined
     RouteTables: aws.ec2.RouteTable[]
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -26,5 +28,8 @@ function create(args: Args): aws.ec2.VpcEndpoint {
         //TMPL {{- if and .RouteTables (eq .VpcEndpointType "Gateway")}}
         routeTableIds: args.RouteTables.map((rt) => rt.id),
         //TMPL {{- end}}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/infra/iac/templates/aws/vpc_link/factory.ts
+++ b/pkg/infra/iac/templates/aws/vpc_link/factory.ts
@@ -1,13 +1,18 @@
 import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Target: aws.lb.LoadBalancer
+    Tags: ModelCaseWrapper<Record<string, string>>
 }
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.apigateway.VpcLink {
     return new aws.apigateway.VpcLink(args.Name, {
         targetArn: args.Target.arn,
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
     })
 }

--- a/pkg/knowledgebase/dynamic_value.go
+++ b/pkg/knowledgebase/dynamic_value.go
@@ -35,10 +35,12 @@ type (
 	// DynamicValueData provides the resource or edge to the templates as
 	// `{{ .Self }}` for resources
 	// `{{ .Source }}` and `{{ .Target }}` for edges
+	// and `{{ .Tag }}` for the global tag
 	DynamicValueData struct {
-		Resource construct.ResourceId
-		Edge     *construct.Edge
-		Path     construct.PropertyPath
+		Resource  construct.ResourceId
+		Edge      *construct.Edge
+		Path      construct.PropertyPath
+		GlobalTag string
 	}
 )
 
@@ -255,6 +257,10 @@ func (data DynamicValueData) Target() (construct.ResourceId, error) {
 		return construct.ResourceId{}, fmt.Errorf("no .Target is set")
 	}
 	return data.Edge.Target, nil
+}
+
+func (data DynamicValueData) Tag() string {
+	return data.GlobalTag
 }
 
 // Log is primarily used for debugging templates and shouldn't actually appear in any.

--- a/pkg/knowledgebase/reader/models.go
+++ b/pkg/knowledgebase/reader/models.go
@@ -71,8 +71,10 @@ func updateModels(property *Property, properties Properties, models map[string]*
 				for name, prop := range model.Properties {
 					// since properties are pointers and models can be reused, we need to clone the property from the model itself
 					newProp := prop.Clone()
-					newProp.Path = fmt.Sprintf("%s.%s", name, prop.Path)
-
+					// We need to make sure we perpend the parent property path
+					if property != nil {
+						newProp.Path = fmt.Sprintf("%s.%s", property.Path, prop.Path)
+					}
 					// we also need to check if the current property has a default and propagate it lower
 					if p.DefaultValue != nil {
 						defaultMap, ok := p.DefaultValue.(map[string]any)

--- a/pkg/provider/aws/aws_resource_test.go
+++ b/pkg/provider/aws/aws_resource_test.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/klothoplatform/klotho/pkg/knowledgebase/reader"
+	"github.com/klothoplatform/klotho/pkg/templates"
+)
+
+var (
+	nonTaggableResource = []string{
+
+		"aws:SERVICE_API",
+		"aws:ecr_image",
+		"aws:security_group_rule",
+		"aws:secret_version",
+		"aws:s3_bucket_policy",
+		"aws:route_table_association",
+		"aws:availability_zone",
+		"aws:region",
+		"aws:listener_certificate",
+		"aws:efs_mount_target",
+		"aws:rds_proxy_target_group",
+		"aws:api_integration",
+		"aws:lambda_permission",
+		"aws:lambda_event_source_mapping",
+		"aws:cloudfront_origin_access_identity",
+		"aws:iam_role_policy_attachment",
+		"aws:api_deployment",
+		"aws:api_method",
+		"aws:api_resource",
+		"aws:ses_email_identity",
+	}
+)
+
+func Test_AwsResourcesSupportTags(t *testing.T) {
+	// Test_AwsResourcesSupportTags tests that all AWS resources support tags
+	// and that the tag keys are unique.
+
+	checked_types := make(map[string]bool)
+
+	kb, err := reader.NewKBFromFs(templates.ResourceTemplates, templates.EdgeTemplates, templates.Models)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := kb.Edges()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, edge := range edges {
+		if edge.Source.Id().Provider == "aws" && !checked_types[edge.Source.Id().Type] {
+			properties := edge.Source.Properties
+			if properties["Tags"] == nil && !slices.Contains(nonTaggableResource, edge.Source.QualifiedTypeName) {
+				t.Errorf("edge %s does not support tags", edge.Source.Id())
+			}
+			checked_types[edge.Source.Id().Type] = true
+		}
+		if edge.Target.Id().Provider == "aws" && !checked_types[edge.Target.Id().Type] {
+			properties := edge.Target.Properties
+			if properties["Tags"] == nil && !slices.Contains(nonTaggableResource, edge.Target.QualifiedTypeName) {
+				t.Errorf("edge %s does not support tags", edge.Target.Id())
+			}
+			checked_types[edge.Target.Id().Type] = true
+		}
+	}
+}

--- a/pkg/templates/aws/models/tags.yaml
+++ b/pkg/templates/aws/models/tags.yaml
@@ -1,0 +1,7 @@
+name: aws:tags
+properties:
+  Tags:
+    type: map(string,string)
+    default_value: 
+      RESOURCE_NAME: '{{ .Self.Name }}'
+      GLOBAL_KLOTHO_TAG: '{{ .Tag }}'

--- a/pkg/templates/aws/resources/acm_certificate.yaml
+++ b/pkg/templates/aws/resources/acm_certificate.yaml
@@ -24,8 +24,8 @@ properties:
     description: Additional FQDNs to be included in the Subject Alternative Name extension of the ACM certificate
 #    min_length: 1
 #    max_length: 253
-  Tags:
-    type: map(string,string)
+  aws:tags:
+    type: model
   ValidationMethod:
     type: string
     default_value: DNS

--- a/pkg/templates/aws/resources/ami.yaml
+++ b/pkg/templates/aws/resources/ami.yaml
@@ -1,10 +1,13 @@
 qualified_type_name: aws:ami
 display_name: AMI
 
+properties:
+  aws:tags:
+    type: model
+
 classification:
   is:
     - machine_image
-
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/api_stage.yaml
+++ b/pkg/templates/aws/resources/api_stage.yaml
@@ -20,6 +20,8 @@ properties:
         direction: downstream
         resources:
           - aws:api_deployment
+  aws:tags:
+    type: model
   StageInvokeUrl:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/app_runer_service.yaml
+++ b/pkg/templates/aws/resources/app_runer_service.yaml
@@ -45,6 +45,8 @@ properties:
   Port:
     type: int
     default_value: 8080
+  aws:tags:
+    type: model
 
     description: The network port that the App Runner service listens to for incoming
       traffic

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -185,6 +185,8 @@ properties:
             default_value: none
   DefaultRootObject:
     type: string
+  aws:tags:
+    type: model
 
 path_satisfaction:
   as_source:

--- a/pkg/templates/aws/resources/dynamodb_table.yaml
+++ b/pkg/templates/aws/resources/dynamodb_table.yaml
@@ -51,6 +51,8 @@ properties:
   RangeKey:
     type: string
     description: The table range key, which is the sort key for the DynamoDB table
+  aws:tags:
+    type: model
   Name:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/ec2_instance.yaml
+++ b/pkg/templates/aws/resources/ec2_instance.yaml
@@ -47,6 +47,8 @@ properties:
     default: t3.medium
     description: The type of the EC2 instance, determining the CPU, memory, and other
       resources
+  aws:tags:
+    type: model
   Id:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/ecr_repo.yaml
+++ b/pkg/templates/aws/resources/ecr_repo.yaml
@@ -5,6 +5,9 @@ properties:
   ForceDelete:
     type: bool
     default_value: true
+  aws:tags:
+    type: model
+
 classification:
   is:
     - repository

--- a/pkg/templates/aws/resources/ecs_cluster.yaml
+++ b/pkg/templates/aws/resources/ecs_cluster.yaml
@@ -1,6 +1,10 @@
 qualified_type_name: aws:ecs_cluster
 display_name: ECS Cluster
 
+properties:
+  aws:tags:
+    type: model
+
 classification:
   is:
     - cluster

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -82,6 +82,8 @@ properties:
       RegistryArn:
         type: string
         description: ARN of the Service Registry. The currently supported service registry is Amazon Route 53 Auto Naming Service
+  aws:tags:
+    type: model
 
 consumption:
   consumed:

--- a/pkg/templates/aws/resources/ecs_task_definition.yaml
+++ b/pkg/templates/aws/resources/ecs_task_definition.yaml
@@ -153,10 +153,6 @@ properties:
             type: string
             description: The protocol used for the port mapping, such as TCP or UDP
         description: A set of port mappings between the container and host
-
-      
-      
-      
   ExecutionRole:
     type: resource(aws:iam_role)
     operational_rule:
@@ -215,7 +211,9 @@ properties:
         description: The authorization configuration details for the EFS volume
     description: An array of Amazon Elastic File System (EFS) volumes to be attached
       to containers
-  
+  aws:tags:
+    type: model  
+
 consumption:
   consumed:
     - model: EnvironmentVariables

--- a/pkg/templates/aws/resources/efs_access_point.yaml
+++ b/pkg/templates/aws/resources/efs_access_point.yaml
@@ -39,6 +39,8 @@ properties:
       Path:
         type: string
         default_value: /mnt/efs
+  aws:tags:
+    type: model
 
 classification:
   is:

--- a/pkg/templates/aws/resources/efs_file_system.yaml
+++ b/pkg/templates/aws/resources/efs_file_system.yaml
@@ -47,6 +47,8 @@ properties:
     type: string
     description: A unique string used to ensure the idempotency of CreateFileSystem
       requests
+  aws:tags:
+    type: model
   Id:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/eks_add_on.yaml
+++ b/pkg/templates/aws/resources/eks_add_on.yaml
@@ -11,10 +11,11 @@ properties:
     description: An EKS Cluster resource to which the AddOn will be attached
   Role:
     type: resource(aws:iam_role)
-
-
     description: An IAM role that provides permissions to the EKS AddOn for making
       AWS API calls
+  aws:tags:
+    type: model
+    
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/eks_cluster.yaml
+++ b/pkg/templates/aws/resources/eks_cluster.yaml
@@ -43,6 +43,8 @@ properties:
           - aws:security_group
         unique: true
     description: Lists the security groups associated with the EKS cluster nodes
+  aws:tags:
+    type: model
   Name:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/eks_fargate_profile.yaml
+++ b/pkg/templates/aws/resources/eks_fargate_profile.yaml
@@ -35,6 +35,8 @@ properties:
         type: string
       Labels:
         type: map(string,string)
+  aws:tags:
+    type: model
 
 classifications:
   is:

--- a/pkg/templates/aws/resources/eks_node_group.yaml
+++ b/pkg/templates/aws/resources/eks_node_group.yaml
@@ -68,9 +68,11 @@ properties:
     description: The instance types that can be used for your worker nodes
   Labels:
     type: map(string,string)
-
     description: Key-value mapping of Kubernetes labels to be applied to the nodes
       in the node group
+  aws:tags:
+    type: model
+
 classifications:
   is:
     - kubernetes

--- a/pkg/templates/aws/resources/elastic_ip.yaml
+++ b/pkg/templates/aws/resources/elastic_ip.yaml
@@ -1,6 +1,10 @@
 qualified_type_name: aws:elastic_ip
 display_name: Elastic IP
 
+properties:
+  aws:tags:
+    type: model
+
 classification:
   is:
     - static_ip_address

--- a/pkg/templates/aws/resources/elasticache_cluster.yaml
+++ b/pkg/templates/aws/resources/elasticache_cluster.yaml
@@ -42,6 +42,8 @@ properties:
     type: int
     default_value: 1
     description: The number of cache nodes that the cache cluster should have.
+  aws:tags:
+    type: model
   Port:
     type: int
     configuration_disabled: true

--- a/pkg/templates/aws/resources/elasticache_subnet_group.yaml
+++ b/pkg/templates/aws/resources/elasticache_subnet_group.yaml
@@ -26,6 +26,8 @@ properties:
             properties:
               Type: private
           - aws:subnet
+  aws:tags:
+    type: model
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/iam_instance_profile.yaml
+++ b/pkg/templates/aws/resources/iam_instance_profile.yaml
@@ -12,3 +12,5 @@ properties:
         unique: true
     description: The role that is associated with the instance profile to be used
       by the EC2 instances
+  aws:tags:
+    type: model

--- a/pkg/templates/aws/resources/iam_oidc_provider.yaml
+++ b/pkg/templates/aws/resources/iam_oidc_provider.yaml
@@ -18,6 +18,8 @@ properties:
         resources:
           - aws:region
     description: The AWS region in which to establish the IAM OIDC provider.
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true
@@ -30,6 +32,8 @@ properties:
     type: string
     configuration_disabled: true
     deploy_time: true
+
+
 classification:
   is:
     - authorization

--- a/pkg/templates/aws/resources/iam_policy.yaml
+++ b/pkg/templates/aws/resources/iam_policy.yaml
@@ -52,6 +52,8 @@ properties:
         description: A list of individual statements that describe the details of
           the permission
     description: Defines the structure of the IAM policy in JSON format
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/iam_role.yaml
+++ b/pkg/templates/aws/resources/iam_role.yaml
@@ -75,6 +75,8 @@ properties:
                     type: map(string,string)
                   Null:
                     type: map(string,string)
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/internet_gateway.yaml
+++ b/pkg/templates/aws/resources/internet_gateway.yaml
@@ -11,6 +11,8 @@ properties:
         direction: downstream
         resources:
           - aws:vpc
+  aws:tags:
+    type: model
 
 classification:
   gives:

--- a/pkg/templates/aws/resources/lambda_function.yaml
+++ b/pkg/templates/aws/resources/lambda_function.yaml
@@ -73,6 +73,8 @@ properties:
             properties:
               LogGroupName: /aws/lambda/{{ .Self.Name }}
         unique: true
+  aws:tags:
+    type: model
   LambdaIntegrationUri:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/load_balancer.yaml
+++ b/pkg/templates/aws/resources/load_balancer.yaml
@@ -77,6 +77,8 @@ properties:
     description: "The type of load balancer: either 'network' or 'application'"
     required: true
     important: true
+  aws:tags:
+    type: model
   NlbUri:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/load_balancer_listener.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener.yaml
@@ -37,7 +37,9 @@ properties:
           - aws:load_balancer
   DefaultActions:
     type: list(model(aws:load_balancer_listener:action))
-
+  aws:tags:
+    type: model
+    
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
+++ b/pkg/templates/aws/resources/load_balancer_listener_rule.yaml
@@ -61,6 +61,8 @@ properties:
     default_value: 1
   Tags:
     type: map(string,string)
+  aws:tags:
+    type: model
 
 delete_context:
   requires_no_upstream: true

--- a/pkg/templates/aws/resources/log_group.yaml
+++ b/pkg/templates/aws/resources/log_group.yaml
@@ -10,6 +10,8 @@ properties:
     default_value: 5
     description: The number of days to retain the log events in the specified log
       group.
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/nat_gateway.yaml
+++ b/pkg/templates/aws/resources/nat_gateway.yaml
@@ -25,9 +25,11 @@ properties:
             properties:
               Type: public
         selection_operator: spread
-
     description: The subnet in which to deploy the NAT Gateway. The subnet must be
       a public subnet.
+  aws:tags:
+    type: model
+
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/private_dns_namespace.yaml
+++ b/pkg/templates/aws/resources/private_dns_namespace.yaml
@@ -12,6 +12,8 @@ properties:
   Name:
     type: string
     description: The name of the namespace
+  aws:tags:
+    type: model
   Id:
     type: string
     deploy_time: true

--- a/pkg/templates/aws/resources/rds_instance.yaml
+++ b/pkg/templates/aws/resources/rds_instance.yaml
@@ -87,6 +87,8 @@ properties:
   AllocatedStorage:
     type: int
     default_value: 20
+  aws:tags:
+    type: model
   CredentialsSecretValue:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/rds_proxy.yaml
+++ b/pkg/templates/aws/resources/rds_proxy.yaml
@@ -50,6 +50,8 @@ properties:
         type: string
       Secret:
         type: resource(aws:secret)
+  aws:tags:
+    type: model
   Endpoint:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/rds_subnet_group.yaml
+++ b/pkg/templates/aws/resources/rds_subnet_group.yaml
@@ -25,8 +25,8 @@ properties:
           - aws:subnet
     description: A list of subnets for the RDS subnet group, with at least 2 needed,
       and all subnets need to be of 'private' type
-  Tags:
-    type: map(string,string)
+  aws:tags:
+    type: model
 
     description: A map of key-value pairs to assign as tags to the RDS subnet group
 delete_context:

--- a/pkg/templates/aws/resources/rest_api.yaml
+++ b/pkg/templates/aws/resources/rest_api.yaml
@@ -13,6 +13,8 @@ properties:
     type: string
     configuration_disabled: true
     deploy_time: true
+  aws:tags:
+    type: model
 
 path_satisfaction:
   as_source:

--- a/pkg/templates/aws/resources/route_table.yaml
+++ b/pkg/templates/aws/resources/route_table.yaml
@@ -29,6 +29,9 @@ properties:
         description: A reference to an internet gateway resource to which traffic
           is directed.
     description: Defines a list of routing rules for directing network traffic.
+  aws:tags:
+    type: model
+
 delete_context:
   requires_no_upstream: true
 views:

--- a/pkg/templates/aws/resources/s3_bucket.yaml
+++ b/pkg/templates/aws/resources/s3_bucket.yaml
@@ -23,6 +23,8 @@ properties:
     type: string
     description: The webpage that Amazon S3 returns when it receives a request to
       the root domain name of the bucket or when an index document is specified
+  aws:tags:
+    type: model
   AllBucketDirectory:
     type: string
     configuration_disabled: true
@@ -42,9 +44,10 @@ properties:
   SSEAlgorithm:
     type: string
     default_value: aws:kms
-
     description: The server-side encryption algorithm to use to encrypt data stored
       in the S3 bucket
+
+
 path_satisfaction:
   as_target:
     - network

--- a/pkg/templates/aws/resources/s3_object.yaml
+++ b/pkg/templates/aws/resources/s3_object.yaml
@@ -10,6 +10,8 @@ properties:
     type: string
   FilePath:
     type: string
+  aws:tags:
+    type: model
 
 classification:
   is:

--- a/pkg/templates/aws/resources/secret.yaml
+++ b/pkg/templates/aws/resources/secret.yaml
@@ -2,6 +2,8 @@ qualified_type_name: aws:secret
 display_name: Secret
 
 properties:
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/security_group.yaml
+++ b/pkg/templates/aws/resources/security_group.yaml
@@ -58,9 +58,11 @@ properties:
         description: Indicates the network protocol used for the egress rule
       Self:
         type: bool
-
         description: A boolean indicating whether the security group can send traffic
           to itself
+  aws:tags:
+    type: model
+
 classification:
   is:
     - network

--- a/pkg/templates/aws/resources/service_discovery_service.yaml
+++ b/pkg/templates/aws/resources/service_discovery_service.yaml
@@ -49,6 +49,8 @@ properties:
       FailureThreshold:
         type: int
         description: The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance. Maximum value of 10.
+  aws:tags:
+    type: model
   Arn:
     type: string
     deploy_time: true

--- a/pkg/templates/aws/resources/sqs_queue.yaml
+++ b/pkg/templates/aws/resources/sqs_queue.yaml
@@ -21,10 +21,9 @@ properties:
     type: int
     description: The period during which Amazon SQS prevents other consuming components
       from receiving and processing a message
-  Tags:
-    type: map(string,string)
+  aws:tags:
+    type: model
 
-    description: A map of tags to assign to the queue
 path_satisfaction:
   as_target:
     - network

--- a/pkg/templates/aws/resources/subnet.yaml
+++ b/pkg/templates/aws/resources/subnet.yaml
@@ -54,6 +54,8 @@ properties:
   MapPublicIpOnLaunch:
     type: bool
     default_value: false
+  aws:tags:
+    type: model
   Id:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/target_group.yaml
+++ b/pkg/templates/aws/resources/target_group.yaml
@@ -88,6 +88,8 @@ properties:
         type: string
   LambdaMultiValueHeadersEnabled:
     type: bool
+  aws:tags:
+    type: model
   Arn:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/vpc.yaml
+++ b/pkg/templates/aws/resources/vpc.yaml
@@ -16,6 +16,8 @@ properties:
     default_value: true
     description: Determines whether instances with public IP addresses get corresponding
       public DNS hostnames
+  aws:tags:
+    type: model
   Id:
     type: string
     configuration_disabled: true

--- a/pkg/templates/aws/resources/vpc_endpoint.yaml
+++ b/pkg/templates/aws/resources/vpc_endpoint.yaml
@@ -35,8 +35,10 @@ properties:
     description: A list of route table IDs to which the endpoint will be associated
   SecurityGroups:
     type: list(resource(aws:security_group))
-
     description: A list of security group IDs that are associated with the VPC Endpoint
+  aws:tags:
+    type: model
+
 classification:
   is:
     - service_endpoint

--- a/pkg/templates/aws/resources/vpc_link.yaml
+++ b/pkg/templates/aws/resources/vpc_link.yaml
@@ -4,6 +4,8 @@ display_name: VPC Link
 properties:
   Target:
     type: resource(aws:load_balancer)
+  aws:tags:
+    type: model
 
 delete_context:
   requires_no_upstream_or_downstream: true


### PR DESCRIPTION
ability to put a global tag in place on all valid resources

added a test to make sure tags are added to resource tempaltes (have to manually override the list if it cant have tags) and updated test data

example 
```
/Users/jordansinger/workspace/klotho/engine Run -c add.yaml -o compiled -t MYGLOBALTAG
/Users/jordansinger/workspace/klotho/iac Generate -a test -i ./compiled/resources.yaml -o compiled

const subnet_1_route_table_nat_gateway_elastic_ip = new aws.ec2.Eip("subnet-1-route_table-nat_gateway-elastic_ip", {
        tags: {GLOBAL_KLOTHO_TAG: "MYGLOBALTAG", RESOURCE_NAME: "subnet-1-route_table-nat_gateway-elastic_ip"},
    })
const subnet_3 = new aws.ec2.Subnet("subnet-3", {
        vpcId: vpc_0.id,
        cidrBlock: "10.0.64.0/18",
        availabilityZone: availability_zone_1,
        mapPublicIpOnLaunch: false,
        tags: {GLOBAL_KLOTHO_TAG: "MYGLOBALTAG", RESOURCE_NAME: "subnet-3"},
    })
const subnet_0_route_table_nat_gateway = new aws.ec2.NatGateway("subnet-0-route_table-nat_gateway", {
        allocationId: subnet_0_route_table_nat_gateway_elastic_ip.id,
        subnetId: subnet_2.id,
        tags: {GLOBAL_KLOTHO_TAG: "MYGLOBALTAG", RESOURCE_NAME: "subnet-0-route_table-nat_gateway"},
    })
const subnet_1_route_table_nat_gateway = new aws.ec2.NatGateway("subnet-1-route_table-nat_gateway", {
        allocationId: subnet_1_route_table_nat_gateway_elastic_ip.id,
        subnetId: subnet_3.id,
        tags: {GLOBAL_KLOTHO_TAG: "MYGLOBALTAG", RESOURCE_NAME: "subnet-1-route_table-nat_gateway"},
    })
```
### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
