### PR TITLE
Template Fixes for ECR and Cloudfront

### DIFF
--- a/pkg/engine/testdata/2_routes.expect.yaml
+++ b/pkg/engine/testdata/2_routes.expect.yaml
@@ -101,6 +101,7 @@ resources:
     aws:ecr_image:lambda_function_0-image:
         Context: .
         Dockerfile: lambda_function_0-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function_0-image-ecr_repo
     aws:iam_role:lambda_function_0-ExecutionRole:
         AssumeRolePolicyDoc:
@@ -121,6 +122,7 @@ resources:
     aws:ecr_image:lambda_function_1-image:
         Context: .
         Dockerfile: lambda_function_1-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function_1-image-ecr_repo
     aws:iam_role:lambda_function_1-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/delete_api_to_lambda_edge.expect.yaml
+++ b/pkg/engine/testdata/delete_api_to_lambda_edge.expect.yaml
@@ -24,6 +24,7 @@ resources:
     aws:ecr_image:lambda_function_2-image:
         Context: .
         Dockerfile: lambda_function_2-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_2-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/delete_namespace_resource.expect.yaml
+++ b/pkg/engine/testdata/delete_namespace_resource.expect.yaml
@@ -12,6 +12,7 @@ resources:
     aws:ecr_image:lambda_function_2-image:
         Context: .
         Dockerfile: lambda_function_2-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_2-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine/testdata/ecs_rds.expect.yaml
@@ -76,6 +76,7 @@ resources:
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
         Dockerfile: ecs_service_0-ecs_service_0.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecs_service_0-ecs_service_0-ecr_repo
     aws:iam_role:ecs_service_0-execution-role:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/extend_graph.expect.yaml
+++ b/pkg/engine/testdata/extend_graph.expect.yaml
@@ -69,6 +69,7 @@ resources:
     aws:ecr_image:lambda_function_0-image:
         Context: .
         Dockerfile: lambda_function_0-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_0-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/idempotent_constraints.expect.yaml
+++ b/pkg/engine/testdata/idempotent_constraints.expect.yaml
@@ -76,6 +76,7 @@ resources:
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
         Dockerfile: ecs_service_0-ecs_service_0.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecs_service_0-ecs_service_0-ecr_repo
     aws:iam_role:ecs_service_0-execution-role:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/k8s_api.expect.yaml
+++ b/pkg/engine/testdata/k8s_api.expect.yaml
@@ -253,6 +253,7 @@ resources:
     aws:ecr_image:pod2-ecr_image:
         Context: .
         Dockerfile: pod2-ecr_image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:pod2-ecr_image-ecr_repo
     aws:eks_node_group:eks_node_group-0:
         AmiType: AL2_x86_64

--- a/pkg/engine/testdata/lambda_efs.expect.yaml
+++ b/pkg/engine/testdata/lambda_efs.expect.yaml
@@ -35,6 +35,7 @@ resources:
     aws:ecr_image:lambda_test_app-image:
         Context: .
         Dockerfile: lambda_test_app-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_test_app-image-ecr_repo
     aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs:
         FileSystem: aws:efs_file_system:test-efs-fs

--- a/pkg/engine/testdata/namespace_pathselect.expect.yaml
+++ b/pkg/engine/testdata/namespace_pathselect.expect.yaml
@@ -29,6 +29,7 @@ resources:
     aws:ecr_image:lambda_function_0-image:
         Context: .
         Dockerfile: lambda_function_0-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_0-ExecutionRole:
         AssumeRolePolicyDoc:
@@ -67,6 +68,7 @@ resources:
     aws:ecr_image:lambda_function_2-image:
         Context: .
         Dockerfile: lambda_function_2-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function_2-image-ecr_repo
     aws:iam_role:lambda_function_2-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/remove_path.expect.yaml
+++ b/pkg/engine/testdata/remove_path.expect.yaml
@@ -76,6 +76,7 @@ resources:
     aws:ecr_image:lambda_function_0-image:
         Context: .
         Dockerfile: lambda_function_0-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_0-ExecutionRole:
         AssumeRolePolicyDoc:
@@ -106,6 +107,7 @@ resources:
     aws:ecr_image:lambda_function_3-image:
         Context: .
         Dockerfile: lambda_function_3-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_function_3-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/rename.expect.yaml
+++ b/pkg/engine/testdata/rename.expect.yaml
@@ -14,6 +14,7 @@ resources:
     aws:ecr_image:lambda_test_app-image:
         Context: .
         Dockerfile: lambda_test_app-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:ecr_repo-0
     aws:iam_role:lambda_test_app-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/single_lambda.expect.yaml
+++ b/pkg/engine/testdata/single_lambda.expect.yaml
@@ -12,6 +12,7 @@ resources:
     aws:ecr_image:lambda_function_0-image:
         Context: .
         Dockerfile: lambda_function_0-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function_0-image-ecr_repo
     aws:iam_role:lambda_function_0-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
@@ -42,6 +42,7 @@ resources:
     aws:ecr_image:lambda_function-image:
         Context: .
         Dockerfile: lambda_function-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function-image-ecr_repo
     aws:iam_role:lambda_function-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
@@ -34,6 +34,7 @@ resources:
     aws:ecr_image:lambda_function-image:
         Context: .
         Dockerfile: lambda_function-image.Dockerfile
+        Platform: linux/amd64
         Repo: aws:ecr_repo:lambda_function-image-ecr_repo
     aws:iam_role:lambda_function-ExecutionRole:
         AssumeRolePolicyDoc:

--- a/pkg/templates/aws/edges/cloudfront_distribution-load_balancer.yaml
+++ b/pkg/templates/aws/edges/cloudfront_distribution-load_balancer.yaml
@@ -37,12 +37,10 @@ operational_rules:
             {{ end }}
             {{ range $i, $route := $routes }}
               {{ $methods := makeSlice }}
-              {{ range $i, $rule := $rules }}
-                {{ range $j, $condition := (fieldValue "Conditions" $rule) }}
-                  {{- if (sliceContains $condition.PathPattern.Values $route) }}
-                    {{ range $j, $method := $condition.HttpRequestMethod.Values }}
-                      {{ $methods = appendSlice $methods $method }}
-                    {{- end }}
+              {{ range $j, $rule := $rules }}
+                {{ range $k, $condition := (fieldValue "Conditions" $rule) }}
+                  {{ range $l, $method := $condition.HttpRequestMethod.Values }}
+                    {{ $methods = appendSlice $methods $method }}
                   {{- end }}
                 {{- end }}
               {{ end }}

--- a/pkg/templates/aws/resources/ecr_image.yaml
+++ b/pkg/templates/aws/resources/ecr_image.yaml
@@ -32,7 +32,11 @@ properties:
     type: string
     configuration_disabled: true
     deploy_time: true
-
+  Platform:
+    type: string
+    description: The platform to use for the Docker image (e.g. linux/amd64, linux/arm64, windows/amd64)
+    default_value: linux/amd64
+    min_length: 3
 classification:
   is:
     - image


### PR DESCRIPTION
- Added Platform property to `aws:ecr_image`
- Removed requirement that path and method are set on the same alb listener rule condition for detecting methods on `aws:cloudfront_distribution -> aws:load_balancer` edges. A given rule's paths and methods are always on different conditions. Each condition only handles one condition type.