### PR TITLE
make lambda image a string

### DIFF
--- a/pkg/engine/testdata/2_routes.expect.yaml
+++ b/pkg/engine/testdata/2_routes.expect.yaml
@@ -82,7 +82,7 @@ resources:
         Source: aws:rest_api:rest_api_1#ChildResources
     aws:lambda_function:lambda_function_0:
         ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
-        Image: aws:ecr_image:lambda_function_0-image
+        Image: aws:ecr_image:lambda_function_0-image#ImageName
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
         Tags:
@@ -91,7 +91,7 @@ resources:
         Timeout: 180
     aws:lambda_function:lambda_function_1:
         ExecutionRole: aws:iam_role:lambda_function_1-ExecutionRole
-        Image: aws:ecr_image:lambda_function_1-image
+        Image: aws:ecr_image:lambda_function_1-image#ImageName
         LogGroup: aws:log_group:lambda_function_1-log-group
         MemorySize: 512
         Tags:

--- a/pkg/engine/testdata/delete_api_to_lambda_edge.dataflow-viz.yaml
+++ b/pkg/engine/testdata/delete_api_to_lambda_edge.dataflow-viz.yaml
@@ -6,8 +6,6 @@ resources:
 
   lambda_function/lambda_function_2:
     children:
-        - aws:ecr_image:lambda_function_2-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_2-ExecutionRole
     tag: big
 

--- a/pkg/engine/testdata/delete_namespace_resource.dataflow-viz.yaml
+++ b/pkg/engine/testdata/delete_namespace_resource.dataflow-viz.yaml
@@ -2,8 +2,6 @@ provider: aws
 resources:
   lambda_function/lambda_function_2:
     children:
-        - aws:ecr_image:lambda_function_2-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_2-ExecutionRole
     tag: big
 

--- a/pkg/engine/testdata/ecs_rds.expect.yaml
+++ b/pkg/engine/testdata/ecs_rds.expect.yaml
@@ -74,7 +74,7 @@ resources:
             ServiceName: aws:ecs_service:ecs_service_0#Name
         EvaluationPeriods: 1
         MetricName: RunningTaskCount
-        Namespace: AWS/ECS
+        Namespace: ECS/ContainerInsights
         Period: 60
         Statistic: Average
         Tags:

--- a/pkg/engine/testdata/extend_graph.dataflow-viz.yaml
+++ b/pkg/engine/testdata/extend_graph.dataflow-viz.yaml
@@ -22,8 +22,6 @@ resources:
 
   lambda_function/lambda_function_0:
     children:
-        - aws:ecr_image:lambda_function_0-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_0-ExecutionRole
     tag: big
 

--- a/pkg/engine/testdata/idempotent_constraints.expect.yaml
+++ b/pkg/engine/testdata/idempotent_constraints.expect.yaml
@@ -74,7 +74,7 @@ resources:
             ServiceName: aws:ecs_service:ecs_service_0#Name
         EvaluationPeriods: 1
         MetricName: RunningTaskCount
-        Namespace: AWS/ECS
+        Namespace: ECS/ContainerInsights
         Period: 60
         Statistic: Average
         Tags:

--- a/pkg/engine/testdata/lambda_efs.expect.yaml
+++ b/pkg/engine/testdata/lambda_efs.expect.yaml
@@ -20,7 +20,7 @@ resources:
     aws:lambda_function:lambda_test_app:
         EfsAccessPoint: aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs
         ExecutionRole: aws:iam_role:lambda_test_app-ExecutionRole
-        Image: aws:ecr_image:lambda_test_app-image
+        Image: aws:ecr_image:lambda_test_app-image#ImageName
         LogGroup: aws:log_group:lambda_test_app-log-group
         MemorySize: 512
         SecurityGroups:

--- a/pkg/engine/testdata/namespace_pathselect.dataflow-viz.yaml
+++ b/pkg/engine/testdata/namespace_pathselect.dataflow-viz.yaml
@@ -2,8 +2,6 @@ provider: aws
 resources:
   lambda_function/lambda_function_0:
     children:
-        - aws:ecr_image:lambda_function_0-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_0-ExecutionRole
     tag: big
 

--- a/pkg/engine/testdata/namespace_pathselect.expect.yaml
+++ b/pkg/engine/testdata/namespace_pathselect.expect.yaml
@@ -48,7 +48,7 @@ resources:
             RESOURCE_NAME: lambda_function_0-ExecutionRole
     aws:lambda_function:lambda_function_2:
         ExecutionRole: aws:iam_role:lambda_function_2-ExecutionRole
-        Image: aws:ecr_image:lambda_function_2-image
+        Image: aws:ecr_image:lambda_function_2-image#ImageName
         LogGroup: aws:log_group:lambda_function_2-log-group
         MemorySize: 512
         SecurityGroups:

--- a/pkg/engine/testdata/remove_path.dataflow-viz.yaml
+++ b/pkg/engine/testdata/remove_path.dataflow-viz.yaml
@@ -2,8 +2,6 @@ provider: aws
 resources:
   lambda_function/lambda_function_0:
     children:
-        - aws:ecr_image:lambda_function_0-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_0-ExecutionRole
     parent: vpc/vpc-0
     tag: big
@@ -17,8 +15,6 @@ resources:
 
   lambda_function/lambda_function_3:
     children:
-        - aws:ecr_image:lambda_function_3-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_function_3-ExecutionRole
     parent: vpc/vpc-0
     tag: big

--- a/pkg/engine/testdata/rename.dataflow-viz.yaml
+++ b/pkg/engine/testdata/rename.dataflow-viz.yaml
@@ -2,8 +2,6 @@ provider: aws
 resources:
   lambda_function/lambda_test_app:
     children:
-        - aws:ecr_image:lambda_test_app-image
-        - aws:ecr_repo:ecr_repo-0
         - aws:iam_role:lambda_test_app-ExecutionRole
     tag: big
 

--- a/pkg/engine/testdata/single_lambda.expect.yaml
+++ b/pkg/engine/testdata/single_lambda.expect.yaml
@@ -1,7 +1,7 @@
 resources:
     aws:lambda_function:lambda_function_0:
         ExecutionRole: aws:iam_role:lambda_function_0-ExecutionRole
-        Image: aws:ecr_image:lambda_function_0-image
+        Image: aws:ecr_image:lambda_function_0-image#ImageName
         LogGroup: aws:log_group:lambda_function_0-log-group
         MemorySize: 512
         Tags:

--- a/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_to_lambda.expect.yaml
@@ -33,7 +33,7 @@ resources:
         imported: true
     aws:lambda_function:lambda_function:
         ExecutionRole: aws:iam_role:lambda_function-ExecutionRole
-        Image: aws:ecr_image:lambda_function-image
+        Image: aws:ecr_image:lambda_function-image#ImageName
         LogGroup: aws:log_group:lambda_function-log-group
         MemorySize: 512
         SecurityGroups:

--- a/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
+++ b/pkg/engine/testdata/vpc_import_wo_subnets_to_lambda.expect.yaml
@@ -19,7 +19,7 @@ resources:
         Vpc: aws:vpc:vpc
     aws:lambda_function:lambda_function:
         ExecutionRole: aws:iam_role:lambda_function-ExecutionRole
-        Image: aws:ecr_image:lambda_function-image
+        Image: aws:ecr_image:lambda_function-image#ImageName
         LogGroup: aws:log_group:lambda_function-log-group
         MemorySize: 512
         SecurityGroups:

--- a/pkg/infra/iac/templates/aws/lambda_function/factory.ts
+++ b/pkg/infra/iac/templates/aws/lambda_function/factory.ts
@@ -5,7 +5,7 @@ import { ModelCaseWrapper } from '../../wrappers'
 
 interface Args {
     Name: string
-    Image: docker.Image
+    Image: string
     ExecutionRole: aws.iam.Role
     EnvironmentVariables: ModelCaseWrapper<Record<string, pulumi.Output<string>>>
     Subnets: aws.ec2.Subnet[]
@@ -23,7 +23,7 @@ function create(args: Args): aws.lambda.Function {
         args.Name,
         {
             packageType: 'Image',
-            imageUri: args.Image.imageName,
+            imageUri: args.Image,
             //TMPL {{- if .MemorySize }}
             memorySize: args.MemorySize,
             //TMPL {{- end }}

--- a/pkg/templates/aws/resources/ecs_service.yaml
+++ b/pkg/templates/aws/resources/ecs_service.yaml
@@ -274,7 +274,7 @@ additional_rules:
         resources:
           - selector: 'aws:cloudwatch_alarm:{{ .Self.Name }}-RunningTaskCount'
             properties:
-              Namespace: AWS/ECS
+              Namespace: ECS/ContainerInsights
               MetricName: RunningTaskCount
               ComparisonOperator: LessThanThreshold
               Threshold: '{{ fieldValue "DesiredCount" .Self }}'

--- a/pkg/templates/aws/resources/lambda_function.yaml
+++ b/pkg/templates/aws/resources/lambda_function.yaml
@@ -11,13 +11,14 @@ properties:
           - aws:iam_role:{{ .Self.Name }}-ExecutionRole
         unique: true
   Image:
-    type: resource(aws:ecr_image)
+    type: string
     operational_rule:
       step:
         direction: downstream
         resources:
           - aws:ecr_image:{{ .Self.Name }}-image
         unique: true
+        use_property_ref: ImageName
   EnvironmentVariables:
     type: map(string,string)
     important: true


### PR DESCRIPTION
let lambdas image be a string rather than resource to allow for imported image names

### Standard checks

- **Unit tests**: Any special considerations?
- **Docs**: Do we need to update any docs, internal or public?
- **Backwards compatibility**: Will this break existing apps? If so, what would be the extra work required to keep them working?
