### PR TITLE
Elasticache param groups & Ignore nil Env Vars

### DIFF
--- a/pkg/infra/iac/templates/aws/ecs_task_definition/container_definitions.ts.tmpl
+++ b/pkg/infra/iac/templates/aws/ecs_task_definition/container_definitions.ts.tmpl
@@ -14,10 +14,12 @@
         {{- if $cd.Environment }}
         environment: [
             {{- range $key, $value := $cd.Environment }}
+            {{- if not (eq $value.Value nil) }}
             {
                 name: "{{ $value.Name }}",
                 value: {{ modelCase $value.Value }},
             },
+            {{- end }}
             {{- end }}
         ],
         {{- end }}

--- a/pkg/infra/iac/templates/aws/elasticache_cluster/factory.ts
+++ b/pkg/infra/iac/templates/aws/elasticache_cluster/factory.ts
@@ -9,6 +9,7 @@ interface Args {
     SecurityGroups: aws.ec2.SecurityGroup[]
     NodeType: string
     NumCacheNodes: number
+    ParameterGroupName?: string
     Tags: ModelCaseWrapper<Record<string, string>>
 }
 
@@ -17,6 +18,9 @@ function create(args: Args): aws.elasticache.Cluster {
         engine: args.Engine,
         nodeType: args.NodeType,
         numCacheNodes: args.NumCacheNodes,
+        //TMPL {{- if .ParameterGroupName }}
+        parameterGroupName: args.ParameterGroupName,
+        //TMPL {{- end }}
         logDeliveryConfigurations: [
             {
                 destination: args.CloudwatchGroup.name,

--- a/pkg/infra/iac/templates/aws/elasticache_parameter_group/factory.ts
+++ b/pkg/infra/iac/templates/aws/elasticache_parameter_group/factory.ts
@@ -1,0 +1,31 @@
+import * as aws from '@pulumi/aws'
+import { ModelCaseWrapper } from '../../wrappers'
+
+interface Args {
+    Name: string
+    Description: string
+    Family: string
+    Parameters: Record<string, string>
+    Tags: ModelCaseWrapper<Record<string, string>>
+}
+
+function create(args: Args): aws.elasticache.SubnetGroup {
+    return new aws.elasticache.ParameterGroup(args.Name, {
+        name: args.Name,
+        family: args.Family,
+        description: args.Description,
+        //TMPL {{- if .Parameters }}
+        parameters: args.Parameters,
+        //TMPL {{- end }}
+        //TMPL {{- if .Tags }}
+        tags: args.Tags,
+        //TMPL {{- end }}
+    })
+}
+
+function properties(object: aws.elasticache.ParameterGroup, args: Args) {
+    return {
+        Arn: object.arn,
+        Name: object.name,
+    }
+}

--- a/pkg/infra/iac/templates/aws/elasticache_parameter_group/package.json
+++ b/pkg/infra/iac/templates/aws/elasticache_parameter_group/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "elasticache_parameter_group",
+    "dependencies": {
+        "@pulumi/aws": "^5.37.0"
+    }
+}

--- a/pkg/templates/aws/edges/elasticache_cluster-elasticache_parameter_group.yaml
+++ b/pkg/templates/aws/edges/elasticache_cluster-elasticache_parameter_group.yaml
@@ -1,0 +1,2 @@
+source: aws:elasticache_cluster
+target: aws:elasticache_parameter_group

--- a/pkg/templates/aws/resources/elasticache_cluster.yaml
+++ b/pkg/templates/aws/resources/elasticache_cluster.yaml
@@ -42,6 +42,15 @@ properties:
     type: int
     default_value: 1
     description: The number of cache nodes that the cache cluster should have.
+  ParameterGroupName:
+    type: string
+    description: The name of the parameter group associated with the cluster.
+    operational_rule:
+      step:
+        direction: downstream
+        resources:
+          - aws:elasticache_parameter_group
+        use_property_ref: Name
   aws:tags:
     type: model
   Port:

--- a/pkg/templates/aws/resources/elasticache_parameter_group.yaml
+++ b/pkg/templates/aws/resources/elasticache_parameter_group.yaml
@@ -1,0 +1,45 @@
+qualified_type_name: aws:elasticache_parameter_group
+display_name: ElastiCache Parameter Group
+
+properties:
+  Family:
+    type: string
+    description: The family of the parameter group corresponding to an engine version.
+    # TODO: make version configurable on elasticache clusters and determine the family based on the version
+    default_value: "redis7"
+    required: true
+    allowed_values:
+      - redis4.0
+      - redis5.0
+      - redis6.x
+      - redis7
+  Description:
+    type: string
+  Parameters:
+    type: list
+    properties:
+      Name:
+        type: string
+        description: The name of the ElastiCache parameter.
+      Value:
+        type: string
+        description: The value of the ElastiCache parameter.
+  aws:tags:
+    type: model
+  Arn:
+    type: string
+    description: The Amazon Resource Name (ARN) of the parameter group.
+    configuration_disabled: true
+    deploy_time: true
+    required: true
+
+delete_context:
+  requires_no_upstream: true
+views:
+  dataflow: small
+
+deployment_permissions:
+  deploy:
+    [
+      'elasticache:*ParameterGroup',
+    ]


### PR DESCRIPTION
Adds support for elasticache parameter groups and ignores environment variables with `nil` values on ECS container definitions.