### PR TITLE
Cloudfront Distribution and SES template improvements

### DIFF
--- a/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
+++ b/pkg/infra/iac/templates/aws/cloudfront_distribution/factory.ts
@@ -1,17 +1,17 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
-import { ModelCaseWrapper } from '../../wrappers'
+import { ModelCaseWrapper, TemplateWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
     Origins: aws.types.input.cloudfront.DistributionOrigin[]
-    ViewerCertificate: aws.types.input.cloudfront.DistributionViewerCertificate
+    ViewerCertificate: TemplateWrapper<aws.types.input.cloudfront.DistributionViewerCertificate>
     Enabled: boolean
     DefaultCacheBehavior: aws.types.input.cloudfront.DistributionDefaultCacheBehavior
     CacheBehaviors: aws.types.input.cloudfront.DistributionCacheBehavior[]
     Restrictions: aws.types.input.cloudfront.DistributionRestrictions
     DefaultRootObject: string
-    CNAMEs: string[]
+    Aliases: string[]
     CustomErrorResponses: aws.types.input.cloudfront.DistributionCustomErrorResponse[]
     Tags: ModelCaseWrapper<Record<string, string>>
 }
@@ -23,8 +23,8 @@ function create(args: Args): aws.cloudfront.Distribution {
         enabled: args.Enabled,
         viewerCertificate: args.ViewerCertificate,
         orderedCacheBehaviors: args.CacheBehaviors,
-        //TMPL {{- if .CNAMEs }}
-        aliases: args.CNAMEs,
+        //TMPL {{- if .Aliases }}
+        aliases: args.Aliases,
         //TMPL {{- end }}
         //TMPL {{- if .CustomErrorResponses }}
         customErrorResponses: args.CustomErrorResponses,

--- a/pkg/infra/iac/templates/aws/cloudfront_distribution/viewer_certificate.ts.tmpl
+++ b/pkg/infra/iac/templates/aws/cloudfront_distribution/viewer_certificate.ts.tmpl
@@ -1,0 +1,17 @@
+{
+    {{- if .AcmCertificateArn }}
+    acmCertificateArn: "{{ .AcmCertificateArn }}",
+    {{- end }}
+    {{- if .IamCertificateId }}
+    iamCertificateId: "{{ .IamCertificateId }}",
+    {{- end }}
+    {{- if and .CloudfrontDefaultCertificate (not .AcmCertificateArn) (not .IamCertificateId) }}
+    cloudfrontDefaultCertificate: "{{ .CloudfrontDefaultCertificate }}",
+    {{- end }}
+    {{- if .SslSupportMethod }}
+    sslSupportMethod: "{{ .SslSupportMethod }}",
+    {{- end }}
+    {{- if .MinimumProtocolVersion }}
+    minimumProtocolVersion: "{{ .MinimumProtocolVersion }}",
+    {{- end }}
+}

--- a/pkg/templates/aws/edges/iam_role-ses_email_identity.yaml
+++ b/pkg/templates/aws/edges/iam_role-ses_email_identity.yaml
@@ -15,4 +15,4 @@ operational_rules:
                       - ses:SendRawEmail
                     Effect: Allow
                     Resource:
-                      - '{{ .Target  }}#Arn'
+                      - '*'

--- a/pkg/templates/aws/resources/cloudfront_distribution.yaml
+++ b/pkg/templates/aws/resources/cloudfront_distribution.yaml
@@ -103,17 +103,29 @@ properties:
     default_value:
       CloudfrontDefaultCertificate: true
     properties:
-      ACMCertificateArn:
+      AcmCertificateArn:
         type: string
-      SSLSupportMethod:
+      SslSupportMethod:
         type: string
+        allowed_values:
+          - sni-only
+          - vip
+          - static-ip
       MinimumProtocolVersion:
         type: string
+        allowed_values:
+          - SSLv3
+          - TLSv1
+          - TLSv1_2016
+          - TLSv1.1_2016
+          - TLSv1.2_2018
+          - TLSv1.2_2019
+          - TLSv1.2_2021
       CloudfrontDefaultCertificate:
         type: bool
-      IAMCertificateId:
+      IamCertificateId:
         type: string
-  CNAMEs:
+  Aliases:
     type: list(string)
     description: |
       A list of CNAMEs (aliases) that you want CloudFront to use for this


### PR DESCRIPTION
- Improves cloudfront support for aliases and certificates
- Fixes SES policy to allow sending emails to any recipient