### PR TITLE
Aws monitoring and SNS + SQS -> Lambda + Global edge type constraints

### DIFF
--- a/pkg/engine/constraints.go
+++ b/pkg/engine/constraints.go
@@ -138,6 +138,15 @@ func applyEdgeConstraint(ctx solution_context.SolutionContext, constraint constr
 		}
 	}
 
+	if constraint.Target.Source.Name == "" || constraint.Target.Target.Name == "" {
+		if constraint.Target.Source.Name == "" && constraint.Target.Target.Name == "" {
+			return fmt.Errorf("source and target names are empty")
+		}
+		// This is considered a global constraint for the type which does not have a name and
+		// will be applied anytime a new resource is added to the graph
+		return nil
+	}
+
 	switch constraint.Operator {
 	case constraints.AddConstraintOperator:
 		return ctx.OperationalView().AddEdge(constraint.Target.Source, constraint.Target.Target)

--- a/pkg/engine/operational_eval/graph.go
+++ b/pkg/engine/operational_eval/graph.go
@@ -287,6 +287,11 @@ func (eval *Evaluator) RemoveResource(id construct.ResourceId) error {
 
 		case *graphStateVertex:
 			checkStates.Add(v.Key())
+
+		case *resourceRuleVertex:
+			if v.Resource == id {
+				errs = errors.Join(errs, eval.removeKey(v.Key()))
+			}
 		}
 	}
 	if errs != nil {

--- a/pkg/engine/testdata/delete_resource_and_iacdeps.expect.yaml
+++ b/pkg/engine/testdata/delete_resource_and_iacdeps.expect.yaml
@@ -7,6 +7,9 @@ resources:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: api_stage-0
     aws:ecs_cluster:ecs_cluster-0:
+        ClusterSettings:
+            - Name: containerInsights
+              Value: enabled
         Tags:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_cluster-0

--- a/pkg/engine/testdata/ecs_rds.deployment-policy.json
+++ b/pkg/engine/testdata/ecs_rds.deployment-policy.json
@@ -20,6 +20,15 @@
         },
         {
             "Action": [
+                "dynamodb:CreateTable",
+                "dynamodb:DeleteTable",
+                "dynamodb:UpdateTable"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
                 "ecs:CreateCluster",
                 "ecs:DeleteCluster",
                 "ecs:UpdateClusterSettings"

--- a/pkg/engine/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine/testdata/ecs_rds.expect.yaml
@@ -33,7 +33,58 @@ resources:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_service_0
         TaskDefinition: aws:ecs_task_definition:ecs_service_0
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for CPUUtilization in the ECS service
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 2
+        MetricName: CPUUtilization
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-CPUUtilization
+        Threshold: 90
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for MemoryUtilization in the ECS service
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 2
+        MetricName: MemoryUtilization
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-MemoryUtilization
+        Threshold: 90
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for any stopped tasks in the ECS service
+        ComparisonOperator: LessThanThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 1
+        MetricName: RunningTaskCount
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-RunningTaskCount
+        Threshold: 1
     aws:ecs_cluster:ecs_cluster-0:
+        ClusterSettings:
+            - Name: containerInsights
+              Value: enabled
         Tags:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_cluster-0
@@ -71,6 +122,51 @@ resources:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_service_0
         TaskRole: aws:iam_role:ecs_service_0-execution-role
+    aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+        DashboardBody:
+            Widgets:
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount#Arn
+                  Type: alarm
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-CPUUtilization#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-CPUUtilization#Arn
+                  Type: alarm
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization#Arn
+                  Type: alarm
+                  Width: 6
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
         Dockerfile: ecs_service_0-ecs_service_0.Dockerfile
@@ -289,10 +385,19 @@ resources:
 edges:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:ecs_service:ecs_service_0:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:vpc:vpc-0:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-CPUUtilization:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount:
     aws:ecs_service:ecs_service_0 -> aws:ecs_cluster:ecs_cluster-0:
     aws:ecs_service:ecs_service_0 -> aws:ecs_task_definition:ecs_service_0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-1:
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization -> aws:region:region-0:
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization -> aws:region:region-0:
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount -> aws:region:region-0:
     aws:ecs_task_definition:ecs_service_0 -> aws:ecr_image:ecs_service_0-ecs_service_0:
     aws:ecs_task_definition:ecs_service_0 -> aws:iam_role:ecs_service_0-execution-role:
     aws:ecs_task_definition:ecs_service_0 -> aws:log_group:ecs_service_0-log-group:

--- a/pkg/engine/testdata/ecs_rds.iac-viz.yaml
+++ b/pkg/engine/testdata/ecs_rds.iac-viz.yaml
@@ -1,12 +1,11 @@
 provider: aws
 resources:
-  ecs_service/ecs_service_0:
+  cloudwatch_dashboard/cloudwatch_dashboard-0:
 
-  ecs_service/ecs_service_0 -> ecs_cluster/ecs_cluster-0:
-  ecs_service/ecs_service_0 -> ecs_task_definition/ecs_service_0:
-  ecs_service/ecs_service_0 -> aws:security_group:vpc-0/ecs_service_0-security_group:
-  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-0:
-  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-1:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-cpuutilization:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-memoryutilization:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-runningtaskcount:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> region/region-0:
   route_table_association/subnet-0-subnet-0-route_table:
 
   route_table_association/subnet-0-subnet-0-route_table -> aws:route_table:vpc-0/subnet-0-route_table:
@@ -23,18 +22,18 @@ resources:
 
   route_table_association/subnet-3-subnet-3-route_table -> aws:route_table:vpc-0/subnet-3-route_table:
   route_table_association/subnet-3-subnet-3-route_table -> aws:subnet:vpc-0/subnet-3:
-  ecs_cluster/ecs_cluster-0:
+  cloudwatch_alarm/ecs_service_0-cpuutilization:
 
-  ecs_task_definition/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-cpuutilization -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-cpuutilization -> region/region-0:
+  cloudwatch_alarm/ecs_service_0-memoryutilization:
 
-  ecs_task_definition/ecs_service_0 -> ecr_image/ecs_service_0-ecs_service_0:
-  ecs_task_definition/ecs_service_0 -> iam_role/ecs_service_0-execution-role:
-  ecs_task_definition/ecs_service_0 -> log_group/ecs_service_0-log-group:
-  ecs_task_definition/ecs_service_0 -> rds_instance/rds-instance-2:
-  ecs_task_definition/ecs_service_0 -> region/region-0:
-  aws:security_group:vpc-0/ecs_service_0-security_group:
+  cloudwatch_alarm/ecs_service_0-memoryutilization -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-memoryutilization -> region/region-0:
+  cloudwatch_alarm/ecs_service_0-runningtaskcount:
 
-  aws:security_group:vpc-0/ecs_service_0-security_group -> vpc/vpc-0:
+  cloudwatch_alarm/ecs_service_0-runningtaskcount -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-runningtaskcount -> region/region-0:
   aws:route_table:vpc-0/subnet-0-route_table:
 
   aws:route_table:vpc-0/subnet-0-route_table -> aws:nat_gateway:subnet-2/subnet-0-route_table-nat_gateway:
@@ -51,14 +50,13 @@ resources:
 
   aws:route_table:vpc-0/subnet-3-route_table -> aws:internet_gateway:vpc-0/internet_gateway-0:
   aws:route_table:vpc-0/subnet-3-route_table -> vpc/vpc-0:
-  ecr_image/ecs_service_0-ecs_service_0:
+  ecs_service/ecs_service_0:
 
-  ecr_image/ecs_service_0-ecs_service_0 -> ecr_repo/ecs_service_0-ecs_service_0-ecr_repo:
-  iam_role/ecs_service_0-execution-role:
-
-  iam_role/ecs_service_0-execution-role -> rds_instance/rds-instance-2:
-  log_group/ecs_service_0-log-group:
-
+  ecs_service/ecs_service_0 -> ecs_cluster/ecs_cluster-0:
+  ecs_service/ecs_service_0 -> ecs_task_definition/ecs_service_0:
+  ecs_service/ecs_service_0 -> aws:security_group:vpc-0/ecs_service_0-security_group:
+  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-0:
+  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-1:
   aws:nat_gateway:subnet-2/subnet-0-route_table-nat_gateway:
 
   aws:nat_gateway:subnet-2/subnet-0-route_table-nat_gateway -> elastic_ip/subnet-0-route_table-nat_gateway-elastic_ip:
@@ -70,12 +68,18 @@ resources:
   aws:internet_gateway:vpc-0/internet_gateway-0:
 
   aws:internet_gateway:vpc-0/internet_gateway-0 -> vpc/vpc-0:
-  ecr_repo/ecs_service_0-ecs_service_0-ecr_repo:
+  ecs_cluster/ecs_cluster-0:
 
-  rds_instance/rds-instance-2:
+  ecs_task_definition/ecs_service_0:
 
-  rds_instance/rds-instance-2 -> rds_subnet_group/rds_subnet_group-0:
-  rds_instance/rds-instance-2 -> aws:security_group:vpc-0/rds-instance-2-security_group:
+  ecs_task_definition/ecs_service_0 -> ecr_image/ecs_service_0-ecs_service_0:
+  ecs_task_definition/ecs_service_0 -> iam_role/ecs_service_0-execution-role:
+  ecs_task_definition/ecs_service_0 -> log_group/ecs_service_0-log-group:
+  ecs_task_definition/ecs_service_0 -> rds_instance/rds-instance-2:
+  ecs_task_definition/ecs_service_0 -> region/region-0:
+  aws:security_group:vpc-0/ecs_service_0-security_group:
+
+  aws:security_group:vpc-0/ecs_service_0-security_group -> vpc/vpc-0:
   elastic_ip/subnet-0-route_table-nat_gateway-elastic_ip:
 
   aws:subnet:vpc-0/subnet-2:
@@ -88,6 +92,20 @@ resources:
 
   aws:subnet:vpc-0/subnet-3 -> aws:availability_zone:region-0/availability_zone-1:
   aws:subnet:vpc-0/subnet-3 -> vpc/vpc-0:
+  ecr_image/ecs_service_0-ecs_service_0:
+
+  ecr_image/ecs_service_0-ecs_service_0 -> ecr_repo/ecs_service_0-ecs_service_0-ecr_repo:
+  iam_role/ecs_service_0-execution-role:
+
+  iam_role/ecs_service_0-execution-role -> rds_instance/rds-instance-2:
+  log_group/ecs_service_0-log-group:
+
+  ecr_repo/ecs_service_0-ecs_service_0-ecr_repo:
+
+  rds_instance/rds-instance-2:
+
+  rds_instance/rds-instance-2 -> rds_subnet_group/rds_subnet_group-0:
+  rds_instance/rds-instance-2 -> aws:security_group:vpc-0/rds-instance-2-security_group:
   rds_subnet_group/rds_subnet_group-0:
 
   rds_subnet_group/rds_subnet_group-0 -> aws:subnet:vpc-0/subnet-0:

--- a/pkg/engine/testdata/idempotent_constraints.deployment-policy.json
+++ b/pkg/engine/testdata/idempotent_constraints.deployment-policy.json
@@ -20,6 +20,15 @@
         },
         {
             "Action": [
+                "dynamodb:CreateTable",
+                "dynamodb:DeleteTable",
+                "dynamodb:UpdateTable"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
                 "ecs:CreateCluster",
                 "ecs:DeleteCluster",
                 "ecs:UpdateClusterSettings"

--- a/pkg/engine/testdata/idempotent_constraints.expect.yaml
+++ b/pkg/engine/testdata/idempotent_constraints.expect.yaml
@@ -33,7 +33,58 @@ resources:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_service_0
         TaskDefinition: aws:ecs_task_definition:ecs_service_0
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for CPUUtilization in the ECS service
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 2
+        MetricName: CPUUtilization
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-CPUUtilization
+        Threshold: 90
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for MemoryUtilization in the ECS service
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 2
+        MetricName: MemoryUtilization
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-MemoryUtilization
+        Threshold: 90
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount:
+        ActionsEnabled: true
+        AlarmDescription: This metric checks for any stopped tasks in the ECS service
+        ComparisonOperator: LessThanThreshold
+        Dimensions:
+            ClusterName: aws:ecs_cluster:ecs_cluster-0#Id
+            ServiceName: aws:ecs_service:ecs_service_0#Name
+        EvaluationPeriods: 1
+        MetricName: RunningTaskCount
+        Namespace: AWS/ECS
+        Period: 60
+        Statistic: Average
+        Tags:
+            GLOBAL_KLOTHO_TAG: ""
+            RESOURCE_NAME: ecs_service_0-RunningTaskCount
+        Threshold: 1
     aws:ecs_cluster:ecs_cluster-0:
+        ClusterSettings:
+            - Name: containerInsights
+              Value: enabled
         Tags:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_cluster-0
@@ -73,6 +124,51 @@ resources:
             GLOBAL_KLOTHO_TAG: ""
             RESOURCE_NAME: ecs_service_0
         TaskRole: aws:iam_role:ecs_service_0-execution-role
+    aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+        DashboardBody:
+            Widgets:
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount#Arn
+                  Type: alarm
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-CPUUtilization#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-CPUUtilization#Arn
+                  Type: alarm
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Annotations:
+                        Alarms:
+                            - aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization#Arn
+                    Region: aws:region:region-0#Name
+                  Type: metric
+                  Width: 6
+                - Height: 6
+                  Properties:
+                    Alarms:
+                        - aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization#Arn
+                  Type: alarm
+                  Width: 6
     aws:ecr_image:ecs_service_0-ecs_service_0:
         Context: .
         Dockerfile: ecs_service_0-ecs_service_0.Dockerfile
@@ -291,10 +387,19 @@ resources:
 edges:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:ecs_service:ecs_service_0:
     aws:security_group:vpc-0:ecs_service_0-security_group -> aws:vpc:vpc-0:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-CPUUtilization:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization:
+    aws:ecs_service:ecs_service_0 -> aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount:
     aws:ecs_service:ecs_service_0 -> aws:ecs_cluster:ecs_cluster-0:
     aws:ecs_service:ecs_service_0 -> aws:ecs_task_definition:ecs_service_0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-0:
     aws:ecs_service:ecs_service_0 -> aws:subnet:vpc-0:subnet-1:
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-CPUUtilization -> aws:region:region-0:
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-MemoryUtilization -> aws:region:region-0:
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount -> aws:cloudwatch_dashboard:cloudwatch_dashboard-0:
+    aws:cloudwatch_alarm:ecs_service_0-RunningTaskCount -> aws:region:region-0:
     aws:ecs_task_definition:ecs_service_0 -> aws:ecr_image:ecs_service_0-ecs_service_0:
     aws:ecs_task_definition:ecs_service_0 -> aws:iam_role:ecs_service_0-execution-role:
     aws:ecs_task_definition:ecs_service_0 -> aws:log_group:ecs_service_0-log-group:

--- a/pkg/engine/testdata/idempotent_constraints.iac-viz.yaml
+++ b/pkg/engine/testdata/idempotent_constraints.iac-viz.yaml
@@ -1,12 +1,11 @@
 provider: aws
 resources:
-  ecs_service/ecs_service_0:
+  cloudwatch_dashboard/cloudwatch_dashboard-0:
 
-  ecs_service/ecs_service_0 -> ecs_cluster/ecs_cluster-0:
-  ecs_service/ecs_service_0 -> ecs_task_definition/ecs_service_0:
-  ecs_service/ecs_service_0 -> aws:security_group:vpc-0/ecs_service_0-security_group:
-  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-0:
-  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-1:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-cpuutilization:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-memoryutilization:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> cloudwatch_alarm/ecs_service_0-runningtaskcount:
+  cloudwatch_dashboard/cloudwatch_dashboard-0 -> region/region-0:
   route_table_association/subnet-0-subnet-0-route_table:
 
   route_table_association/subnet-0-subnet-0-route_table -> aws:route_table:vpc-0/subnet-0-route_table:
@@ -23,6 +22,25 @@ resources:
 
   route_table_association/subnet-3-subnet-3-route_table -> aws:route_table:vpc-0/subnet-3-route_table:
   route_table_association/subnet-3-subnet-3-route_table -> aws:subnet:vpc-0/subnet-3:
+  cloudwatch_alarm/ecs_service_0-cpuutilization:
+
+  cloudwatch_alarm/ecs_service_0-cpuutilization -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-cpuutilization -> region/region-0:
+  cloudwatch_alarm/ecs_service_0-memoryutilization:
+
+  cloudwatch_alarm/ecs_service_0-memoryutilization -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-memoryutilization -> region/region-0:
+  cloudwatch_alarm/ecs_service_0-runningtaskcount:
+
+  cloudwatch_alarm/ecs_service_0-runningtaskcount -> ecs_service/ecs_service_0:
+  cloudwatch_alarm/ecs_service_0-runningtaskcount -> region/region-0:
+  ecs_service/ecs_service_0:
+
+  ecs_service/ecs_service_0 -> ecs_cluster/ecs_cluster-0:
+  ecs_service/ecs_service_0 -> ecs_task_definition/ecs_service_0:
+  ecs_service/ecs_service_0 -> aws:security_group:vpc-0/ecs_service_0-security_group:
+  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-0:
+  ecs_service/ecs_service_0 -> aws:subnet:vpc-0/subnet-1:
   ecs_cluster/ecs_cluster-0:
 
   ecs_task_definition/ecs_service_0:

--- a/pkg/infra/iac/templates/aws/cloudfront_distribution/viewer_certificate.ts.tmpl
+++ b/pkg/infra/iac/templates/aws/cloudfront_distribution/viewer_certificate.ts.tmpl
@@ -6,7 +6,7 @@
     iamCertificateId: "{{ .IamCertificateId }}",
     {{- end }}
     {{- if and .CloudfrontDefaultCertificate (not .AcmCertificateArn) (not .IamCertificateId) }}
-    cloudfrontDefaultCertificate: "{{ .CloudfrontDefaultCertificate }}",
+    cloudfrontDefaultCertificate: {{ .CloudfrontDefaultCertificate }},
     {{- end }}
     {{- if .SslSupportMethod }}
     sslSupportMethod: "{{ .SslSupportMethod }}",

--- a/pkg/infra/iac/templates/aws/cloudwatch_alarm/factory.ts
+++ b/pkg/infra/iac/templates/aws/cloudwatch_alarm/factory.ts
@@ -1,0 +1,90 @@
+import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
+
+interface Args {
+    Name: string
+    ComparisonOperator: string
+    EvaluationPeriods: number
+    ActionsEnabled: boolean
+    AlarmActions: string[]
+    AlarmDescription: string
+    DatapointsToAlarm: string
+    Dimensions: ModelCaseWrapper<Record<string, string>>
+    ExtendedStatistic: string
+    InsufficientDataActions: string[]
+    MetricName: string
+    Namespace: string
+    OKActions: string[]
+    Period: number
+    Statistic: string
+    Threshold: number
+    TreatMissingData: string
+    Unit: string
+    Tags: ModelCaseWrapper<Record<string, string>>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.cloudwatch.MetricAlarm {
+    return new aws.cloudwatch.MetricAlarm(args.Name, {
+        //TMPL {{- if .ComparisonOperator }}
+        comparisonOperator: args.ComparisonOperator,
+        //TMPL {{- end }}
+        //TMPL {{- if .EvaluationPeriods }}
+        evaluationPeriods: args.EvaluationPeriods,
+        //TMPL {{- end }}
+        //TMPL {{- if .ActionsEnabled }}
+        actionsEnabled: args.ActionsEnabled,
+        //TMPL {{- end }}
+        //TMPL {{- if .AlarmActions }}
+        alarmActions: args.AlarmActions,
+        //TMPL {{- end }}
+        //TMPL {{- if .AlarmDescription }}
+        alarmDescription: args.AlarmDescription,
+        //TMPL {{- end }}
+        //TMPL {{- if .DatapointsToAlarm }}
+        datapointsToAlarm: args.DatapointsToAlarm,
+        //TMPL {{- end }}
+        //TMPL {{- if .Dimensions }}
+        dimensions: args.Dimensions,
+        //TMPL {{- end }}
+        //TMPL {{- if .ExtendedStatistic }}
+        extendedStatistic: args.ExtendedStatistic,
+        //TMPL {{- end }}
+        //TMPL {{- if .InsufficientDataActions }}
+        insufficientDataActions: args.InsufficientDataActions,
+        //TMPL {{- end }}
+        //TMPL {{- if .MetricName }}
+        metricName: args.MetricName,
+        //TMPL {{- end }}
+        //TMPL {{- if .Namespace }}
+        namespace: args.Namespace,
+        //TMPL {{- end }}
+        //TMPL {{- if .OKActions }}
+        okActions: args.OKActions,
+        //TMPL {{- end }}
+        //TMPL {{- if .Period }}
+        period: args.Period,
+        //TMPL {{- end }}
+        //TMPL {{- if .Statistic }}
+        statistic: args.Statistic,
+        //TMPL {{- end }}
+        //TMPL {{- if .Threshold }}
+        threshold: args.Threshold,
+        //TMPL {{- end }}
+        //TMPL {{- if .TreatMissingData }}
+        treatMissingData: args.TreatMissingData,
+        //TMPL {{- end }}
+        //TMPL {{- if .Unit }}
+        unit: args.Unit,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
+}
+
+function properties(object: aws.cloudwatch.MetricAlarm, args: Args) {
+    return {
+        Arn: object.arn,
+    }
+}

--- a/pkg/infra/iac/templates/aws/cloudwatch_alarm/package.json
+++ b/pkg/infra/iac/templates/aws/cloudwatch_alarm/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "cloudwatch_alarm",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/infra/iac/templates/aws/cloudwatch_dashboard/factory.ts
+++ b/pkg/infra/iac/templates/aws/cloudwatch_dashboard/factory.ts
@@ -1,0 +1,22 @@
+import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
+import { ModelCaseWrapper } from '../../wrappers'
+
+interface Args {
+    Name: string
+    DashboardBody: Record<string, any>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.cloudwatch.Dashboard {
+    return new aws.cloudwatch.Dashboard(args.Name, {
+        dashboardName: args.Name,
+        dashboardBody: pulumi.jsonStringify(args.DashboardBody),
+    })
+}
+
+function properties(object: aws.cloudwatch.Dashboard, args: Args) {
+    return {
+        Arn: object.dashboardArn,
+    }
+}

--- a/pkg/infra/iac/templates/aws/cloudwatch_dashboard/package.json
+++ b/pkg/infra/iac/templates/aws/cloudwatch_dashboard/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "cloudwatch_dashboard",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0",
+        "@pulumi/pulumi": "^3.69.0"
+    }
+}

--- a/pkg/infra/iac/templates/aws/ecs_cluster/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_cluster/factory.ts
@@ -1,8 +1,11 @@
 import * as aws from '@pulumi/aws'
 import { ModelCaseWrapper } from '../../wrappers'
+import * as awsInputs from '@pulumi/aws/types/input'
 
 interface Args {
     Name: string
+    ClusterSettings?: awsInputs.ecs.ClusterSetting[]
+    ServiceConnectDefaults: awsInputs.ecs.ClusterServiceConnectDefaults
     Tags: ModelCaseWrapper<Record<string, string>>
     Id?: string
 }
@@ -10,6 +13,12 @@ interface Args {
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.ecs.Cluster {
     return new aws.ecs.Cluster(args.Name, {
+        //TMPL {{- if .ClusterSettings }}
+        settings: args.ClusterSettings,
+        //TMPL {{- end }}
+        //TMPL {{- if .ServiceConnectDefaults }}
+        serviceConnectDefaults: args.ServiceConnectDefaults,
+        //TMPL {{- end }}
         //TMPL {{- if .Tags }}
         tags: args.Tags,
         //TMPL {{- end }}

--- a/pkg/infra/iac/templates/aws/ecs_service/factory.ts
+++ b/pkg/infra/iac/templates/aws/ecs_service/factory.ts
@@ -82,3 +82,10 @@ function create(args: Args): aws.ecs.Service {
         { dependsOn: args.dependsOn }
     )
 }
+
+function properties(object: aws.cloudwatch.MetricAlarm, args: Args) {
+    return {
+        Arn: object.arn,
+        Name: object.name,
+    }
+}

--- a/pkg/infra/iac/templates/aws/lambda_function/factory.ts
+++ b/pkg/infra/iac/templates/aws/lambda_function/factory.ts
@@ -65,3 +65,7 @@ function properties(object: aws.lambda.Function, args: Args) {
         Arn: object.arn,
     }
 }
+
+function importResource(args: Args): aws.lambda.Function {
+    return aws.lambda.Function.get(args.Name, args.Id)
+}

--- a/pkg/infra/iac/templates/aws/sns_topic/factory.ts
+++ b/pkg/infra/iac/templates/aws/sns_topic/factory.ts
@@ -31,83 +31,80 @@ interface Args {
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.sns.Topic {
-    return new aws.sns.Topic(
-        args.Name,
-        {
-            //TMPL {{- if .ApplicationFailureFeedbackRoleArn }}
-            applicationFailureFeedbackRoleArn: args.ApplicationFailureFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .ApplicationSuccessFeedbackRoleArn }}
-            applicationSuccessFeedbackRoleArn: args.ApplicationSuccessFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .ApplicationSuccessFeedbackSampleRate }}
-            applicationSuccessFeedbackSampleRate: args.ApplicationSuccessFeedbackSampleRate,
-            //TMPL {{- end }}
-            //TMPL {{- if .ArchivePolicy }}
-            archivePolicy: args.ArchivePolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .ContentBasedDeduplication }}
-            contentBasedDeduplication: args.ContentBasedDeduplication,
-            //TMPL {{- end }}
-            //TMPL {{- if .DeliveryPolicy }}
-            deliveryPolicy: args.DeliveryPolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .FifoTopic }}
-            fifoTopic: args.FifoTopic,
-            //TMPL {{- end }}
-            //TMPL {{- if .FirehoseFailureFeedbackRoleArn }}
-            firehoseFailureFeedbackRoleArn: args.FirehoseFailureFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .FirehoseSuccessFeedbackRoleArn }}
-            firehoseSuccessFeedbackRoleArn: args.FirehoseSuccessFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .FirehoseSuccessFeedbackSampleRate }}
-            firehoseSuccessFeedbackSampleRate: args.FirehoseSuccessFeedbackSampleRate,
-            //TMPL {{- end }}
-            //TMPL {{- if .HttpFailureFeedbackRoleArn }}
-            httpFailureFeedbackRoleArn: args.HttpFailureFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .HttpSuccessFeedbackRoleArn }}
-            httpSuccessFeedbackRoleArn: args.HttpSuccessFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .HttpSuccessFeedbackSampleRate }}
-            httpSuccessFeedbackSampleRate: args.HttpSuccessFeedbackSampleRate,
-            //TMPL {{- end }}
-            //TMPL {{- if .KmsMasterKeyId }}
-            kmsMasterKeyId: args.KmsMasterKeyId,
-            //TMPL {{- end }}
-            //TMPL {{- if .LambdaFailureFeedbackRoleArn }}
-            lambdaFailureFeedbackRoleArn: args.LambdaFailureFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .LambdaSuccessFeedbackRoleArn }}
-            lambdaSuccessFeedbackRoleArn: args.LambdaSuccessFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .LambdaSuccessFeedbackSampleRate }}
-            lambdaSuccessFeedbackSampleRate: args.LambdaSuccessFeedbackSampleRate,
-            //TMPL {{- end }}
-            //TMPL {{- if .Policy }}
-            policy: args.Policy,
-            //TMPL {{- end }}
-            //TMPL {{- if .SignatureVersion }}
-            signatureVersion: args.SignatureVersion,
-            //TMPL {{- end }}
-            //TMPL {{- if .SqsFailureFeedbackRoleArn }}
-            sqsFailureFeedbackRoleArn: args.SqsFailureFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .SqsSuccessFeedbackRoleArn }}
-            sqsSuccessFeedbackRoleArn: args.SqsSuccessFeedbackRoleArn,
-            //TMPL {{- end }}
-            //TMPL {{- if .SqsSuccessFeedbackSampleRate }}
-            sqsSuccessFeedbackSampleRate: args.SqsSuccessFeedbackSampleRate,
-            //TMPL {{- end }}
-            //TMPL {{- if .TracingConfig }}
-            tracingConfig: args.TracingConfig,
-            //TMPL {{- end }}
-            //TMPL {{- if .Tags }}
-            tags: args.Tags,
-            //TMPL {{- end }}
-        },
-    )
+    return new aws.sns.Topic(args.Name, {
+        //TMPL {{- if .ApplicationFailureFeedbackRoleArn }}
+        applicationFailureFeedbackRoleArn: args.ApplicationFailureFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .ApplicationSuccessFeedbackRoleArn }}
+        applicationSuccessFeedbackRoleArn: args.ApplicationSuccessFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .ApplicationSuccessFeedbackSampleRate }}
+        applicationSuccessFeedbackSampleRate: args.ApplicationSuccessFeedbackSampleRate,
+        //TMPL {{- end }}
+        //TMPL {{- if .ArchivePolicy }}
+        archivePolicy: args.ArchivePolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .ContentBasedDeduplication }}
+        contentBasedDeduplication: args.ContentBasedDeduplication,
+        //TMPL {{- end }}
+        //TMPL {{- if .DeliveryPolicy }}
+        deliveryPolicy: args.DeliveryPolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .FifoTopic }}
+        fifoTopic: args.FifoTopic,
+        //TMPL {{- end }}
+        //TMPL {{- if .FirehoseFailureFeedbackRoleArn }}
+        firehoseFailureFeedbackRoleArn: args.FirehoseFailureFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .FirehoseSuccessFeedbackRoleArn }}
+        firehoseSuccessFeedbackRoleArn: args.FirehoseSuccessFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .FirehoseSuccessFeedbackSampleRate }}
+        firehoseSuccessFeedbackSampleRate: args.FirehoseSuccessFeedbackSampleRate,
+        //TMPL {{- end }}
+        //TMPL {{- if .HttpFailureFeedbackRoleArn }}
+        httpFailureFeedbackRoleArn: args.HttpFailureFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .HttpSuccessFeedbackRoleArn }}
+        httpSuccessFeedbackRoleArn: args.HttpSuccessFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .HttpSuccessFeedbackSampleRate }}
+        httpSuccessFeedbackSampleRate: args.HttpSuccessFeedbackSampleRate,
+        //TMPL {{- end }}
+        //TMPL {{- if .KmsMasterKeyId }}
+        kmsMasterKeyId: args.KmsMasterKeyId,
+        //TMPL {{- end }}
+        //TMPL {{- if .LambdaFailureFeedbackRoleArn }}
+        lambdaFailureFeedbackRoleArn: args.LambdaFailureFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .LambdaSuccessFeedbackRoleArn }}
+        lambdaSuccessFeedbackRoleArn: args.LambdaSuccessFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .LambdaSuccessFeedbackSampleRate }}
+        lambdaSuccessFeedbackSampleRate: args.LambdaSuccessFeedbackSampleRate,
+        //TMPL {{- end }}
+        //TMPL {{- if .Policy }}
+        policy: args.Policy,
+        //TMPL {{- end }}
+        //TMPL {{- if .SignatureVersion }}
+        signatureVersion: args.SignatureVersion,
+        //TMPL {{- end }}
+        //TMPL {{- if .SqsFailureFeedbackRoleArn }}
+        sqsFailureFeedbackRoleArn: args.SqsFailureFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .SqsSuccessFeedbackRoleArn }}
+        sqsSuccessFeedbackRoleArn: args.SqsSuccessFeedbackRoleArn,
+        //TMPL {{- end }}
+        //TMPL {{- if .SqsSuccessFeedbackSampleRate }}
+        sqsSuccessFeedbackSampleRate: args.SqsSuccessFeedbackSampleRate,
+        //TMPL {{- end }}
+        //TMPL {{- if .TracingConfig }}
+        tracingConfig: args.TracingConfig,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
 }
 
 function properties(object: aws.sns.Topic, args: Args) {

--- a/pkg/infra/iac/templates/aws/sns_topic/factory.ts
+++ b/pkg/infra/iac/templates/aws/sns_topic/factory.ts
@@ -1,0 +1,122 @@
+import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
+
+interface Args {
+    Name: string
+    ApplicationFailureFeedbackRoleArn: string
+    ApplicationSuccessFeedbackRoleArn: string
+    ApplicationSuccessFeedbackSampleRate: number
+    ArchivePolicy: string
+    ContentBasedDeduplication: boolean
+    DeliveryPolicy: string
+    FifoTopic: boolean
+    FirehoseFailureFeedbackRoleArn: string
+    FirehoseSuccessFeedbackRoleArn: string
+    FirehoseSuccessFeedbackSampleRate: number
+    HttpFailureFeedbackRoleArn: string
+    HttpSuccessFeedbackRoleArn: string
+    HttpSuccessFeedbackSampleRate: number
+    KmsMasterKeyId: string
+    LambdaFailureFeedbackRoleArn: string
+    LambdaSuccessFeedbackRoleArn: string
+    LambdaSuccessFeedbackSampleRate: number
+    Policy: string
+    SignatureVersion: number
+    SqsFailureFeedbackRoleArn: string
+    SqsSuccessFeedbackRoleArn: string
+    SqsSuccessFeedbackSampleRate: number
+    TracingConfig: string
+    Tags: ModelCaseWrapper<Record<string, string>>
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.sns.Topic {
+    return new aws.sns.Topic(
+        args.Name,
+        {
+            //TMPL {{- if .ApplicationFailureFeedbackRoleArn }}
+            applicationFailureFeedbackRoleArn: args.ApplicationFailureFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .ApplicationSuccessFeedbackRoleArn }}
+            applicationSuccessFeedbackRoleArn: args.ApplicationSuccessFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .ApplicationSuccessFeedbackSampleRate }}
+            applicationSuccessFeedbackSampleRate: args.ApplicationSuccessFeedbackSampleRate,
+            //TMPL {{- end }}
+            //TMPL {{- if .ArchivePolicy }}
+            archivePolicy: args.ArchivePolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .ContentBasedDeduplication }}
+            contentBasedDeduplication: args.ContentBasedDeduplication,
+            //TMPL {{- end }}
+            //TMPL {{- if .DeliveryPolicy }}
+            deliveryPolicy: args.DeliveryPolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .FifoTopic }}
+            fifoTopic: args.FifoTopic,
+            //TMPL {{- end }}
+            //TMPL {{- if .FirehoseFailureFeedbackRoleArn }}
+            firehoseFailureFeedbackRoleArn: args.FirehoseFailureFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .FirehoseSuccessFeedbackRoleArn }}
+            firehoseSuccessFeedbackRoleArn: args.FirehoseSuccessFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .FirehoseSuccessFeedbackSampleRate }}
+            firehoseSuccessFeedbackSampleRate: args.FirehoseSuccessFeedbackSampleRate,
+            //TMPL {{- end }}
+            //TMPL {{- if .HttpFailureFeedbackRoleArn }}
+            httpFailureFeedbackRoleArn: args.HttpFailureFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .HttpSuccessFeedbackRoleArn }}
+            httpSuccessFeedbackRoleArn: args.HttpSuccessFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .HttpSuccessFeedbackSampleRate }}
+            httpSuccessFeedbackSampleRate: args.HttpSuccessFeedbackSampleRate,
+            //TMPL {{- end }}
+            //TMPL {{- if .KmsMasterKeyId }}
+            kmsMasterKeyId: args.KmsMasterKeyId,
+            //TMPL {{- end }}
+            //TMPL {{- if .LambdaFailureFeedbackRoleArn }}
+            lambdaFailureFeedbackRoleArn: args.LambdaFailureFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .LambdaSuccessFeedbackRoleArn }}
+            lambdaSuccessFeedbackRoleArn: args.LambdaSuccessFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .LambdaSuccessFeedbackSampleRate }}
+            lambdaSuccessFeedbackSampleRate: args.LambdaSuccessFeedbackSampleRate,
+            //TMPL {{- end }}
+            //TMPL {{- if .Policy }}
+            policy: args.Policy,
+            //TMPL {{- end }}
+            //TMPL {{- if .SignatureVersion }}
+            signatureVersion: args.SignatureVersion,
+            //TMPL {{- end }}
+            //TMPL {{- if .SqsFailureFeedbackRoleArn }}
+            sqsFailureFeedbackRoleArn: args.SqsFailureFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .SqsSuccessFeedbackRoleArn }}
+            sqsSuccessFeedbackRoleArn: args.SqsSuccessFeedbackRoleArn,
+            //TMPL {{- end }}
+            //TMPL {{- if .SqsSuccessFeedbackSampleRate }}
+            sqsSuccessFeedbackSampleRate: args.SqsSuccessFeedbackSampleRate,
+            //TMPL {{- end }}
+            //TMPL {{- if .TracingConfig }}
+            tracingConfig: args.TracingConfig,
+            //TMPL {{- end }}
+            //TMPL {{- if .Tags }}
+            tags: args.Tags,
+            //TMPL {{- end }}
+        },
+    )
+}
+
+function properties(object: aws.sns.Topic, args: Args) {
+    return {
+        Arn: object.arn,
+        ID: object.id,
+    }
+}
+
+function importResource(args: Args): aws.sns.Topic {
+    return aws.sns.Topic.get(args.Name, args.Id)
+}

--- a/pkg/infra/iac/templates/aws/sns_topic/package.json
+++ b/pkg/infra/iac/templates/aws/sns_topic/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "sns_topic",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/infra/iac/templates/aws/sns_topic_subscription/factory.ts
+++ b/pkg/infra/iac/templates/aws/sns_topic_subscription/factory.ts
@@ -19,41 +19,38 @@ interface Args {
 
 // noinspection JSUnusedLocalSymbols
 function create(args: Args): aws.sns.TopicSubscription {
-    return new aws.sns.TopicSubscription(
-        args.Name,
-        {
-            endpoint: args.Endpoint,
-            protocol: args.Protocol,
-            topic: args.Topic,
-            //TMPL {{- if .ConfirmationTimeoutInMinutes }}
-            confirmationTimeoutInMinutes: args.ConfirmationTimeoutInMinutes,
-            //TMPL {{- end }}
-            //TMPL {{- if .DeliveryPolicy }}
-            deliveryPolicy: args.DeliveryPolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .EndpointAutoConfirms }}
-            endpointAutoConfirms: args.EndpointAutoConfirms,
-            //TMPL {{- end }}
-            //TMPL {{- if .FilterPolicy }}
-            filterPolicy: args.FilterPolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .FilterPolicyScope }}
-            filterPolicyScope: args.FilterPolicyScope,
-            //TMPL {{- end }}
-            //TMPL {{- if .RawMessageDelivery }}
-            rawMessageDelivery: args.RawMessageDelivery,
-            //TMPL {{- end }}
-            //TMPL {{- if .RedrivePolicy }}
-            redrivePolicy: args.RedrivePolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .ReplayPolicy }}
-            replayPolicy: args.ReplayPolicy,
-            //TMPL {{- end }}
-            //TMPL {{- if .SubscriptionRoleArn }}
-            subscriptionRoleArn: args.SubscriptionRoleArn,
-            //TMPL {{- end }}            
-        },
-    )
+    return new aws.sns.TopicSubscription(args.Name, {
+        endpoint: args.Endpoint,
+        protocol: args.Protocol,
+        topic: args.Topic,
+        //TMPL {{- if .ConfirmationTimeoutInMinutes }}
+        confirmationTimeoutInMinutes: args.ConfirmationTimeoutInMinutes,
+        //TMPL {{- end }}
+        //TMPL {{- if .DeliveryPolicy }}
+        deliveryPolicy: args.DeliveryPolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .EndpointAutoConfirms }}
+        endpointAutoConfirms: args.EndpointAutoConfirms,
+        //TMPL {{- end }}
+        //TMPL {{- if .FilterPolicy }}
+        filterPolicy: args.FilterPolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .FilterPolicyScope }}
+        filterPolicyScope: args.FilterPolicyScope,
+        //TMPL {{- end }}
+        //TMPL {{- if .RawMessageDelivery }}
+        rawMessageDelivery: args.RawMessageDelivery,
+        //TMPL {{- end }}
+        //TMPL {{- if .RedrivePolicy }}
+        redrivePolicy: args.RedrivePolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .ReplayPolicy }}
+        replayPolicy: args.ReplayPolicy,
+        //TMPL {{- end }}
+        //TMPL {{- if .SubscriptionRoleArn }}
+        subscriptionRoleArn: args.SubscriptionRoleArn,
+        //TMPL {{- end }}
+    })
 }
 
 function properties(object: aws.sns.TopicSubscription, args: Args) {

--- a/pkg/infra/iac/templates/aws/sns_topic_subscription/factory.ts
+++ b/pkg/infra/iac/templates/aws/sns_topic_subscription/factory.ts
@@ -1,0 +1,63 @@
+import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
+
+interface Args {
+    Name: string
+    Endpoint: string
+    Protocol: string
+    Topic: string
+    ConfirmationTimeoutInMinutes: number
+    DeliveryPolicy: string
+    EndpointAutoConfirms: boolean
+    FilterPolicy: string
+    FilterPolicyScope: string
+    RawMessageDelivery: boolean
+    RedrivePolicy: string
+    ReplayPolicy: string
+    SubscriptionRoleArn: string
+}
+
+// noinspection JSUnusedLocalSymbols
+function create(args: Args): aws.sns.TopicSubscription {
+    return new aws.sns.TopicSubscription(
+        args.Name,
+        {
+            endpoint: args.Endpoint,
+            protocol: args.Protocol,
+            topic: args.Topic,
+            //TMPL {{- if .ConfirmationTimeoutInMinutes }}
+            confirmationTimeoutInMinutes: args.ConfirmationTimeoutInMinutes,
+            //TMPL {{- end }}
+            //TMPL {{- if .DeliveryPolicy }}
+            deliveryPolicy: args.DeliveryPolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .EndpointAutoConfirms }}
+            endpointAutoConfirms: args.EndpointAutoConfirms,
+            //TMPL {{- end }}
+            //TMPL {{- if .FilterPolicy }}
+            filterPolicy: args.FilterPolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .FilterPolicyScope }}
+            filterPolicyScope: args.FilterPolicyScope,
+            //TMPL {{- end }}
+            //TMPL {{- if .RawMessageDelivery }}
+            rawMessageDelivery: args.RawMessageDelivery,
+            //TMPL {{- end }}
+            //TMPL {{- if .RedrivePolicy }}
+            redrivePolicy: args.RedrivePolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .ReplayPolicy }}
+            replayPolicy: args.ReplayPolicy,
+            //TMPL {{- end }}
+            //TMPL {{- if .SubscriptionRoleArn }}
+            subscriptionRoleArn: args.SubscriptionRoleArn,
+            //TMPL {{- end }}            
+        },
+    )
+}
+
+function properties(object: aws.sns.TopicSubscription, args: Args) {
+    return {
+        ID: object.id,
+    }
+}

--- a/pkg/infra/iac/templates/aws/sns_topic_subscription/package.json
+++ b/pkg/infra/iac/templates/aws/sns_topic_subscription/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "sns_topic",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/infra/iac/templates/aws/sqs_queue/factory.ts
+++ b/pkg/infra/iac/templates/aws/sqs_queue/factory.ts
@@ -43,3 +43,7 @@ function properties(object: aws.sqs.Queue, args: Args) {
         Arn: object.arn,
     }
 }
+
+function importResource(args: Args): aws.sqs.Queue {
+    return aws.sqs.Queue.get(args.Name, args.Id)
+}

--- a/pkg/infra/state_reader/state_template/mappings/pulumi/lambda_function.yaml
+++ b/pkg/infra/state_reader/state_template/mappings/pulumi/lambda_function.yaml
@@ -1,0 +1,10 @@
+qualified_type_name: aws:lambda_function
+iac_qualified_type: aws:lambda/function:Function
+
+property_mappings:
+  arn: Arn
+  id: Id
+  tags: Tags
+  memorySize: MemorySize
+  timeout: Timeout
+  name: Name

--- a/pkg/infra/state_reader/state_template/mappings/pulumi/sns_topic.yaml
+++ b/pkg/infra/state_reader/state_template/mappings/pulumi/sns_topic.yaml
@@ -1,0 +1,7 @@
+qualified_type_name: aws:sns_topic
+iac_qualified_type: aws:sns/topic:Topic
+
+property_mappings:
+  arn: Arn
+  id: Id
+  tags: Tags

--- a/pkg/infra/state_reader/state_template/mappings/pulumi/sqs_queue.yaml
+++ b/pkg/infra/state_reader/state_template/mappings/pulumi/sqs_queue.yaml
@@ -1,0 +1,11 @@
+qualified_type_name: aws:sqs_queue
+iac_qualified_type: aws:sqs/queue:Queue
+
+property_mappings:
+  arn: Arn
+  id: Id
+  tags: Tags
+  delaySeconds: DelaySeconds
+  fifoQueue: FifoQueue
+  maxMessageSize: MaxMessageSize
+  visibilityTimeoutSeconds: VisibilityTimeoutSeconds

--- a/pkg/provider/aws/aws_resource_test.go
+++ b/pkg/provider/aws/aws_resource_test.go
@@ -31,6 +31,8 @@ var (
 		"aws:api_resource",
 		"aws:ses_email_identity",
 		"aws:ecs_cluster_capacity_provider",
+		"aws:sns_topic_subscription",
+		"aws:cloudwatch_dashboard",
 	}
 )
 

--- a/pkg/templates/aws/edges/cloudwatch_alarm-cloudwatch_dashboard.yaml
+++ b/pkg/templates/aws/edges/cloudwatch_alarm-cloudwatch_dashboard.yaml
@@ -1,0 +1,20 @@
+source: aws:cloudwatch_alarm
+target: aws:cloudwatch_dashboard
+deployment_order_reversed: true
+
+operational_rules:
+  - configuration_rules:
+    - resource: '{{ .Target }}'
+      configuration:
+        field: DashboardBody.Widgets
+        value:
+          - Type: 'metric'
+            Properties:
+              Region: '{{ fieldRef "Name" (downstream "aws:region" .Source) }}' 
+              Annotations:
+                Alarms:
+                  - '{{ fieldRef "Arn" .Source }}'
+          - Type: 'alarm'
+            Properties:
+              Alarms:
+                - '{{ fieldRef "Arn" .Source }}'

--- a/pkg/templates/aws/edges/cloudwatch_alarm-region.yaml
+++ b/pkg/templates/aws/edges/cloudwatch_alarm-region.yaml
@@ -1,0 +1,2 @@
+source: aws:cloudwatch_alarm
+target: aws:region

--- a/pkg/templates/aws/edges/cloudwatch_alarm-sns_topic.yaml
+++ b/pkg/templates/aws/edges/cloudwatch_alarm-sns_topic.yaml
@@ -1,0 +1,24 @@
+source: aws:cloudwatch_alarm
+target: aws:sns_topic
+
+operational_rules:
+  - configuration_rules:
+    - resource: '{{.Source}}'
+      configuration:
+        field: AlarmActions
+        value: 
+          - '{{ fieldRef "Arn" .Target }}'
+    - resource: '{{.Source}}'
+      configuration:
+        field: InsufficientDataActions
+        value: 
+          - '{{ fieldRef "Arn" .Target }}'
+    - resource: '{{.Source}}'
+      configuration:
+        field: OKActions
+        value: 
+          - '{{ fieldRef "Arn" .Target }}'
+
+classification:
+  - network
+  - permissions

--- a/pkg/templates/aws/edges/cloudwatch_alarm.yaml
+++ b/pkg/templates/aws/edges/cloudwatch_alarm.yaml
@@ -1,0 +1,6 @@
+resource: aws:cloudwatch_alarm
+deployment_order_reversed: true
+
+sources:
+  - aws:ecs_service
+  - aws:lambda_function

--- a/pkg/templates/aws/edges/lambda_event_source_mapping-lambda_function.yaml
+++ b/pkg/templates/aws/edges/lambda_event_source_mapping-lambda_function.yaml
@@ -1,5 +1,8 @@
 source: aws:lambda_event_source_mapping
 target: aws:lambda_function
 
-unique:
-  Destination: true
+unique: many-to-one
+
+classification:
+  - network
+  - permissions

--- a/pkg/templates/aws/edges/sns_topic-lambda_permission.yaml
+++ b/pkg/templates/aws/edges/sns_topic-lambda_permission.yaml
@@ -1,0 +1,20 @@
+source: aws:sns_topic
+target: aws:lambda_permission
+deployment_order_reversed: true
+unique: one_to_many
+
+operational_rules:
+  - configuration_rules:
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Source
+          value: |
+            {{ fieldRef "Arn" .Source }}
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Principal
+          value: sns.amazonaws.com
+      - resource: '{{ .Target }}'
+        configuration:
+          field: Action
+          value: lambda:InvokeFunction

--- a/pkg/templates/aws/edges/sns_topic-sns_topic_subscription.yaml
+++ b/pkg/templates/aws/edges/sns_topic-sns_topic_subscription.yaml
@@ -1,0 +1,11 @@
+source: aws:sns_topic
+target: aws:sns_topic_subscription
+deployment_order_reversed: true
+unique: one_to_many
+
+operational_rules:
+  - configuration_rules:
+    - resource: '{{ .Target }}'
+      configuration:
+        field: Topic
+        value: '{{ fieldRef "Arn" .Source }}'

--- a/pkg/templates/aws/edges/sns_topic_subscription-lambda_function.yaml
+++ b/pkg/templates/aws/edges/sns_topic_subscription-lambda_function.yaml
@@ -1,0 +1,17 @@
+source: aws:sns_topic_subscription
+target: aws:lambda_function
+unique: many_to_one
+
+operational_rules:
+  - configuration_rules:
+    - resource: '{{ .Source }}'
+      configuration:
+        field: Endpoint
+        value: '{{ fieldRef "Arn" .Target }}'
+    - resource: '{{ .Source }}'
+      configuration:
+        field: Protocol
+        value: lambda
+
+classification:
+  - network

--- a/pkg/templates/aws/edges/sqs_queue-iam_role.yaml
+++ b/pkg/templates/aws/edges/sqs_queue-iam_role.yaml
@@ -14,6 +14,7 @@ operational_rules:
                   - Action:
                       - sqs:ReceiveMessage
                       - sqs:DeleteMessage
+                      - sqs:GetQueueAttributes
                     Effect: Allow
                     Resource:
                       - '{{ .Source  }}#Arn'

--- a/pkg/templates/aws/edges/sqs_queue-lambda_event_source_mapping.yaml
+++ b/pkg/templates/aws/edges/sqs_queue-lambda_event_source_mapping.yaml
@@ -12,3 +12,8 @@ operational_rules:
         direction: upstream
         resources:
           - '{{ .Source }}'
+    configuration_rules: 
+      - resource: '{{ .Source }}'
+        configuration:
+          field: VisibilityTimeout
+          value: '{{ add (fieldValue "Timeout" (downstream "aws:lambda_function" .Target)) 10 }}'

--- a/pkg/templates/aws/resources/cloudwatch_alarm.yaml
+++ b/pkg/templates/aws/resources/cloudwatch_alarm.yaml
@@ -1,0 +1,102 @@
+qualified_type_name: aws:cloudwatch_alarm
+display_name: Cloudwatch Alarm
+
+properties:
+  ComparisonOperator:
+    type: string
+    required: true
+    description: The arithmetic operation to use when comparing the specified Statistic and Threshold
+    allowed_values:
+        - GreaterThanOrEqualToThreshold
+        - GreaterThanThreshold
+        - LessThanThreshold
+        - LessThanOrEqualToThreshold
+  EvaluationPeriods:
+    type: int
+    required: true
+    description: The number of periods over which data is compared to the specified threshold
+  ActionsEnabled:
+    type: bool
+    default_value: true
+    description: Indicates whether or not actions should be executed during any changes to the alarm's state
+  AlarmActions:
+    type: list(string)
+    description: The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN)
+  AlarmDescription:
+    type: string
+    description: The description for the alarm
+  DatapointsToAlarm:
+    type: string
+    description: The number of data points that must be breaching to trigger the alarm
+  Dimensions:
+    type: map(string,string)
+    description: The dimensions for the alarm's associated metric
+  ExtendedStatistic:
+    type: string
+    description: The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100.
+  InsufficientDataActions:
+    type: list(string)
+    description: The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN)
+  MetricName:
+    type: string
+    description: The name for the alarm's associated metric
+  Namespace:
+    type: string
+    description: The namespace for the alarm's associated metric
+  OKActions:
+    type: list(string)
+    description: The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)
+  Period:
+    type: int
+    description: The period in seconds over which the specified Statistic is applied. Valid values are 10, 30, or any multiple of 60.
+  Statistic:
+    type: string
+    description: The statistic to apply to the alarm's associated metric
+    allowed_values:
+        - SampleCount
+        - Average
+        - Sum
+        - Minimum
+        - Maximum
+  Threshold:
+    type: int
+    description: The value against which the specified Statistic is compared
+  TreatMissingData:
+    type: string
+    description: Sets how this alarm is to handle missing data points
+    allowed_values:
+        - breaching
+        - notBreaching
+        - ignore
+        - missing
+  Unit:
+    type: string
+    description: The unit for the alarm's associated metric
+  aws:tags:
+    type: model
+  Arn:
+    type: string
+    configuration_disabled: true
+    deploy_time: true
+
+additional_rules:
+  - steps:
+      - direction: downstream
+        resources:
+          - aws:cloudwatch_dashboard
+      - direction: downstream
+        resources:
+          - aws:region
+
+classification:
+  is:
+    - alarm
+    - monitoring
+
+
+
+
+deployment_permissions:
+  deploy: ["dynamodb:CreateTable"]
+  tear_down: ["dynamodb:DeleteTable"]
+  update: ["dynamodb:UpdateTable"]

--- a/pkg/templates/aws/resources/cloudwatch_dashboard.yaml
+++ b/pkg/templates/aws/resources/cloudwatch_dashboard.yaml
@@ -1,0 +1,78 @@
+qualified_type_name: aws:cloudwatch_dashboard
+display_name: Cloudwatch Dashboard
+
+properties:
+  DashboardBody:
+    type: map
+    description: The number of periods over which data is compared to the specified threshold
+    properties:
+      Widgets:
+        type: list
+        required: true
+        description: The type of widget to display
+        properties:
+          Type:
+            type: string
+            required: true
+            description: The type of widget
+            allowed_values:
+              - metric
+              - text
+              - log
+              - alarm
+              - explorer
+          X:
+            type: int
+            description: The horizontal position of the widget on the 24-column dashboard grid. The default is the next available position.
+            min_value: 0
+            max_value: 23
+          Y:
+            type: int
+            description: The vertical position of the widget on the 24-column dashboard grid. The default is the next available position.
+            min_value: 0
+            max_value: 23
+          Width:
+            type: int
+            description: The width of the widget in grid units (in a 24-column grid).
+            min_value: 1
+            max_value: 24
+            default_value: 6
+          Height:
+            type: int
+            description: The height of the widget in grid units (in a 24-column grid).
+            min_value: 1
+            max_value: 1000
+            default_value: 6
+          Properties:
+            type: map
+            properties:
+              Annotations:
+                type: map
+                properties:
+                  Alarms:
+                    type: list(string)
+                    description: The list of alarms to display in the widget, if applicable. If you specify an alarm annotation, you cannot also specify a metrics array in the same widget.
+              Region:
+                type: string
+                description: The region of the metric.
+              Alarms:
+                type: list(string)
+                description: The list of alarms to display in the widget, if applicable (only for alarm widgets).
+  Arn:
+    type: string
+    configuration_disabled: true
+    deploy_time: true
+
+
+classification:
+  is:
+    - alarm
+    - monitoring
+
+
+
+
+deployment_permissions:
+  deploy: ["dynamodb:CreateTable"]
+  tear_down: ["dynamodb:DeleteTable"]
+  update: ["dynamodb:UpdateTable"]

--- a/pkg/templates/aws/resources/ecs_cluster.yaml
+++ b/pkg/templates/aws/resources/ecs_cluster.yaml
@@ -17,6 +17,20 @@ properties:
             unique: true
             use_property_ref: Arn
         description: The ARN of the aws.servicediscovery.HttpNamespace that's used when you create a service and don't specify a Service Connect configuration.
+  ClusterSettings:
+    type: list
+    default_value:
+      - Name: containerInsights
+        Value: enabled
+    properties:
+      Name:
+        type: string
+        description: The name of the setting to use.
+        required: true
+      Value:
+        type: string
+        description: The value to use for the setting.
+        required: true
   aws:tags:
     type: model
   Arn:

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -267,24 +267,9 @@ additional_rules:
             Dimensions:
               ServiceName: '{{ fieldRef "Name" .Self }}'
               ClusterName: '{{ fieldRef "Id" (downstream "aws:ecs_cluster" .Self) }}'
-  - if: |
-      {{- if and (hasDownstream "aws:ecs_cluster" .Self) (hasField "DesiredCount" .Self) (hasField "ClusterSettings" (downstream "aws:ecs_cluster" .Self))  }}
-        {{ $insightsEnabled := false }}
-        {{ $clusterSettings := (fieldValue "ClusterSettings" (downstream "aws:ecs_cluster" .Self)) }}
-        {{ range $i, $clusterSetting := $clusterSettings }}
-          {{- if and (eq $clusterSetting.Name "containerInsights") (eq $clusterSetting.Value "enabled") }}
-            {{ $insightsEnabled := true }}
-          {{ end }}
-        {{ end }}
-        {{- if $insightsEnabled }}
-          true
-        {{- else }}
-          false
-        {{- end }}
-      {{- else }}
-        false
-      {{- end }}
-    steps:
+
+  # TODO: Make this only apply if the cluster has container insights enabled. Currently not supported in operational eval
+
     - direction: downstream
       unique: true
       resources:

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -219,6 +219,89 @@ properties:
                 description: The ARN of the IAM Role that's associated with the Service Connect TLS.
   aws:tags:
     type: model
+  Arn:
+    type: string
+    description: The Amazon Resource Name (ARN) that identifies the service
+    deploy_time: true
+    configuration_disabled: true
+  Name:
+    type: string
+    description: The name of the service
+    deploy_time: true
+    configuration_disabled: true
+    required: true
+
+
+additional_rules:
+  - if: '{{ (hasDownstream "aws:ecs_cluster" .Self) }}'
+    steps:
+    - direction: downstream
+      unique: true
+      resources:
+        - selector: 'aws:cloudwatch_alarm:{{ .Self.Name }}-MemoryUtilization'
+          properties:
+            Namespace: AWS/ECS
+            MetricName: MemoryUtilization
+            ComparisonOperator: GreaterThanOrEqualToThreshold
+            Threshold: 90
+            Period: 60
+            EvaluationPeriods: 2
+            Statistic: Average
+            AlarmDescription: This metric checks for MemoryUtilization in the ECS service
+            Dimensions:
+              ServiceName: '{{ fieldRef "Name" .Self }}'
+              ClusterName: '{{ fieldRef "Id" (downstream "aws:ecs_cluster" .Self) }}'
+    - direction: downstream
+      unique: true
+      resources:
+        - selector: 'aws:cloudwatch_alarm:{{ .Self.Name }}-CPUUtilization'
+          properties:
+            Namespace: AWS/ECS
+            MetricName: CPUUtilization
+            ComparisonOperator: GreaterThanOrEqualToThreshold
+            Threshold: 90
+            Period: 60
+            EvaluationPeriods: 2
+            Statistic: Average
+            AlarmDescription: This metric checks for CPUUtilization in the ECS service
+            Dimensions:
+              ServiceName: '{{ fieldRef "Name" .Self }}'
+              ClusterName: '{{ fieldRef "Id" (downstream "aws:ecs_cluster" .Self) }}'
+  - if: |
+      {{- if and (hasDownstream "aws:ecs_cluster" .Self) (hasField "DesiredCount" .Self) (hasField "ClusterSettings" (downstream "aws:ecs_cluster" .Self))  }}
+        {{ $insightsEnabled := false }}
+        {{ $clusterSettings := (fieldValue "ClusterSettings" (downstream "aws:ecs_cluster" .Self)) }}
+        {{ range $i, $clusterSetting := $clusterSettings }}
+          {{- if and (eq $clusterSetting.Name "containerInsights") (eq $clusterSetting.Value "enabled") }}
+            {{ $insightsEnabled := true }}
+          {{ end }}
+        {{ end }}
+        {{- if $insightsEnabled }}
+          true
+        {{- else }}
+          false
+        {{- end }}
+      {{- else }}
+        false
+      {{- end }}
+    steps:
+    - direction: downstream
+      unique: true
+      resources:
+        - selector: 'aws:cloudwatch_alarm:{{ .Self.Name }}-RunningTaskCount'
+          properties:
+            Namespace: AWS/ECS
+            MetricName: RunningTaskCount
+            ComparisonOperator: LessThanThreshold
+            Threshold: '{{ fieldValue "DesiredCount" .Self }}'
+            Period: 60
+            EvaluationPeriods: 1
+            Statistic: Average
+            AlarmDescription: This metric checks for any stopped tasks in the ECS service
+            Dimensions:
+              ServiceName: '{{ fieldRef "Name" .Self }}'
+              ClusterName: '{{ fieldRef "Id" (downstream "aws:ecs_cluster" .Self) }}'
+
 
 consumption:
   consumed:

--- a/pkg/templates/aws/resources/sns_topic.yaml
+++ b/pkg/templates/aws/resources/sns_topic.yaml
@@ -1,0 +1,105 @@
+qualified_type_name: aws:sns_topic
+display_name: SNS Topic
+
+
+properties:
+  ApplicationFailureFeedbackRoleArn:
+    type: string
+    description: IAM role for failure feedback
+  ApplicationSuccessFeedbackRoleArn:
+    type: string
+    description: The IAM role permitted to receive success feedback for this topic
+  ApplicationSuccessFeedbackSampleRate:
+    type: int
+    description: Percentage of success to sample
+  ArchivePolicy:
+    type: string
+    description: The message archive policy for FIFO topics. More details in the AWS documentation.
+  ContentBasedDeduplication:
+    type: bool
+    description: Enables content-based deduplication for FIFO topics. For more information, see the related documentation
+  DeliveryPolicy:
+    type: string
+    description: The SNS delivery policy. More details in the AWS documentation.
+  FifoTopic:
+    type: bool
+    description: Boolean indicating whether or not to create a FIFO (first-in-first-out) topic (default is false).
+  FirehoseFailureFeedbackRoleArn:
+    type: string
+    description: IAM role for failure feedback
+  FirehoseSuccessFeedbackRoleArn:
+    type: string
+    description: The IAM role permitted to receive success feedback for this topic
+  FirehoseSuccessFeedbackSampleRate:
+    type: int
+    description: Percentage of success to sample
+  HttpFailureFeedbackRoleArn:
+    type: string
+    description: IAM role for failure feedback
+  HttpSuccessFeedbackRoleArn:
+    type: string
+    description: The IAM role permitted to receive success feedback for this topic
+  HttpSuccessFeedbackSampleRate:
+    type: int
+    description: Percentage of success to sample
+  KmsMasterKeyId:
+    type: string
+    description: The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms
+  LambdaFailureFeedbackRoleArn:
+    type: string
+    description: IAM role for failure feedback
+  LambdaSuccessFeedbackRoleArn:
+    type: string
+    description: The IAM role permitted to receive success feedback for this topic
+  LambdaSuccessFeedbackSampleRate:
+    type: int
+    description: Percentage of success to sample
+  Policy:
+    type: string
+    description: The fully-formed AWS policy as JSON.
+  SignatureVersion:
+    type: int
+    description: If SignatureVersion should be 1 (SHA1) or 2 (SHA256). The signature version corresponds to the hashing algorithm used while creating the signature of the notifications, subscription confirmations, or unsubscribe confirmation messages sent by Amazon SNS.
+  SqsFailureFeedbackRoleArn:
+    type: string
+    description: IAM role for failure feedback
+  SqsSuccessFeedbackRoleArn:
+    type: string
+    description: The IAM role permitted to receive success feedback for this topic
+  SqsSuccessFeedbackSampleRate:
+    type: int
+    description: Percentage of success to sample
+  aws:tags:
+    type: model
+  TracingConfig:
+    type: string
+    description: Tracing mode of an Amazon SNS topic. Valid values, "PassThrough", "Active".
+  Arn:
+    type: string
+    description: The ARN of the SNS topic
+    deploy_time: true
+    configuration_disabled: true
+  Id:
+    type: string
+    description: The ID of the SNS topic
+    deploy_time: true
+    configuration_disabled: true
+    required: true
+
+path_satisfaction:
+  as_target:
+    - network
+    - permissions
+
+classification:
+  is:
+    - notification
+    - messaging
+
+views:
+  dataflow: big
+
+deployment_permissions:
+  deploy: ["sqs:CreateTopic", "sns:AddPermission", "sns:SetTopicAttributes", "sqs:ListSubscriptionsByTopic", "sns:GetTopicAttributes", "sns:TagResource"]
+  tear_down: ["sqs:DeleteTopic"]
+  update: ["sqs:SetTopicAttributes", "sns:AddPermission", "sns:GetTopicAttributes", "sns:TagResource", "sns:UntagResource"]

--- a/pkg/templates/aws/resources/sns_topic_subscription.yaml
+++ b/pkg/templates/aws/resources/sns_topic_subscription.yaml
@@ -1,0 +1,73 @@
+qualified_type_name: aws:sns_topic_subscription
+display_name: SNS Topic Subscription
+
+
+properties:
+  Endpoint:
+    required: true
+    type: string
+    description: Endpoint to send data to. The contents vary with the protocol. See details below.
+  Protocol:
+    required: true
+    type: string
+    description: Protocol to use. Valid values are, sqs, sms, lambda, firehose, and application. Protocols email, email-json, http and https are also valid but partially supported. See details below.
+    allowed_values:
+      - sqs
+      - sms
+      - lambda
+      - firehose
+      - application
+      - email
+      - email-json
+      - http
+      - https  
+  Topic:
+    required: true
+    type: string
+    description: ARN of the SNS topic to subscribe to.
+  ConfirmationTimeoutInMinutes:
+    type: int
+    description: Integer indicating number of minutes to wait in retrying mode for fetching subscription arn before marking it as failure. Only applicable for http and https protocols. Default is 1.
+  DeliveryPolicy:
+    type: string
+    description: JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription - this only applies to HTTP/S subscriptions. Refer to the SNS docs for more details.
+  EndpointAutoConfirms:
+    type: bool
+    description: Whether the endpoint is capable of auto confirming subscription (e.g., PagerDuty). Default is false.
+  FilterPolicy:
+    type: string
+    description: JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the SNS docs for more details.
+  FilterPolicyScope:
+    type: string
+    description: Whether the filter_policy applies to MessageAttributes (default) or MessageBody.
+  RawMessageDelivery:
+    type: bool
+    description: Whether to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property). Default is false.
+  RedrivePolicy:
+    type: string
+    description: JSON String with the redrive policy that will be used in the subscription. Refer to the SNS docs for more details.
+  ReplayPolicy:
+    type: string
+    description: JSON String with the archived message replay policy that will be used in the subscription. Refer to the SNS docs for more details.
+  SubscriptionRoleArn:
+    type: string
+    description: ARN of the IAM role to publish to Kinesis Data Firehose delivery stream. Refer to SNS docs.
+  Id:
+    type: string
+    description: The ID of the SNS topic
+    deploy_time: true
+    configuration_disabled: true
+    required: true
+
+
+classification:
+  is:
+    - sns
+
+delete_context:
+  requires_no_upstream_or_downstream: true
+
+  deployment_permissions:
+  deploy: ["sqs:SetSubscriptionAttributes", "sns:Subscribe", "sns:ListSubscriptions", "sqs:ListSubscriptionsByTopic", "sns:GetSubscriptionAttributes"]
+  tear_down: ["sqs:Unsubscribe"]
+  update: ["sqs:SetSubscriptionAttributes"]

--- a/pkg/templates/aws/resources/sqs_queue.yaml
+++ b/pkg/templates/aws/resources/sqs_queue.yaml
@@ -2,10 +2,6 @@ qualified_type_name: aws:sqs_queue
 display_name: SQS Queue
 
 properties:
-  Arn:
-    type: string
-    configuration_disabled: true
-    deploy_time: true
   FifoQueue:
     type: bool
     description: Designates whether the queue is a FIFO queue
@@ -23,6 +19,16 @@ properties:
       from receiving and processing a message
   aws:tags:
     type: model
+  Arn:
+    type: string
+    configuration_disabled: true
+    deploy_time: true
+  Id:
+    type: string
+    description: The unique identifier for the queue
+    configuration_disabled: true
+    deploy_time: true
+    required: true
 
 path_satisfaction:
   as_target:


### PR DESCRIPTION
Adds CW Alarms, CW Dashboard, SNS, SQS -> Lambda, SNS -> Lambda

makes sure additional resource rules vertices are cleaned up properly when a resource is removed

gives the ability to specify edge constraints that apply to all resources of a given type.

The following functional test changes are due to auto generated CW resources for ecs

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
