### PR TITLE
Revert "dont assume users and ownership for efs access point"

### DIFF
--- a/pkg/engine/testdata/lambda_efs.expect.yaml
+++ b/pkg/engine/testdata/lambda_efs.expect.yaml
@@ -39,8 +39,13 @@ resources:
         Repo: aws:ecr_repo:lambda_test_app-image-ecr_repo
     aws:efs_access_point:test-efs-fs:lambda_test_app-test-efs-fs:
         FileSystem: aws:efs_file_system:test-efs-fs
+        PosixUser:
+            Gid: 1000
+            Uid: 1000
         RootDirectory:
             CreationInfo:
+                OwnerGid: 1000
+                OwnerUid: 1000
                 Permissions: "777"
             Path: /mnt/efs
         Tags:

--- a/pkg/templates/aws/resources/efs_access_point.yaml
+++ b/pkg/templates/aws/resources/efs_access_point.yaml
@@ -16,8 +16,10 @@ properties:
     properties:
       Gid:
         type: int
+        default_value: 1000
       Uid:
         type: int
+        default_value: 1000
   RootDirectory:
     type: map
     important: true
@@ -27,8 +29,10 @@ properties:
         properties:
           OwnerGid:
             type: int
+            default_value: 1000
           OwnerUid:
             type: int
+            default_value: 1000
           Permissions:
             type: string
             default_value: '777'


### PR DESCRIPTION
Reverts klothoplatform/klotho#984

A permission being set but no Gid/Uid results in
```
index.ts(117,25): error TS2322: Type '{ permissions: string; }' is not assignable to type 'AccessPointRootDirectoryCreationInfo | Promise<AccessPointRootDirectoryCreationInfo> | OutputInstance<...> | undefined'.
```