### PR TITLE
Add CachePolicyId and OriginRequestPolicyId

### DIFF
--- a/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
+++ b/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
@@ -8,7 +8,7 @@ interface Args {
     ViewerCertificate: TemplateWrapper<aws.types.input.cloudfront.DistributionViewerCertificate>
     Enabled: boolean
     DefaultCacheBehavior: aws.types.input.cloudfront.DistributionDefaultCacheBehavior
-    CacheBehaviors: aws.types.input.cloudfront.DistributionCacheBehavior[]
+    CacheBehaviors: aws.types.input.cloudfront.DistributionOrderedCacheBehavior[]
     Restrictions: aws.types.input.cloudfront.DistributionRestrictions
     DefaultRootObject: string
     Aliases: string[]

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -98,6 +98,12 @@ properties:
       SmoothStreaming:
         type: bool
         default_value: false
+      CachePolicyId:
+        type: string
+        default_value: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad' # Managed-CachingDisabled
+      OriginRequestPolicyId:
+        type: string
+        default_value: 'b689b0a8-53d0-40ab-baf2-68738e2966ac' # Managed-AllViewerExceptHostHeader
   ViewerCertificate:
     type: map
     default_value:
@@ -236,8 +242,7 @@ delete_context:
 views:
   dataflow: big
 
-
 aws:cloudfront_distribution:
-  deploy: ["cloudfront:CreateDistribution"]
-  tear_down: ["cloudfront:DeleteDistribution"]
-  update: ["cloudfront:UpdateDistribution"]
+  deploy: ['cloudfront:CreateDistribution']
+  tear_down: ['cloudfront:DeleteDistribution']
+  update: ['cloudfront:UpdateDistribution']

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -86,10 +86,6 @@ properties:
       DefaultTtl:
         type: int
         default_value: 3600
-      CachePolicyId:
-        type: string
-      OriginRequestPolicyId:
-        type: string
       ViewerProtocolPolicy:
         type: string
         default_value: allow-all
@@ -194,7 +190,7 @@ properties:
       CachePolicyId:
         type: string
       OriginRequestPolicyId:
-          type: string
+        type: string
       ViewerProtocolPolicy:
         type: string
         default_value: allow-all


### PR DESCRIPTION
and change default from ForwardedValues (legacy) to managed policies

Both Infracopilot and StackSnap need this (and currently set it manually in the IaC).

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
